### PR TITLE
Draft KEM DEM example and improve inference of validity proofs

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -70,6 +70,7 @@ theories/Crypt/examples/PRF.v
 theories/Crypt/examples/AsymScheme.v
 theories/Crypt/examples/ElGamal.v
 theories/Crypt/examples/OTP.v
+theories/Crypt/examples/KEMDEM.v
 #std. distributions
 # theories/Crypt/only_prob/SymmetricSchemeStateProbStdDistr.v
 

--- a/theories/Crypt/Prelude.v
+++ b/theories/Crypt/Prelude.v
@@ -196,6 +196,11 @@ Class Lt n m :=
 #[export] Hint Extern 4 (Lt ?n) =>
   unfold Lt ; apply/ltP ; nat_reify ; lia : typeclass_instances.
 
+Instance Positive_Lt n `{Positive n} : Lt 0 n.
+Proof.
+  unfold Lt. auto.
+Qed.
+
 Instance PositiveInFin n m (h : Lt n m) : Positive m.
 Proof.
   unfold Lt in h. exact _.

--- a/theories/Crypt/chUniverse.v
+++ b/theories/Crypt/chUniverse.v
@@ -90,7 +90,7 @@ Next Obligation.
 Defined.
 Next Obligation.
   exists 0. destruct n as [p h]. simpl.
-  unfold Positive in h. auto.
+  eapply from_Positive in h. auto.
 Defined.
 
 Section chUniverseTypes.
@@ -481,22 +481,23 @@ Section chUniverseTypes.
 
   Lemma codeK : pcancel encode decode.
   Proof.
-    move=> t. induction t; intuition.
+    intro t. induction t.
+    all: intuition.
     all: simpl.
     - rewrite IHt1. rewrite IHt2. reflexivity.
     - rewrite IHt1. rewrite IHt2. reflexivity.
     - rewrite IHt. reflexivity.
     - destruct n as [n npos]. cbn.
       destruct n.
-      + discriminate.
+      + eapply from_Positive in npos as h. discriminate.
       + cbn.
         rewrite -subnE subn0.
-        repeat f_equal.
-        apply bool_irrelevance.
+        reflexivity.
   Defined.
 
   Definition chUniverse_choiceMixin := PcanChoiceMixin codeK.
-  Canonical chUniverse_choiceType := ChoiceType chUniverse chUniverse_choiceMixin.
+  Canonical chUniverse_choiceType :=
+    ChoiceType chUniverse chUniverse_choiceMixin.
 
   Definition chUniverse_ordMixin := OrdMixin chUniverse_leqP.
   Canonical chUniverse_ordType :=

--- a/theories/Crypt/examples/ElGamal.v
+++ b/theories/Crypt/examples/ElGamal.v
@@ -361,7 +361,7 @@ Proof.
   - cbn - [f]. intros x. rewrite -[RHS]prod2ch_ch2prod.
     set (y := ch2prod x). clearbody y. clear x.
     simpl in y. destruct y as [a b].
-    rewrite otf_fto. rewrite gf. f_equal.
+    rewrite otf_fto. rewrite gf.
     rewrite !fto_otf. reflexivity.
   - cbn - [f]. intro x.
     replace x with (fto (f m (g (otf x)))) at 2.
@@ -369,8 +369,7 @@ Proof.
     set (y := g (otf x)). change (g (otf x)) with y. clearbody y. clear x.
     destruct y as [a b]. rewrite ch2prod_prod2ch. rewrite !otf_fto.
     reflexivity.
-(* Qed. *)
-Admitted.
+Qed.
 
 Lemma ots_real_vs_rnd_equiv_false :
   ots_real_vs_rnd false ≈₀ Aux ∘ DH_rnd.

--- a/theories/Crypt/examples/ElGamal.v
+++ b/theories/Crypt/examples/ElGamal.v
@@ -99,11 +99,13 @@ Module MyAlg <: AsymmetricSchemeAlgorithms MyParam.
 
   Instance positive_gT : Positive #|gT|.
   Proof.
+    constructor.
     apply /card_gt0P. exists g. auto.
   Qed.
 
   Instance positive_SecKey : Positive #|SecKey|.
   Proof.
+    constructor.
     apply /card_gt0P. exists sec0. auto.
   Qed.
 
@@ -367,7 +369,8 @@ Proof.
     set (y := g (otf x)). change (g (otf x)) with y. clearbody y. clear x.
     destruct y as [a b]. rewrite ch2prod_prod2ch. rewrite !otf_fto.
     reflexivity.
-Qed.
+(* Qed. *)
+Admitted.
 
 Lemma ots_real_vs_rnd_equiv_false :
   ots_real_vs_rnd false ≈₀ Aux ∘ DH_rnd.

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -184,18 +184,6 @@ Section KEMDEM.
 
   Opaque ValidPackage mkfmap pkg_composition.mkdef.
 
-  (* #[export] *) Hint Extern 10 =>
-    shelve : packages.
-
-    (* Hint Extern 1 (ValidPackage ?L ?I ?E (mkfmap ((?i, pkg_composition.mkdef ?A ?B ?f) :: ?p)))
-    =>
-    eapply valid_package_cons ; [
-      eapply valid_package_from_class || shelve
-    | intro ; eapply valid_code_from_class || shelve
-    | shelve
-    ]
-    : packages. *)
-
   (* Probably a loc_GamePair *)
   #[program] Definition PKE_CCA (ζ : PKE_scheme) b :
     package

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -33,29 +33,6 @@ Import PackageNotation.
 #[local] Open Scope ring_scope.
 #[local] Open Scope package_scope.
 
-(** Procedure names
-
-  All in one place so it's easier.
-
-*)
-
-(* KEY *)
-Definition GEN := 0%N.
-Definition SET := 1%N.
-Definition GET := 2%N.
-
-(* MOD-CCA *)
-Definition PKGEN := 3%N.
-Definition PKENC := 4%N.
-Definition PKDEC := 5%N.
-
-(** KEY Package *)
-
-(* TODO Section for length?  *)
-Definition i_key (l : nat) := l.
-
-Definition key n `{Positive n} : Location := ('option ('fin n) ; 0%N).
-
 (* TODO MOVE *)
 (* TODO Same as finmap.oextract but with a better name? *)
 Definition getSome {A} (o : option A) :
@@ -66,43 +43,139 @@ Proof.
   assumption.
 Defined.
 
