### PR TITLE
Wrap valid_package in inductive to avoid unification troubles

### DIFF
--- a/theories/Crypt/package/pkg_composition.v
+++ b/theories/Crypt/package/pkg_composition.v
@@ -84,6 +84,7 @@ Lemma lookup_op_valid :
       ∀ x, valid_code L I (f x).
 Proof.
   intros L I E p o hp ho.
+  eapply from_valid_package in hp.
   specialize (hp o ho).
   destruct o as [n [So To]].
   destruct hp as [f [ef hf]].
@@ -164,6 +165,8 @@ Lemma valid_link :
     valid_package (L1 :|: L2) I E (link p1 p2).
 Proof.
   intros L1 l2 I M E p1 p2 h1 h2.
+  apply prove_valid_package.
+  eapply from_valid_package in h1.
   intros [n [So To]] ho. unfold link.
   rewrite mapmE.
   specialize (h1 _ ho) as h1'. cbn in h1'.
@@ -241,6 +244,8 @@ Lemma valid_trim :
     valid_package L I E (trim E p).
 Proof.
   intros L I E p h.
+  apply prove_valid_package.
+  eapply from_valid_package in h.
   intros [n [So To]] ho.
   specialize (h _ ho). cbn in h. destruct h as [f [ef hf]].
   exists f. intuition auto.
@@ -354,6 +359,7 @@ Proof.
   f_equal. f_equal. f_equal.
   extensionality x.
   apply trim_get_inv in e as [e he].
+  eapply from_valid_package in h.
   specialize (h _ he). cbn in h.
   destruct h as [f [ef h]].
   rewrite ef in e. noconf e.
@@ -430,6 +436,9 @@ Lemma valid_par :
     valid_package (L1 :|: L2) (I1 :|: I2) (E1 :|: E2) (par p1 p2).
 Proof.
   intros L1 L2 I1 I2 E1 E2 p1 p2 h h1 h2.
+  apply prove_valid_package.
+  eapply from_valid_package in h1.
+  eapply from_valid_package in h2.
   intros [n [So To]] ho.
   unfold par. rewrite unionmE.
   rewrite in_fsetU in ho. move: ho => /orP [ho | ho].
@@ -657,6 +666,7 @@ Proof.
   - simpl. f_equal. f_equal. f_equal.
     extensionality x.
     eapply trimmed_valid_Some_in in e1 as hi. 2,3: eauto.
+    eapply from_valid_package in h1.
     specialize (h1 _ hi). cbn in h1.
     destruct h1 as [g [eg hg]].
     rewrite e1 in eg. noconf eg. cbn in hg.
@@ -665,6 +675,7 @@ Proof.
   - simpl. destruct (p2 n) as [[S2 [T2 f2]]|] eqn:e2.
     + simpl. f_equal. f_equal. f_equal. extensionality x.
       eapply trimmed_valid_Some_in in e2 as hi. 2,3: eauto.
+      eapply from_valid_package in h2.
       specialize (h2 _ hi). cbn in h2.
       destruct h2 as [g [eg hg]].
       rewrite e2 in eg. noconf eg. cbn in hg.
