### PR TITLE
Remove `SProp` again, changing inference mechanism a bit for `Positive`

### DIFF
--- a/theories/Crypt/chUniverse.v
+++ b/theories/Crypt/chUniverse.v
@@ -90,7 +90,7 @@ Next Obligation.
 Defined.
 Next Obligation.
   exists 0. destruct n as [p h]. simpl.
-  eapply from_Positive in h. auto.
+  unfold Positive in h. auto.
 Defined.
 
 Section chUniverseTypes.
@@ -489,10 +489,9 @@ Section chUniverseTypes.
     - rewrite IHt. reflexivity.
     - destruct n as [n npos]. cbn.
       destruct n.
-      + eapply from_Positive in npos as h. discriminate.
+      + discriminate.
       + cbn.
-        rewrite -subnE subn0.
-        reflexivity.
+        rewrite -subnE subn0. repeat f_equal. apply eq_irrelevance.
   Defined.
 
   Definition chUniverse_choiceMixin := PcanChoiceMixin codeK.

--- a/theories/Crypt/examples/ElGamal.v
+++ b/theories/Crypt/examples/ElGamal.v
@@ -99,13 +99,11 @@ Module MyAlg <: AsymmetricSchemeAlgorithms MyParam.
 
   Instance positive_gT : Positive #|gT|.
   Proof.
-    constructor.
     apply /card_gt0P. exists g. auto.
   Qed.
 
   Instance positive_SecKey : Positive #|SecKey|.
   Proof.
-    constructor.
     apply /card_gt0P. exists sec0. auto.
   Qed.
 

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -217,7 +217,7 @@ Section KEMDEM.
 
   (** PKE-CCA *)
 
-  Opaque ValidPackage mkfmap mkdef.
+  Opaque mkfmap mkdef.
 
   Definition PKE_CCA_out :=
     [interface
@@ -261,9 +261,6 @@ Section KEMDEM.
         ret m
       }
     ].
-  Next Obligation.
-    exact _.
-  Qed.
   Next Obligation.
     ssprove_valid.
     (* TODO A hint to deal with this case *)

--- a/theories/Crypt/examples/OTP.v
+++ b/theories/Crypt/examples/OTP.v
@@ -44,11 +44,11 @@ Section OTP_example.
     apply Zp_cast.
     pose proof n_pos as n_pos.
     destruct n as [| k].
-    1:{ eapply from_Positive in n_pos. inversion n_pos. }
+    1:{ inversion n_pos. }
     rewrite expnS.
     move: (PositiveExp2 k).
-    eapply from_Positive in n_pos.
-    intro Hpos. eapply from_Positive in Hpos.
+    unfold Positive in n_pos.
+    intro Hpos. unfold Positive in Hpos.
     rewrite !mulSnr.
     change (0 * ?n ^ ?m)%N with 0%N.
     set (m := (2^ k)%N) in *. clearbody m.

--- a/theories/Crypt/package/package_usage_example.v
+++ b/theories/Crypt/package/package_usage_example.v
@@ -96,7 +96,7 @@ Definition test₁ :
 
 Definition sig := {sig #[0] : 'nat → 'nat }.
 
-Definition test₂ :
+#[program] Definition test₂ :
   package
     [fset ('nat; 0)]
     [interface val #[0] : 'nat → 'nat ]

--- a/theories/Crypt/package/pkg_rhl.v
+++ b/theories/Crypt/package/pkg_rhl.v
@@ -94,7 +94,7 @@ Proof.
   - exact (IHa1, IHa2).
   - exact emptym.
   - exact None.
-  - exact (fintype.Ordinal (from_Positive _ n.(cond_pos))).
+  - exact (fintype.Ordinal n.(cond_pos)).
 Defined.
 
 Definition heap := { h : raw_heap | valid_heap h }.
@@ -2434,7 +2434,7 @@ Lemma ordinal_finType_inhabited :
   ∀ i `{Positive i}, ordinal_finType i.
 Proof.
   intros i hi.
-  exists 0%N. eapply from_Positive. auto.
+  exists 0%N. auto.
 Qed.
 
 Section Uniform_prod.

--- a/theories/Crypt/package/pkg_tactics.v
+++ b/theories/Crypt/package/pkg_tactics.v
@@ -338,6 +338,20 @@ Proof.
     exists g. intuition auto.
 Qed.
 
+Lemma valid_package_cons_upto :
+  ∀ L I i A B A' B' f E p,
+    valid_package L I (fset E) (mkfmap p) →
+    (∀ x, valid_code L I (f x)) →
+    i \notin (λ '(i,_), i) @: fset E →
+    A = A' →
+    B = B' →
+    valid_package L I (fset ((i, (A', B')) :: E))
+      (mkfmap ((i, mkdef A B f) :: p)).
+Proof.
+  intros L I i A B A' B' f E p hp hf hi eA eB. subst.
+  eapply valid_package_cons. all: eauto.
+Qed.
+
 (* TODO MOVE *)
 Lemma notin_fset :
   ∀ (T : ordType) (s : seq T) (x : T),
@@ -372,6 +386,26 @@ Qed.
     eapply valid_package_from_class
   | intro ; eapply valid_code_from_class
   | rewrite imfset_fset ; rewrite notin_fset
+  ]
+  : typeclass_instances packages.
+
+Ltac chUniverse_eq_prove :=
+  lazymatch goal with
+  | |- chProd _ _ = chProd _ _ => f_equal ; chUniverse_eq_prove
+  | |- chMap _ _ = chMap _ _ => f_equal ; chUniverse_eq_prove
+  | |- chOption _ = chOption _ => f_equal ; chUniverse_eq_prove
+  | |- chFin _ = chFin _ => f_equal ; apply positive_ext ; reflexivity
+  | |- _ = _ => reflexivity
+  end.
+
+#[export] Hint Extern 4 (ValidPackage ?L ?I ?E (mkfmap ((?i, mkdef ?A ?B ?f) :: ?p)))
+  =>
+  eapply valid_package_cons_upto ; [
+    eapply valid_package_from_class
+  | intro ; eapply valid_code_from_class
+  | rewrite imfset_fset ; rewrite notin_fset
+  | chUniverse_eq_prove
+  | chUniverse_eq_prove
   ]
   : typeclass_instances packages.
 

--- a/theories/Crypt/rules/UniformStateProb.v
+++ b/theories/Crypt/rules/UniformStateProb.v
@@ -28,7 +28,7 @@ Lemma F_w0 :
   forall (i : Index), fin_family i.
 Proof.
   intros i. unfold fin_family. cbn.
-  exists 0%N. eapply from_Positive. eapply i.(cond_pos).
+  exists 0%N. eapply i.(cond_pos).
 Qed.
 
 (* extend the initial parameters for the rules  *)


### PR DESCRIPTION
Equality of `chUniverse` is now handled by `chUniverse_eq_prove` and validity of package now has a lemma up to equality of `chUniverse` that is called when the usual one did not succeed.
`SProp` is gone again from our codebase.