-Definition KEY n `{Positive n} :
-  package
-    (fset [:: key n ])
-    [interface]
-    [interface
-      val #[ GEN ] : 'unit → 'unit ;
-      val #[ SET ] : ('fin n) → 'unit ;
-      val #[ GET ] : 'unit → 'fin n
-    ] :=
-  [package
-    def #[ GEN ] (_ : 'unit) : 'unit {
-      k ← get (key n) ;;
-      assert (k == None) ;;
-      k ← sample uniform (i_key n) ;;
-      put (key n) := Some k ;;
-      ret Datatypes.tt
-    } ;
-    def #[ SET ] (k : ('fin n)) : 'unit {
-      k' ← get (key n) ;;
-      assert (k' == None) ;;
-      put (key n) := Some k ;;
-      ret Datatypes.tt
-    } ;
-    def #[ GET ] (_ : 'unit) : ('fin n) {
-      k ← get (key n) ;;
-      #assert (isSome k) as kSome ;;
-      @ret ('fin n) (getSome k kSome)
-    }
-  ].
+Section KEMDEM.
 
-(** MOD-CCA *)
+  (** In the SSP paper, we have λ.
+      key_length would 2^λ because we do not use bitstrings.
+  *)
+  Context (key_length : nat) `{Positive key_length}.
 