@@ -774,6 +785,7 @@ Proof.
   pose bar := mkfmap foo.
   exists (@mapm _ (typed_function L I) typed_raw_function
     (λ '(So ; To ; f), (So ; To ; λ x, (f x).(prog))) bar).
+  apply prove_valid_package.
   intros [n [So To]] ho.
   rewrite mapmE. subst bar foo.
   rewrite mkfmapE.
@@ -896,6 +908,7 @@ Lemma valid_ID :
     valid_package L I I (ID I).
 Proof.
   intros L I hI.
+  apply prove_valid_package.
   intros [id [S T]] ho.
   rewrite IDE. destruct getm_def as [[S' T']|] eqn:e.
   2:{ exfalso. eapply in_getm_def_None. 2: eauto. exact ho. }
@@ -936,6 +949,7 @@ Proof.
   rewrite mapmE. destruct (p n) as [[S [T f]]|] eqn:e.
   - cbn. f_equal. f_equal. f_equal. extensionality x.
     eapply trimmed_valid_Some_in in e as hi. 2,3: eauto.
+    eapply from_valid_package in hp.
     specialize (hp _ hi) as h'. cbn in h'.
     destruct h' as [g [eg hg]].
     rewrite e in eg. noconf eg. cbn in hg.
@@ -954,6 +968,7 @@ Proof.
   rewrite mapmE. rewrite IDE.
   destruct getm_def as [[So To]|] eqn:e.
   - eapply getm_def_in in e as hi.
+    eapply from_valid_package in hp.
     specialize (hp _ hi) as h'. cbn in h'.
     destruct h' as [f [ef hf]].
     cbn. destruct (p n) as [[St [Tt g]]|] eqn:e1. 2: discriminate.

--- a/theories/Crypt/package/pkg_rhl.v
+++ b/theories/Crypt/package/pkg_rhl.v
@@ -293,6 +293,7 @@ Proof.
   exfalso.
   destruct o as [n [S T]].
   cbn - [lookup_op] in e.
+  eapply from_valid_package in hp.
   specialize (hp _ ho). cbn in hp. destruct hp as [f [ef hf]].
   cbn in e. destruct (p n) as [[St [Tt g]]|] eqn:e2.
   2: discriminate.
@@ -386,30 +387,34 @@ Lemma get_raw_package_op_link {L} {I M E} {o : opsig}
     code_link ((get_raw_package_op p1 hp1 o hin arg).(prog)) p2.
 Proof.
   destruct (lookup_op (link p1 p2) o) as [f|] eqn:e.
-  2: { unfold valid_package in hpl.
-        pose (hpl o hin) as H.
-        destruct o as [id [S T]].
-        destruct H as [f [H1 H2]].
-        unfold lookup_op in e.
-        rewrite H1 in e.
-        destruct chUniverse_eqP.
-        2:{ noconf ef. congruence. }
-        destruct chUniverse_eqP.
-        2:{ noconf ef. congruence. }
-        discriminate. }
+  2:{
+    eapply from_valid_package in hpl as H.
+    specialize (H o hin).
+    destruct o as [id [S T]].
+    destruct H as [f [H1 H2]].
+    unfold lookup_op in e.
+    rewrite H1 in e.
+    destruct chUniverse_eqP.
+    2:{ noconf ef. congruence. }
+    destruct chUniverse_eqP.
+    2:{ noconf ef. congruence. }
+    discriminate.
+  }
   rewrite (get_raw_package_op_lookup (link p1 p2) _ o hin arg f e).
   destruct (lookup_op p1 o) as [fl|] eqn:el.
-  2: { unfold valid_package in hp1.
-        pose (hp1 o hin) as H.
-        destruct o as [id [S T]].
-        destruct H as [f' [H1 H2]].
-        unfold lookup_op in el.
-        rewrite H1 in el.
-        destruct chUniverse_eqP.
-        2:{ noconf ef. congruence. }
-        destruct chUniverse_eqP.
-        2:{ noconf ef. congruence. }
-        discriminate. }
+  2:{
+    eapply from_valid_package in hp1 as H.
+    specialize (H o hin).
+    destruct o as [id [S T]].
+    destruct H as [f' [H1 H2]].
+    unfold lookup_op in el.
+    rewrite H1 in el.
+    destruct chUniverse_eqP.
+    2:{ noconf ef. congruence. }
+    destruct chUniverse_eqP.
+    2:{ noconf ef. congruence. }
+    discriminate.
+  }
   rewrite (get_raw_package_op_lookup p1 _ o hin arg fl el).
   apply (code_link_ext o hin arg p1 p2 fl el f e).
 Qed.
@@ -423,17 +428,19 @@ Lemma get_raw_package_op_trim {L} {I E} {o : opsig}
 Proof.
   apply code_ext.
   destruct (lookup_op p o) as [f|] eqn:e.
-  2: { unfold valid_package in hp.
-        pose (hp o hin) as H.
-        destruct o as [id [S T]].
-        destruct H as [f [H1 H2]].
-        unfold lookup_op in e.
-        rewrite H1 in e.
-        destruct chUniverse_eqP.
-        2:{ noconf ef. congruence. }
-        destruct chUniverse_eqP.
-        2:{ noconf ef. congruence. }
-        discriminate. }
+  2:{
+    eapply from_valid_package in hp as H.
+    specialize (H o hin).
+    destruct o as [id [S T]].
+    destruct H as [f [H1 H2]].
+    unfold lookup_op in e.
+    rewrite H1 in e.
+    destruct chUniverse_eqP.
+    2:{ noconf ef. congruence. }
+    destruct chUniverse_eqP.
+    2:{ noconf ef. congruence. }
+    discriminate.
+  }
   rewrite (get_raw_package_op_lookup p _ o hin arg f e).
   assert (lookup_op (trim E p) o = Some f) as H.
   { rewrite (lookup_op_trim E o p).
@@ -450,17 +457,19 @@ Lemma get_raw_package_op_ext {L1 L2} {I E} {o : opsig}
     (get_raw_package_op p hp2 o hin arg).(prog).
 Proof.
   destruct (lookup_op p o) as [f|] eqn:e.
-  2: { unfold valid_package in hp1.
-        pose (hp1 o hin) as H.
-        destruct o as [id [S T]].
-        destruct H as [f [H1 H2]].
-        unfold lookup_op in e.
-        rewrite H1 in e.
-        destruct chUniverse_eqP.
-        2:{ noconf ef. congruence. }
-        destruct chUniverse_eqP.
-        2:{ noconf ef. congruence. }
-        discriminate. }
+  2:{
+    eapply from_valid_package in hp1 as H.
+    specialize (H o hin).
+    destruct o as [id [S T]].
+    destruct H as [f [H1 H2]].
+    unfold lookup_op in e.
+    rewrite H1 in e.
+    destruct chUniverse_eqP.
+    2:{ noconf ef. congruence. }
+    destruct chUniverse_eqP.
+    2:{ noconf ef. congruence. }
+    discriminate.
+  }
   rewrite (get_raw_package_op_lookup p _ o hin arg f e).
   rewrite (get_raw_package_op_lookup p _ o hin arg f e).
   reflexivity.
@@ -496,6 +505,7 @@ Proof.
   unfold get_op_default.
   destruct lookup_op eqn:e.
   - eapply lookup_op_spec in e as h.
+    eapply from_valid_package in hp.
     specialize (hp _ ho). destruct o as [id [S T]].
     destruct hp as [f [ef hf]].
     cbn in h. rewrite ef in h. noconf h.
@@ -572,6 +582,7 @@ Proof.
     destruct p as [L [p hp]].
     destruct o as [n [S T]].
     cbn - [lookup_op] in e.
+    eapply from_valid_package in hp.
     specialize (hp _ ho). cbn in hp. destruct hp as [f [ef hf]].
     cbn in e. destruct (p n) as [[St [Tt g]]|] eqn:e2.
     2: discriminate.
@@ -1348,8 +1359,10 @@ Proof.
   - cbn - [semantic_judgement lookup_op].
     apply inversion_valid_opr in vA as hA. destruct hA as [hi vk].
     destruct o as [id [S T]].
+    eapply from_valid_package in vp₀.
     specialize (vp₀ _ hi). simpl in vp₀.
     destruct vp₀ as [f₀ [e₀ h₀]].
+    eapply from_valid_package in vp₁.
     specialize (vp₁ _ hi). simpl in vp₁.
     destruct vp₁ as [f₁ [e₁ h₁]].
     erewrite lookup_op_spec_inv. 2: eauto.

--- a/theories/Crypt/package/pkg_tactics.v
+++ b/theories/Crypt/package/pkg_tactics.v
@@ -257,6 +257,7 @@ Lemma valid_empty_package :
 Proof.
   intros L I.
   rewrite -fset0E.
+  apply prove_valid_package.
   intros [id [S T]] ho. eapply fromEmpty. eauto.
 Qed.
 
@@ -271,6 +272,7 @@ Lemma valid_package1 :
     valid_package L I (fset [:: (i, (A, B))]) (mkfmap [:: (i, mkdef A B f)]).
 Proof.
   intros L I i A B f hf.
+  apply prove_valid_package.
   intros o ho. rewrite in_fset in ho.
   rewrite mem_seq1 in ho. move: ho => /eqP ho. subst o.
   cbn. exists f.
@@ -292,6 +294,7 @@ Lemma flat_valid_package :
 Proof.
   intros L I E p hp.
   intros i [u1 u2] [v1 v2] h1 h2.
+  eapply from_valid_package in hp.
   specialize (hp _ h1) as h1'.
   specialize (hp _ h2) as h2'.
   simpl in *.
@@ -310,6 +313,7 @@ Lemma valid_package_cons :
       (mkfmap ((i, mkdef A B f) :: p)).
 Proof.
   intros L I i A B f E p hp hf hi.
+  apply prove_valid_package.
   intros o ho. rewrite in_fset in ho. rewrite in_cons in ho.
   move: ho => /orP [ho | ho].
   - move: ho => /eqP ho. subst o.
@@ -318,6 +322,7 @@ Proof.
     2:{ move: e => /eqP. contradiction. }
     intuition auto.
   - rewrite -in_fset in ho.
+    eapply from_valid_package in hp.
     specialize (hp _ ho).
     destruct o as [id [S T]].
     destruct hp as [g [eg hg]].


### PR DESCRIPTION
By removing conversions on `valid_package` I hope to speed up the unification (especially in the case of failures). The overhead in proofs (not on the user side) is not that big.