-Definition MODCCA l `{Positive l} :
-  package
-    (fset [:: (* TODO *) ])
-    [interface] (* TODO Import KEM and DEM *)
-    [interface
-      val #[ PKGEN ] : 'unit → ('fin l) × ('fin l)
+  Context (plain_length : nat) `{Positive plain_length}.
+
+  (** In the paper, the following are functions of |m|, here we assume |m|
+      is constant: plain_length.
+  *)
+  Context (clen : nat) `{Positive clen}.
+  Context (elen : nat) `{Positive elen}.
+
+  (** Types *)
+  Notation "'key" := ('fin key_length) (in custom pack_type at level 2).
+  Notation "'key" := ('fin key_length) (at level 2) : package_scope.
+
+  Notation "'plain" := ('fin plain_length) (in custom pack_type at level 2).
+  Notation "'plain" := ('fin plain_length) (at level 2) : package_scope.
+
+  Notation "'clen" := ('fin clen) (in custom pack_type at level 2).
+  Notation "'clen" := ('fin clen) (at level 2) : package_scope.
+
+  Notation "'elen" := ('fin elen) (in custom pack_type at level 2).
+  Notation "'elen" := ('fin elen) (at level 2) : package_scope.
+
+  (** Procedure names *)
+
+  (* KEY *)
+  Definition GEN := 0%N.
+  Definition SET := 1%N.
+  Definition GET := 2%N.
+
+  (* KEM-CCA *)
+  Definition KEMGEN := 6%N.
+  Definition ENCAP := 7%N.
+  Definition DECAP := 8%N.
+
+  (* DEM-CCA *)
+  Definition ENC := 9%N.
+  Definition DEC := 10%N.
+
+  (* PKE-CCA / MOD-CCA *)
+  Definition PKGEN := 3%N.
+  Definition PKENC := 4%N.
+  Definition PKDEC := 5%N.
+
+  (** Memory locations *)
+  Definition key : Location := ('option ('fin key_length) ; 0%N).
+
+  (** Uniform distributions *)
+  Definition i_key := key_length.
+
+  (** KEY Package *)
+
+  Definition KEY :
+    package
+      (fset [:: key ])
+      [interface]
+      [interface
+        val #[ GEN ] : 'unit → 'unit ;
+        val #[ SET ] : 'key → 'unit ;
+        val #[ GET ] : 'unit → 'key
+      ] :=
+    [package
+      def #[ GEN ] (_ : 'unit) : 'unit {
+        k ← get key ;;
+        assert (k == None) ;;
+        k ← sample uniform i_key ;;
+        put key := Some k ;;
+        ret Datatypes.tt
+      } ;
+      def #[ SET ] (k : 'key) : 'unit {
+        k' ← get key ;;
+        assert (k' == None) ;;
+        put key := Some k ;;
+        ret Datatypes.tt
+      } ;
+      def #[ GET ] (_ : 'unit) : 'key {
+        k ← get key ;;
+        #assert (isSome k) as kSome ;;
+        @ret 'key (getSome k kSome)
+      }
     ].
-Abort.
+
+  (** Assumed KEM game *)
+  (* TODO Not sure if I should do this, or simply assusme some code. *)
+  Definition KEM_export :=
+    [interface
+      val #[ KEMGEN ] : 'unit → 'key ;
+      val #[ ENCAP ] : 'unit → 'elen ;
+      val #[ DECAP ] : 'elen → 'key
+    ].
+
+  Context (KEM₀ : loc_package [interface val #[ SET ] : 'key → 'unit ] KEM_export).
+  Context (KEM₁ : loc_package [interface val #[ GEN ] : 'unit → 'unit ] KEM_export).
+
+  (** Assumed DEM game *)
+  Definition DEM_export :=
+    [interface
+      val #[ ENC ] : 'plain → 'clen ;
+      val #[ DEC ] : 'clen → 'plain
+    ].
+
+  Context (DEM₀ : loc_package [interface val #[ GET ] : 'unit → 'key ] DEM_export).
+  Context (DEM₁ : loc_package [interface val #[ GET ] : 'unit → 'key ] DEM_export).
+
+  (** PKE-CCA *)
+
+  Definition PKE_CCA :
+    package
+      (fset [:: (* TODO *) ])
+      [interface (* TODO *) ]
+      [interface
+        val #[ PKGEN ] : 'unit → 'key ;
+        val #[ PKENC ] : 'plain → 'clen ;
+        val #[ PKDEC ] : 'elen × 'clen → 'plain
+      ].
+  Abort.
+
+  (** MOD-CCA *)
+
+  Definition MOD_CCA :
+    package
+      (fset [:: (* TODO *) ])
+      [interface (* TODO *) ]
+      [interface
+        val #[ PKGEN ] : 'unit → 'key ;
+        val #[ PKENC ] : 'plain → 'clen ;
+        val #[ PKDEC ] : 'elen × 'clen → 'plain
+      ].
+  Abort.
+
+End KEMDEM.

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -184,6 +184,18 @@ Section KEMDEM.
 
   Opaque ValidPackage mkfmap pkg_composition.mkdef.
 
+  (* #[export] *) Hint Extern 10 =>
+    shelve : packages.
+
+    (* Hint Extern 1 (ValidPackage ?L ?I ?E (mkfmap ((?i, pkg_composition.mkdef ?A ?B ?f) :: ?p)))
+    =>
+    eapply valid_package_cons ; [
+      eapply valid_package_from_class || shelve
+    | intro ; eapply valid_code_from_class || shelve
+    | shelve
+    ]
+    : packages. *)
+
   (* Probably a loc_GamePair *)
   #[program] Definition PKE_CCA (ζ : PKE_scheme) b :
     package
@@ -231,13 +243,9 @@ Section KEMDEM.
     exact _.
   Qed.
   Next Obligation.
-    (* TODO Have a tactic that does most of the work. *)
-    eapply valid_package_cons.
-    3:{ unfold "\notin" ; rewrite imfset_fset ; rewrite in_fset ; eauto. }
-    1: eapply valid_package_cons.
-    3:{ unfold "\notin" ; rewrite imfset_fset ; rewrite in_fset ; eauto. }
-    1: eapply valid_package1.
-    - intro. eapply valid_getr. 1: auto_in_fset.
+    unshelve typeclasses eauto with packages.
+    - exact _.
+    - eapply valid_getr. 1: auto_in_fset.
       intro.
       match goal with
       | |- valid_code _ _ (@assertD ?A ?b ?k) =>
@@ -250,7 +258,7 @@ Section KEMDEM.
       2:{ intro. eapply valid_code_from_class. exact _. }
       (* NEED to update PKE_dec to use these locs I guess... *)
       give_up.
-    - intro. eapply valid_getr. 1: auto_in_fset.
+    - eapply valid_getr. 1: auto_in_fset.
       intro.
       match goal with
       | |- valid_code _ _ (@assertD ?A ?b ?k) =>
@@ -265,7 +273,7 @@ Section KEMDEM.
       2:{ eapply valid_code_from_class. exact _. }
       (* NEED to update PKE_enc to use these locs I guess... *)
       give_up.
-    - intro. eapply valid_getr. 1: auto_in_fset.
+    - eapply valid_getr. 1: auto_in_fset.
       intro. eapply valid_bind.
       1:{ eapply valid_code_from_class. exact _. }
       intro. eapply valid_bind.

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -41,10 +41,7 @@ Definition GET := 2%N.
 
 Definition key n `{Positive n} : Location := ('option ('fin n) ; 0%N).
 
-(* It can't solve it for now because it doesn't have any rules for
-  assert, fail and assert_false.
-*)
-(* Definition KEY n `{Positive n} :
+Definition KEY n `{Positive n} :
   package
     (fset [:: key n ])
     [interface]
@@ -57,7 +54,7 @@ Definition key n `{Positive n} : Location := ('option ('fin n) ; 0%N).
     def #[ GEN ] (_ : 'unit) : 'unit {
       k ← get (key n) ;;
       assert (k == None) ;;
-      k ← sample U (i_key n) ;;
+      k ← sample uniform (i_key n) ;;
       put (key n) := Some k ;;
       ret Datatypes.tt
     } ;
@@ -71,7 +68,7 @@ Definition key n `{Positive n} : Location := ('option ('fin n) ; 0%N).
       k ← get (key n) ;;
       match k with
       | Some k => ret k
-      | None => @assert_false ('fin n)
+      | None => @fail ('fin n)
       end
     }
-  ]. *)
+  ].

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -33,11 +33,26 @@ Import PackageNotation.
 #[local] Open Scope ring_scope.
 #[local] Open Scope package_scope.
 
-Definition i_key (l : nat) := l.
+(** Procedure names
 
+  All in one place so it's easier.
+
+*)
+
+(* KEY *)
 Definition GEN := 0%N.
 Definition SET := 1%N.
 Definition GET := 2%N.
+
+(* MOD-CCA *)
+Definition PKGEN := 3%N.
+Definition PKENC := 4%N.
+Definition PKDEC := 5%N.
+
+(** KEY Package *)
+
+(* TODO Section for length?  *)
+Definition i_key (l : nat) := l.
 
 Definition key n `{Positive n} : Location := ('option ('fin n) ; 0%N).
 
@@ -80,3 +95,14 @@ Definition KEY n `{Positive n} :
       @ret ('fin n) (getSome k kSome)
     }
   ].
+
+(** MOD-CCA *)
+
+Definition MODCCA l `{Positive l} :
+  package
+    (fset [:: (* TODO *) ])
+    [interface] (* TODO Import KEM and DEM *)
+    [interface
+      val #[ PKGEN ] : 'unit → ('fin l) × ('fin l)
+    ].
+Abort.

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -154,6 +154,7 @@ Section KEMDEM.
 
   (** PKE-CCA *)
 
+  (* Probably a loc_GamePair *)
   Definition PKE_CCA :
     package
       (fset [:: (* TODO *) ])
@@ -177,5 +178,21 @@ Section KEMDEM.
         val #[ PKDEC ] : 'elen × 'clen → 'plain
       ].
   Abort.
+
+  (** Security theorem *)
+
+  (* Since in the theorem we use the PKE of construction 23, we can probably
+    directly specialise things?
+  *)
+
+  (* Theorem PKE_security :
+    ∀ LA A,
+      ValidPackage LA PKE_CCA_export A_export A →
+      fdisjoint LA (PKE_CCA true).(locs) →
+      fdisjoint LA (PKE_CCA false).(locs) →
+      Advantage PKE_CCA A <=
+      Advantage KEM_CCA (A ∘ MOC_CCA ∘ par (ID KEM_export) DEM₀) +
+      Advantage DEM_CCA (A ∘ MOD_CCA ∘ par KEM₁ (ID DEM_export)).
+  Abort. *)
 
 End KEMDEM.

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -231,43 +231,14 @@ Section KEMDEM.
     exact _.
   Qed.
   Next Obligation.
-    unshelve typeclasses eauto with packages.
-    - exact _.
-    - eapply valid_getr. 1: auto_in_fset.
-      intro.
-      match goal with
-      | |- valid_code _ _ (@assertD ?A ?b ?k) =>
-        eapply (valid_assertD A _ _ b k)
-      end.
-      intro. eapply valid_getr. 1: auto_in_fset.
-      intro. eapply valid_bind.
-      1:{ eapply valid_code_from_class. exact _. }
-      intro. eapply valid_bind.
-      2:{ intro. eapply valid_code_from_class. exact _. }
-      (* NEED to update PKE_dec to use these locs I guess... *)
+    ssprove_valid.
+    - (* NEED to update PKE_dec to use these locs I guess... *)
       give_up.
-    - eapply valid_getr. 1: auto_in_fset.
-      intro.
-      match goal with
-      | |- valid_code _ _ (@assertD ?A ?b ?k) =>
-        eapply (valid_assertD A _ _ b k)
-      end.
-      intro. eapply valid_getr. 1: auto_in_fset.
-      intro. eapply valid_bind.
-      1:{ eapply valid_code_from_class. exact _. }
-      intro. eapply valid_bind.
-      2:{ intro. eapply valid_code_from_class. exact _. }
-      destruct b.
-      2:{ eapply valid_code_from_class. exact _. }
-      (* NEED to update PKE_enc to use these locs I guess... *)
+    - (* NEED to update PKE_enc to use these locs I guess... *)
       give_up.
-    - eapply valid_getr. 1: auto_in_fset.
-      intro. eapply valid_bind.
-      1:{ eapply valid_code_from_class. exact _. }
-      intro. eapply valid_bind.
-      + (* NEED to update PKE_kgen to use these locs I guess... *)
-        admit.
-      + intros []. eapply valid_code_from_class. exact _.
+    - (* NEED to update PKE_kgen to use these locs I guess... *)
+      give_up.
+    - destruct x1. ssprove_valid.
   Admitted.
 
   (** MOD-CCA *)

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -93,10 +93,37 @@ Section KEMDEM.
   Definition PKDEC := 5%N.
 
   (** Memory locations *)
-  Definition key : Location := ('option ('fin key_length) ; 0%N).
+  Definition key : Location := ('option 'key ; 0%N).
+  Definition pk_loc : Location := ('option 'key ; 1%N).
+  Definition sk_loc : Location := ('option 'key ; 2%N).
+  Definition c_loc : Location := ('option ('elen × 'clen) ; 2%N).
 
   (** Uniform distributions *)
   Definition i_key := key_length.
+
+  (** PKE scheme *)
+  Record PKE_scheme := {
+    PKE_loc : {fset Location } ;
+    PKE_kgen : code PKE_loc [interface] ('key × 'key) ;
+    PKE_enc : 'key → 'plain → code PKE_loc [interface] 'clen ;
+    (* clen is global *)
+    PKE_dec : 'key → 'elen × 'clen → code PKE_loc [interface] 'plain
+  }.
+
+  (** KEM scheme *)
+  Record KEM_scheme := {
+    KEM_loc : {fset Location } ;
+    KEM_kgen : code KEM_loc [interface] ('key × 'key) ;
+    KEM_encap : 'key → code KEM_loc [interface] 'elen ;
+    KEM_decap : 'key → 'elen → code KEM_loc [interface] 'key
+  }.
+
+  (** DEM scheme *)
+  Record DEM_scheme := {
+    DEM_loc : {fset Location } ;
+    DEM_enc : 'key → 'plain → code DEM_loc [interface] 'clen ;
+    DEM_dec : 'key → 'clen → code DEM_loc [interface] 'plain
+  }.
 
   (** KEY Package *)
 
@@ -155,16 +182,34 @@ Section KEMDEM.
   (** PKE-CCA *)
 
   (* Probably a loc_GamePair *)
-  Definition PKE_CCA :
+  (* Definition PKE_CCA b :
     package
-      (fset [:: (* TODO *) ])
-      [interface (* TODO *) ]
+      (fset [:: pk_loc ; sk_loc ; c_loc ])
+      [interface]
       [interface
         val #[ PKGEN ] : 'unit → 'key ;
         val #[ PKENC ] : 'plain → 'clen ;
         val #[ PKDEC ] : 'elen × 'clen → 'plain
-      ].
-  Abort.
+      ] :=
+    [package
+      def #[ PKGEN ] (_ : 'unit) : 'key {
+        sk ← get sk_loc ;;
+        assert (sk == None) ;;
+        ??
+      } ;
+      def #[ PKENC ] (m : 'plain) : 'clen {
+        pk ← get pk_loc ;;
+        #assert (isSome pk) as pkSome ;;
+        c ← get c_loc ;;
+        assert (c == None) ;;
+        c ← sample (if b then ? else ?) ;;
+        put c_loc := c ;;
+        ret c
+      } ;
+      def #[ PKDEC ] (c' : 'elen × 'clen) : 'clen {
+        ?
+      }
+    ]. *)
 
   (** MOD-CCA *)
 

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -180,13 +180,14 @@ Section KEMDEM.
   Context (DEM₀ : loc_package [interface val #[ GET ] : 'unit → 'key ] DEM_export).
   Context (DEM₁ : loc_package [interface val #[ GET ] : 'unit → 'key ] DEM_export).
 
+  (* Set Typeclasses Debug.
+  Set Typeclasses Depth 10.
+  Set Typeclasses Debug Verbosity 2. *)
+
   (** PKE-CCA *)
 
   (* Probably a loc_GamePair *)
-  (* Now it loops! Probably same problem as Nikolaj where interfaces don't
-    match
-  *)
-  (* Definition PKE_CCA (ζ : PKE_scheme) b :
+  Fail Definition PKE_CCA (ζ : PKE_scheme) b :
     package
       (fset [:: pk_loc ; sk_loc ; c_loc ])
       [interface]
@@ -227,7 +228,7 @@ Section KEMDEM.
         m ← ζ.(PKE_dec) sk c' ;;
         ret m
       }
-    ]. *)
+    ].
 
   (** MOD-CCA *)
 

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -41,6 +41,16 @@ Definition GET := 2%N.
 
 Definition key n `{Positive n} : Location := ('option ('fin n) ; 0%N).
 
+(* TODO MOVE *)
+(* TODO Same as finmap.oextract but with a better name? *)
+Definition getSome {A} (o : option A) :
+  isSome o → A.
+Proof.
+  intro h.
+  destruct o. 2: discriminate.
+  assumption.
+Defined.
+
 Definition KEY n `{Positive n} :
   package
     (fset [:: key n ])
@@ -66,9 +76,7 @@ Definition KEY n `{Positive n} :
     } ;
     def #[ GET ] (_ : 'unit) : ('fin n) {
       k ← get (key n) ;;
-      match k with
-      | Some k => ret k
-      | None => @fail ('fin n)
-      end
+      #assert (isSome k) as kSome ;;
+      @ret ('fin n) (getSome k kSome)
     }
   ].

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -180,14 +180,12 @@ Section KEMDEM.
   Context (DEM₀ : loc_package [interface val #[ GET ] : 'unit → 'key ] DEM_export).
   Context (DEM₁ : loc_package [interface val #[ GET ] : 'unit → 'key ] DEM_export).
 
-  (* Set Typeclasses Debug.
-  Set Typeclasses Depth 10.
-  Set Typeclasses Debug Verbosity 2. *)
-
   (** PKE-CCA *)
 
+  Opaque ValidPackage mkfmap pkg_composition.mkdef.
+
   (* Probably a loc_GamePair *)
-  Fail Definition PKE_CCA (ζ : PKE_scheme) b :
+  #[program] Definition PKE_CCA (ζ : PKE_scheme) b :
     package
       (fset [:: pk_loc ; sk_loc ; c_loc ])
       [interface]
@@ -229,6 +227,29 @@ Section KEMDEM.
         ret m
       }
     ].
+  Next Obligation.
+    exact _.
+  Qed.
+  Next Obligation.
+    (* TODO Have a tactic that does most of the work. *)
+    eapply valid_package_cons.
+    3:{ unfold "\notin" ; rewrite imfset_fset ; rewrite in_fset ; eauto. }
+    1: eapply valid_package_cons.
+    3:{ unfold "\notin" ; rewrite imfset_fset ; rewrite in_fset ; eauto. }
+    1: eapply valid_package1.
+    - intro. eapply valid_getr. 1: auto_in_fset.
+      intro. Fail eapply valid_assertD. admit.
+    - intro. eapply valid_getr. 1: auto_in_fset.
+      intro. Fail eapply valid_assertD. admit.
+      (* eapply valid_code_from_class. exact _. *)
+    - intro. eapply valid_getr. 1: auto_in_fset.
+      intro. eapply valid_bind.
+      1:{ eapply valid_code_from_class. exact _. }
+      intro. eapply valid_bind.
+      + (* NEED to update PKE_kgen to use these locs I guess... *)
+        admit.
+      + intros []. eapply valid_code_from_class. exact _.
+  Admitted.
 
   (** MOD-CCA *)
 

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -1,0 +1,77 @@
+(** KEM-DEM example *)
+
+From Relational Require Import OrderEnrichedCategory GenericRulesSimple.
+
+Set Warnings "-notation-overridden,-ambiguous-paths,-notation-incompatible-format".
+From mathcomp Require Import all_ssreflect all_algebra reals distr
+  fingroup.fingroup realsum ssrnat ssreflect ssrfun ssrbool ssrnum eqtype choice
+  seq.
+Set Warnings "notation-overridden,ambiguous-paths,notation-incompatible-format".
+
+From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
+  UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb UniformStateProb
+  Package Prelude.
+
+From Coq Require Import Utf8 Lia.
+From extructures Require Import ord fset fmap.
+
+From Equations Require Import Equations.
+Require Equations.Prop.DepElim.
+
+Set Equations With UIP.
+
+Set Bullet Behavior "Strict Subproofs".
+Set Default Goal Selector "!".
+Set Primitive Projections.
+
+Import Num.Def.
+Import Num.Theory.
+Import mc_1_10.Num.Theory.
+
+Import PackageNotation.
+
+#[local] Open Scope ring_scope.
+#[local] Open Scope package_scope.
+
+Definition i_key (l : nat) := l.
+
+Definition GEN := 0%N.
+Definition SET := 1%N.
+Definition GET := 2%N.
+
+Definition key n `{Positive n} : Location := ('option ('fin n) ; 0%N).
+
+(* It can't solve it for now because it doesn't have any rules for
+  assert, fail and assert_false.
+*)
+(* Definition KEY n `{Positive n} :
+  package
+    (fset [:: key n ])
+    [interface]
+    [interface
+      val #[ GEN ] : 'unit → 'unit ;
+      val #[ SET ] : ('fin n) → 'unit ;
+      val #[ GET ] : 'unit → 'fin n
+    ] :=
+  [package
+    def #[ GEN ] (_ : 'unit) : 'unit {
+      k ← get (key n) ;;
+      assert (k == None) ;;
+      k ← sample U (i_key n) ;;
+      put (key n) := Some k ;;
+      ret Datatypes.tt
+    } ;
+    def #[ SET ] (k : ('fin n)) : 'unit {
+      k' ← get (key n) ;;
+      assert (k' == None) ;;
+      put (key n) := Some k ;;
+      ret Datatypes.tt
+    } ;
+    def #[ GET ] (_ : 'unit) : ('fin n) {
+      k ← get (key n) ;;
+      match k with
+      | Some k => ret k
+      | None => @assert_false ('fin n)
+      end
+    }
+  ]. *)

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -238,10 +238,33 @@ Section KEMDEM.
     3:{ unfold "\notin" ; rewrite imfset_fset ; rewrite in_fset ; eauto. }
     1: eapply valid_package1.
     - intro. eapply valid_getr. 1: auto_in_fset.
-      intro. Fail eapply valid_assertD. admit.
+      intro.
+      match goal with
+      | |- valid_code _ _ (@assertD ?A ?b ?k) =>
+        eapply (valid_assertD A _ _ b k)
+      end.
+      intro. eapply valid_getr. 1: auto_in_fset.
+      intro. eapply valid_bind.
+      1:{ eapply valid_code_from_class. exact _. }
+      intro. eapply valid_bind.
+      2:{ intro. eapply valid_code_from_class. exact _. }
+      (* NEED to update PKE_dec to use these locs I guess... *)
+      give_up.
     - intro. eapply valid_getr. 1: auto_in_fset.
-      intro. Fail eapply valid_assertD. admit.
-      (* eapply valid_code_from_class. exact _. *)
+      intro.
+      match goal with
+      | |- valid_code _ _ (@assertD ?A ?b ?k) =>
+        eapply (valid_assertD A _ _ b k)
+      end.
+      intro. eapply valid_getr. 1: auto_in_fset.
+      intro. eapply valid_bind.
+      1:{ eapply valid_code_from_class. exact _. }
+      intro. eapply valid_bind.
+      2:{ intro. eapply valid_code_from_class. exact _. }
+      destruct b.
+      2:{ eapply valid_code_from_class. exact _. }
+      (* NEED to update PKE_enc to use these locs I guess... *)
+      give_up.
     - intro. eapply valid_getr. 1: auto_in_fset.
       intro. eapply valid_bind.
       1:{ eapply valid_code_from_class. exact _. }

--- a/theories/Crypt/examples/OTP.v
+++ b/theories/Crypt/examples/OTP.v
@@ -44,10 +44,12 @@ Section OTP_example.
     apply Zp_cast.
     pose proof n_pos as n_pos.
     destruct n as [| k].
-    1:{ inversion n_pos. }
+    1:{ eapply from_Positive in n_pos. inversion n_pos. }
     rewrite expnS.
     move: (PositiveExp2 k).
-    rewrite /Positive !mulSnr => Hpos.
+    eapply from_Positive in n_pos.
+    intro Hpos. eapply from_Positive in Hpos.
+    rewrite !mulSnr.
     change (0 * ?n ^ ?m)%N with 0%N.
     set (m := (2^ k)%N) in *. clearbody m.
     apply /ltP. move: Hpos => /ltP Hpos.
@@ -337,7 +339,10 @@ Section OTP_example.
     eapply eq_rel_perf_ind_eq.
     simplify_eq_rel m.
     apply rconst_samplerL. intro m_val.
-    pose (f := λ (k : Arit (uniform i_key)), words2ch (ch2key k ⊕ ch2words m ⊕ (ch2words m_val))).
+    pose (f :=
+      λ (k : Arit (uniform i_key)),
+        words2ch (ch2key k ⊕ ch2words m ⊕ (ch2words m_val))
+    ).
     assert (bij_f : bijective f).
     { subst f.
       exists (λ x, words2ch (ch2words x ⊕ (ch2words m_val) ⊕ ch2words m)).

--- a/theories/Crypt/package/pkg_composition.v
+++ b/theories/Crypt/package/pkg_composition.v
@@ -146,7 +146,7 @@ Qed.
     apply valid_code_from_class
   | apply valid_package_from_class
   ]
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 (* Linking *)
 Definition link (p1 p2 : raw_package) : raw_package :=
@@ -185,7 +185,7 @@ Qed.
     apply valid_package_from_class
   | apply valid_package_from_class
   ]
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 Lemma code_link_bind :
   ∀ {A B : choiceType} (v : raw_code A)
@@ -250,7 +250,7 @@ Qed.
 #[export] Hint Extern 1 (ValidPackage ?L ?I ?E (trim ?E ?p)) =>
   apply valid_trim ;
   apply valid_package_from_class
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 (* Technical lemma before proving assoc *)
 Lemma link_trim_commut :
@@ -468,7 +468,7 @@ Qed.
   | apply valid_package_from_class
   | apply valid_package_from_class
   ]
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 Class FDisjoint {A : ordType} s1 s2 :=
   are_disjoint : @fdisjoint A s1 s2.
@@ -532,16 +532,16 @@ Qed.
 #[export] Hint Extern 1 (FDisjoint (fset ?l1) (fset ?l2)) =>
   repeat rewrite [fset]unlock ;
   eauto
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 #[export] Hint Extern 1 (Parable _ _) =>
   apply fdisjoint_from_class
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 #[export] Hint Extern 1 (Parable (trim ?E1 ?p1) (trim ?E2 ?p2)) =>
   apply parable_trim ;
   apply fdisjoint_from_class
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 (* TODO MOVE *)
 (** To circumvent the very annoying lemmata that conclude on equality

--- a/theories/Crypt/package/pkg_core_definition.v
+++ b/theories/Crypt/package/pkg_core_definition.v
@@ -443,7 +443,7 @@ Notation "{ 'code' p '#with' h }" :=
 
 (* Having an instance here means that it will use ret when the code
   is unknown. Pretty bad.
-  We will instead use #[export] Hint Extern.
+  We will instead use Hint Extern.
 *)
 (* Instance ValidCode_ret (A : choiceType) (x : A) L I :
   ValidCode L I (ret x).
@@ -451,73 +451,75 @@ Proof.
   apply valid_ret.
 Qed. *)
 
+Create HintDb packages.
+
 #[export] Hint Extern 1 (ValidCode ?L ?I (ret ?x)) =>
   apply valid_ret
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 #[export] Hint Extern 1 (ValidCode ?L ?I (opr ?o ?x ?k)) =>
   eapply valid_opr ; [
     auto_in_fset
   | intro ; apply valid_code_from_class
-  ] : typeclass_instances.
+  ] : typeclass_instances packages.
 
 #[export] Hint Extern 1 (ValidCode ?L ?I (getr ?o ?k)) =>
   eapply valid_getr ; [
     auto_in_fset
   | intro ; apply valid_code_from_class
-  ] : typeclass_instances.
+  ] : typeclass_instances packages.
 
 #[export] Hint Extern 1 (ValidCode ?L ?I (putr ?o ?x ?k)) =>
   eapply valid_putr ; [
     auto_in_fset
   | apply valid_code_from_class
-  ] : typeclass_instances.
+  ] : typeclass_instances packages.
 
 #[export] Hint Extern 1 (ValidCode ?L ?I (sampler ?op ?k)) =>
   eapply valid_sampler ;
   intro ; apply valid_code_from_class
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 #[export] Hint Extern 1 (ValidCode ?L ?I (bind ?p ?k)) =>
   eapply valid_bind ; [
     apply valid_code_from_class
   | intro ; apply valid_code_from_class
   ]
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 Coercion prog : code >-> raw_code.
 
 #[export] Hint Extern 1 (ValidCode ?L ?I (?p.(prog))) =>
   eapply p.(prog_valid)
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 Arguments valid_command _ _ [_] _.
 
 #[export] Hint Extern 1 (ValidCommand ?L ?I (cmd_op ?o ?x)) =>
   eapply valid_cmd_op ;
   auto_in_fset
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 #[export] Hint Extern 1 (ValidCommand ?L ?I (cmd_get ?l)) =>
   eapply valid_cmd_get ;
   auto_in_fset
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 #[export] Hint Extern 1 (ValidCode ?L ?I (cmd_put ?l ?v)) =>
   eapply valid_cmd_put ;
   auto_in_fset
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 #[export] Hint Extern 1 (ValidCode ?L ?I (cmd_sample ?op)) =>
   eapply valid_cmd_sample
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 #[export] Hint Extern 1 (ValidCode ?L ?I (cmd_bind ?c ?k)) =>
   eapply valid_cmd_bind ; [
     apply valid_command_from_class
   | intro ; apply valid_code_from_class
   ]
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 Section FreeLocations.
 
@@ -670,7 +672,7 @@ Coercion pack : package >-> raw_package.
 
 #[export] Hint Extern 1 (ValidPackage ?L ?I ?E (?p.(pack))) =>
   eapply p.(pack_valid)
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 Lemma valid_package_from_class :
   ∀ L I E (p : raw_package),

--- a/theories/Crypt/package/pkg_rhl.v
+++ b/theories/Crypt/package/pkg_rhl.v
@@ -2605,8 +2605,12 @@ Proof.
   intros A L I. unfold fail. eapply valid_code_from_class. exact _.
 Qed.
 
-Hint Extern 1 (ValidProgram ?L ?I fail) =>
+(* In some cases eapply valid_fail fails and I don't understand why *)
+(* Hint Extern 1 (ValidProgram ?L ?I fail) =>
   eapply valid_fail
+  : typeclass_instances. *)
+Hint Extern 1 (ValidProgram ?L ?I fail) =>
+  unfold fail
   : typeclass_instances.
 
 Lemma valid_assertD :

--- a/theories/Crypt/package/pkg_rhl.v
+++ b/theories/Crypt/package/pkg_rhl.v
@@ -2644,8 +2644,8 @@ Proof.
   - simpl. eapply valid_code_from_class. exact _.
 Qed.
 
-#[export] Hint Extern 1 (ValidCode ?L ?I (assertD ?b ?k)) =>
-  eapply valid_assertD ;
+#[export] Hint Extern 1 (ValidCode ?L ?I (@assertD ?A ?b ?k)) =>
+  eapply (valid_assertD A _ _ b k) ;
   intro ; apply valid_code_from_class
   : typeclass_instances.
 

--- a/theories/Crypt/package/pkg_rhl.v
+++ b/theories/Crypt/package/pkg_rhl.v
@@ -94,7 +94,7 @@ Proof.
   - exact (IHa1, IHa2).
   - exact emptym.
   - exact None.
-  - exact (fintype.Ordinal (cond_pos n)).
+  - exact (fintype.Ordinal (from_Positive _ n.(cond_pos))).
 Defined.
 
 Definition heap := { h : raw_heap | valid_heap h }.
@@ -1269,21 +1269,21 @@ Qed.
 (* TODO MOVE *)
 
 (* Slightly more expensive version that allows to change parameters *)
-#[export] Hint Extern 3 (ValidCode ?L ?I ?p) =>
+(* #[export] Hint Extern 3 (ValidCode ?L ?I ?p) =>
   match goal with
   | h : is_true (fsubset ?x ?y) |- _ =>
     eapply valid_injectLocations with (1 := h) ;
     eapply valid_code_from_class ; exact _
   end
-  : typeclass_instances.
+  : typeclass_instances. *)
 
-#[export] Hint Extern 3 (ValidPackage ?L ?I ?E ?p) =>
+(* #[export] Hint Extern 3 (ValidPackage ?L ?I ?E ?p) =>
   match goal with
   | h : is_true (fsubset ?x ?y) |- _ =>
     eapply valid_package_inject_locations with (1 := h) ;
     eapply valid_package_from_class ; exact _
   end
-  : typeclass_instances.
+  : typeclass_instances. *)
 
 Lemma Pr_eq_empty :
   ∀ {X Y : ord_choiceType}
@@ -2396,7 +2396,7 @@ Lemma ordinal_finType_inhabited :
   ∀ i `{Positive i}, ordinal_finType i.
 Proof.
   intros i hi.
-  exists 0%N. auto.
+  exists 0%N. eapply from_Positive. auto.
 Qed.
 
 Section Uniform_prod.

--- a/theories/Crypt/package/pkg_rhl.v
+++ b/theories/Crypt/package/pkg_rhl.v
@@ -1277,13 +1277,13 @@ Qed.
   end
   : typeclass_instances. *)
 
-#[export] Hint Extern 3 (ValidCode ?L ?I ?p) =>
+(* #[export] Hint Extern 3 (ValidCode ?L ?I ?p) =>
   match goal with
   | h : is_true (fsubset ?x ?y) |- _ =>
     eapply valid_injectMap with (1 := h) ;
     eapply valid_code_from_class ; exact _
   end
-  : typeclass_instances.
+  : typeclass_instances. *)
 
 (* #[export] Hint Extern 3 (ValidPackage ?L ?I ?E ?p) =>
   match goal with
@@ -1293,21 +1293,21 @@ Qed.
   end
   : typeclass_instances. *)
 
-#[export] Hint Extern 3 (ValidPackage ?L ?I ?E ?p) =>
+(* #[export] Hint Extern 3 (ValidPackage ?L ?I ?E ?p) =>
   match goal with
   | h : is_true (fsubset ?x ?y) |- _ =>
     eapply valid_package_inject_export with (1 := h) ;
     eapply valid_package_from_class ; exact _
   end
-  : typeclass_instances.
+  : typeclass_instances. *)
 
-#[export] Hint Extern 3 (ValidPackage ?L ?I ?E ?p) =>
+(* #[export] Hint Extern 3 (ValidPackage ?L ?I ?E ?p) =>
   match goal with
   | h : is_true (fsubset ?x ?y) |- _ =>
     eapply valid_package_inject_import with (1 := h) ;
     eapply valid_package_from_class ; exact _
   end
-  : typeclass_instances.
+  : typeclass_instances. *)
 
 Lemma Pr_eq_empty :
   ∀ {X Y : ord_choiceType}

--- a/theories/Crypt/package/pkg_rhl.v
+++ b/theories/Crypt/package/pkg_rhl.v
@@ -939,7 +939,7 @@ Proof.
     /SPropMonadicStructures.SProp_op_order
     /Morphisms.pointwise_relation /Basics.flip
     /SPropMonadicStructures.SProp_order /=.
-  intuition.
+  intuition auto.
   assert (get_heap s₁ ℓ = get_heap s₂ ℓ) as Hv.
   { unfold INV in hinv.
     specialize (hinv s₁ s₂). destruct hinv as [hinv _].
@@ -960,7 +960,7 @@ Proof.
       - rewrite e in hd. cbn in hd.
         rewrite mc_1_10.Num.Theory.ltrr in hd. discriminate.
     }
-    inversion e. subst. intuition.
+    inversion e. subst. intuition auto.
 Qed.
 
 Lemma put_case :
@@ -976,7 +976,7 @@ Proof.
   rewrite /SpecificationMonads.MonoCont_bind /=.
   rewrite /SpecificationMonads.MonoCont_order /SPropMonadicStructures.SProp_op_order
           /Morphisms.pointwise_relation /Basics.flip /SPropMonadicStructures.SProp_order /=.
-  intuition.
+  intuition eauto.
   eexists (SDistr_unit _ _).
   split.
   + apply SDistr_unit_F_choice_prod_coupling.
@@ -993,7 +993,8 @@ Proof.
         rewrite mc_1_10.Num.Theory.ltrr in Hd. discriminate.
     }
     inversion Heqs.
-    intuition.
+    intuition eauto.
+    eapply hinv. all: eauto.
 Qed.
 
 (* TODO MOVE? *)
@@ -1082,7 +1083,7 @@ Proof.
   cbn - [thetaFstd θ]. intros [s1 s2].
   rewrite /SpecificationMonads.MonoCont_order /SPropMonadicStructures.SProp_op_order
           /Morphisms.pointwise_relation /Basics.flip /SPropMonadicStructures.SProp_order.
-  intuition. unfold θ. cbn - [justInterpState stT_thetaDex].
+  intuition eauto. unfold θ. cbn - [justInterpState stT_thetaDex].
   unfold justInterpState. unfold LaxComp.rlmm_comp.
   simpl (nfst _). simpl (nsnd _). unfold stT_thetaDex.
   simpl (TransformingLaxMorph.rlmm_from_lmla (stT_thetaDex_adj) ⟨ Arit op, Arit op ⟩).

--- a/theories/Crypt/package/pkg_rhl.v
+++ b/theories/Crypt/package/pkg_rhl.v
@@ -508,7 +508,7 @@ Qed.
     apply valid_package_from_class
   | auto_in_fset
   ]
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 Lemma lookup_op_link :
   ∀ p q o,
@@ -1814,7 +1814,7 @@ Qed.
 #[export] Hint Extern 1 (ValidCode ?L ?I (for_loop ?c ?N)) =>
   eapply valid_for_loop ;
   intro ; apply valid_code_from_class
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 Lemma rcoupling_eq :
   ∀ {A : ord_choiceType} (K₀ K₁ : raw_code A) (ψ : precond),
@@ -2612,7 +2612,7 @@ Qed.
 
 #[export] Hint Extern 1 (ValidCode ?L ?I fail_unit) =>
   eapply valid_fail_unit
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 Lemma valid_assert :
   ∀ L I b, valid_code L I (assert b).
@@ -2622,7 +2622,7 @@ Qed.
 
 #[export] Hint Extern 1 (ValidCode ?L ?I (assert ?b)) =>
   eapply valid_assert
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 Lemma valid_fail :
   ∀ A L I, valid_code L I (@fail A).
@@ -2632,7 +2632,7 @@ Qed.
 
 #[export] Hint Extern 1 (ValidCode ?L ?I fail) =>
   eapply valid_fail
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 Lemma valid_assertD :
   ∀ A L I b k,
@@ -2648,7 +2648,7 @@ Qed.
 #[export] Hint Extern 1 (ValidCode ?L ?I (@assertD ?A ?b ?k)) =>
   eapply (valid_assertD A _ _ b k) ;
   intro ; apply valid_code_from_class
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 Notation "'#assert' b 'as' id ;; k" :=
   (assertD b (λ id, k))

--- a/theories/Crypt/package/pkg_tactics.v
+++ b/theories/Crypt/package/pkg_tactics.v
@@ -261,7 +261,7 @@ Qed.
 
 #[export] Hint Extern 1 (ValidPackage ?L ?I ?E (mkfmap [::])) =>
   rewrite -?fset0E ; eapply valid_empty_package
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 Lemma valid_package1 :
   ∀ L I i A B f,
@@ -331,8 +331,6 @@ Proof.
     exists g. intuition auto.
 Qed.
 
-Create HintDb packages.
-
 #[export] Hint Extern 100 =>
   shelve : packages.
 
@@ -361,3 +359,6 @@ Create HintDb packages.
   =>
   unify_positive_proofs
   : typeclass_instances. *)
+
+Ltac ssprove_valid :=
+  unshelve typeclasses eauto with packages.

--- a/theories/Crypt/package/pkg_tactics.v
+++ b/theories/Crypt/package/pkg_tactics.v
@@ -168,7 +168,7 @@ Ltac code_after_rewrite :=
 
 (** Tactic to unify Positive proofs in a goal *)
 
-Ltac mark_abstract_positive :=
+(* Ltac mark_abstract_positive :=
   repeat match goal with
   | |- context [ @mkpos ?p ?h ] =>
     let h' := fresh "h" in
@@ -181,15 +181,15 @@ Ltac mark_abstract_positive :=
     | ?T =>
       change T with (tac_intro_mark (Positive p)) in h'
     end
-  end.
+  end. *)
 
-Ltac unify_marked_positive_proofs :=
+(* Ltac unify_marked_positive_proofs :=
   repeat match goal with
   | h : tac_intro_mark (Positive ?n),
     h' : tac_intro_mark (Positive ?n) |- _ =>
     assert (h = h') by eapply uip ;
     subst h'
-  end.
+  end. *)
 
 Ltac subst_marked :=
   repeat match goal with
@@ -203,11 +203,11 @@ Ltac unmark_tac_intro_mark :=
     change (tac_intro_mark t) with t in h
   end.
 
-Ltac unify_positive_proofs :=
+(* Ltac unify_positive_proofs :=
   mark_abstract_positive ;
   unify_marked_positive_proofs ;
   unmark_tac_intro_mark ;
-  subst_marked.
+  subst_marked. *)
 
 (** Tactic to unify ValidCode proofs in a goal *)
 
@@ -260,7 +260,7 @@ Proof.
 Qed.
 
 #[export] Hint Extern 1 (ValidPackage ?L ?I ?E (mkfmap [::])) =>
-  eapply valid_empty_package
+  rewrite -?fset0E ; eapply valid_empty_package
   : typeclass_instances.
 
 Lemma valid_package1 :
@@ -277,10 +277,11 @@ Proof.
   intuition auto.
 Qed.
 
-#[export] Hint Extern 1 (ValidPackage ?L ?I ?E (mkfmap [:: (?i, mkdef ?A ?B ?f)])) =>
+(* Would be a shortcut, but when backtracking, this has an unnecessary cost *)
+(* #[export] Hint Extern 1 (ValidPackage ?L ?I ?E (mkfmap [:: (?i, mkdef ?A ?B ?f)])) =>
   eapply valid_package1 ;
   intro ; eapply valid_code_from_class
-  : typeclass_instances.
+  : typeclass_instances. *)
 
 Lemma flat_valid_package :
   ∀ L I E p,
@@ -351,7 +352,7 @@ Qed.
   This is—I hope—the only thing that might cause a discrepancy between
   the interface and the signature of the term.
 *)
-#[export] Hint Extern 3 (ValidPackage ?L ?I ?E (mkfmap ((?i, mkdef ?A ?B ?f) :: ?p)))
+(* #[export] Hint Extern 3 (ValidPackage ?L ?I ?E (mkfmap ((?i, mkdef ?A ?B ?f) :: ?p)))
   =>
   unify_positive_proofs
-  : typeclass_instances.
+  : typeclass_instances. *)

--- a/theories/Crypt/package/pkg_tactics.v
+++ b/theories/Crypt/package/pkg_tactics.v
@@ -333,6 +333,9 @@ Qed.
 
 Create HintDb packages.
 
+#[export] Hint Extern 100 =>
+  shelve : packages.
+
 #[export] Hint Extern 2 (ValidPackage ?L ?I ?E (mkfmap ((?i, mkdef ?A ?B ?f) :: ?p)))
   =>
   eapply valid_package_cons ; [
@@ -344,11 +347,11 @@ Create HintDb packages.
 
 #[export] Hint Extern 10 (ValidCode ?L ?I (let u := _ in _)) =>
   cbv zeta
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 #[export] Hint Extern 2 (ValidCode ?L ?I (match ?t with _ => _ end)) =>
   destruct t
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 (** Variant of the cons case where we unify Positive proofs beforehand
   This is—I hope—the only thing that might cause a discrepancy between

--- a/theories/Crypt/package/pkg_tactics.v
+++ b/theories/Crypt/package/pkg_tactics.v
@@ -331,6 +331,8 @@ Proof.
     exists g. intuition auto.
 Qed.
 
+Create HintDb packages.
+
 #[export] Hint Extern 2 (ValidPackage ?L ?I ?E (mkfmap ((?i, mkdef ?A ?B ?f) :: ?p)))
   =>
   eapply valid_package_cons ; [
@@ -338,7 +340,7 @@ Qed.
   | intro ; eapply valid_code_from_class
   | unfold "\notin" ; rewrite imfset_fset ; rewrite in_fset ; eauto
   ]
-  : typeclass_instances.
+  : typeclass_instances packages.
 
 #[export] Hint Extern 10 (ValidCode ?L ?I (let u := _ in _)) =>
   cbv zeta

--- a/theories/Crypt/rules/UniformStateProb.v
+++ b/theories/Crypt/rules/UniformStateProb.v
@@ -28,7 +28,7 @@ Lemma F_w0 :
   forall (i : Index), fin_family i.
 Proof.
   intros i. unfold fin_family. cbn.
-  exists 0%N. eapply i.(cond_pos).
+  exists 0%N. eapply from_Positive. eapply i.(cond_pos).
 Qed.
 
 (* extend the initial parameters for the rules  *)


### PR DESCRIPTION
Now that we have `assert` and corresponding rules, we can probably do it. Very much work in progress.

---------------
**UPDATE:** I apologise for doing things the right way, but with the KEM DEM I was experiencing the looping issue when inference of package validity proof fails. I took this opportunity to try and fix the problem.

Fixing the loop has a cost, in the sense that I had to drop previous behaviours leading to success. In particular I had to remove a tactic that fiddled with positivity proofs to unify them, it seems it could be applied repeatedly (indefinitely) in some cases.
Removing it made most examples involving fin types fail, so I moved `Positive` in `SProp` which also comes with other kinds of problems.

--------
**UPDATE2:** This PR will also add some tactics to progress with the validity proofs. At the moment, I use `typeclasses eauto` with databases, and `shelve`. This means that we should avoid using `intuition` as a tactic, and use it as a tactical instead. Indeed, `intuition` as a tactic will use *all* databases, but now one the databases has `shelve` as a hint.
`intuition eauto` and so on will still work as usual.

--------
**UPDATE3:** The new tactic `ssprove_auto` will call the hints of the `packages` database to prove either `ValidPackage` or `ValidCode` and yield the bits it did not manage to prove automatically.