### PR TITLE
Remove mathcomp compatibility layer

### DIFF
--- a/theories/Crypt/examples/AsymScheme.v
+++ b/theories/Crypt/examples/AsymScheme.v
@@ -33,7 +33,6 @@ Set Primitive Projections.
 
 Import Num.Def.
 Import Num.Theory.
-Import mc_1_10.Num.Theory.
 
 Import PackageNotation.
 

--- a/theories/Crypt/examples/AsymSchemeAdmits.v
+++ b/theories/Crypt/examples/AsymSchemeAdmits.v
@@ -55,7 +55,6 @@ Set Primitive Projections.
 
 Import Num.Def.
 Import Num.Theory.
-Import mc_1_10.Num.Theory.
 
 Local Open Scope ring_scope.
 

--- a/theories/Crypt/examples/ElGamal.v
+++ b/theories/Crypt/examples/ElGamal.v
@@ -32,7 +32,7 @@ Set Default Goal Selector "!".
 Set Primitive Projections.
 
 Import Num.Theory.
-Import mc_1_10.Num.Theory.
+Import Order.POrderTheory.
 
 Local Open Scope ring_scope.
 Import GroupScope GRing.Theory.
@@ -432,7 +432,7 @@ Proof.
     Aux ∘ DH_real
   ] (ots_real_vs_rnd true) A
   as ineq.
-  eapply ler_trans. 1: exact ineq.
+  eapply le_trans. 1: exact ineq.
   clear ineq.
   rewrite ots_real_vs_rnd_equiv_true. 3: auto.
   2:{

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -34,6 +34,7 @@ Set Primitive Projections.
 
 Import Num.Def.
 Import Num.Theory.
+Import Order.POrderTheory.
 
 Import PackageNotation.
 
@@ -616,7 +617,7 @@ Section KEMDEM.
       par CK₁ CD₀ ∘ KEY
     ] (par CK₁ CD₁ ∘ KEY) A
     as ineq.
-    eapply Order.POrderTheory.le_trans. 1: exact ineq.
+    eapply le_trans. 1: exact ineq.
     clear ineq.
     eapply ler_add.
     (* Idealising the core keying package *)
@@ -645,7 +646,7 @@ Section KEMDEM.
       rewrite Advantage_link.
       unfold K₀, K₁.
       rewrite !link_assoc.
-      apply Order.POrderTheory.lexx.
+      apply lexx.
     (* Idealising the core keyed package *)
     - replace (par CK₁ CD₀) with ((par CK₁ (ID ED)) ∘ (par (ID IGEN) CD₀)).
       2:{
@@ -672,7 +673,7 @@ Section KEMDEM.
       rewrite Advantage_link.
       unfold D₀, D₁.
       rewrite !link_assoc.
-      apply Order.POrderTheory.lexx.
+      apply lexx.
     Unshelve. all: exact fset0.
   Qed.
 
@@ -708,7 +709,7 @@ Section KEMDEM.
       par CK₁ CD₁ ∘ KEY
     ] (par CK₀ CD₁ ∘ KEY) A
     as ineq.
-    eapply Order.POrderTheory.le_trans. 1: exact ineq.
+    eapply le_trans. 1: exact ineq.
     clear ineq.
     eapply ler_add.
     - eapply single_key_a. all: eauto.
@@ -739,7 +740,7 @@ Section KEMDEM.
       unfold K₀, K₁.
       rewrite !link_assoc.
       rewrite Advantage_sym.
-      apply Order.POrderTheory.lexx.
+      apply lexx.
     Unshelve. all: exact fset0.
   Qed.
 
@@ -1039,13 +1040,13 @@ Section KEMDEM.
       (MOD_CCA KEM_DEM) ∘ par (KEM true) (DEM true) ∘ KEY
     ] (PKE_CCA KEM_DEM true) A
     as ineq.
-    eapply Order.POrderTheory.le_trans. 1: exact ineq.
+    eapply le_trans. 1: exact ineq.
     clear ineq.
     rewrite PKE_CCA_perf. 2,3: auto.
     rewrite PKE_CCA_perf_true. 2,3: auto.
     rewrite GRing.addr0. rewrite GRing.add0r.
     (* Now we massage the expression to apply the single key lemma *)
-    eapply Order.POrderTheory.le_trans.
+    eapply le_trans.
     - rewrite Advantage_sym.
       rewrite -Advantage_link.
       eapply single_key_b with (CK₁ := (KEM false).(pack)).

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -34,7 +34,6 @@ Set Primitive Projections.
 
 Import Num.Def.
 Import Num.Theory.
-Import mc_1_10.Num.Theory.
 
 Import PackageNotation.
 
@@ -617,7 +616,7 @@ Section KEMDEM.
       par CK₁ CD₀ ∘ KEY
     ] (par CK₁ CD₁ ∘ KEY) A
     as ineq.
-    eapply ler_trans. 1: exact ineq.
+    eapply Order.POrderTheory.le_trans. 1: exact ineq.
     clear ineq.
     eapply ler_add.
     (* Idealising the core keying package *)
@@ -646,7 +645,7 @@ Section KEMDEM.
       rewrite Advantage_link.
       unfold K₀, K₁.
       rewrite !link_assoc.
-      apply lerr.
+      apply Order.POrderTheory.lexx.
     (* Idealising the core keyed package *)
     - replace (par CK₁ CD₀) with ((par CK₁ (ID ED)) ∘ (par (ID IGEN) CD₀)).
       2:{
@@ -673,7 +672,7 @@ Section KEMDEM.
       rewrite Advantage_link.
       unfold D₀, D₁.
       rewrite !link_assoc.
-      apply lerr.
+      apply Order.POrderTheory.lexx.
     Unshelve. all: exact fset0.
   Qed.
 
@@ -709,7 +708,7 @@ Section KEMDEM.
       par CK₁ CD₁ ∘ KEY
     ] (par CK₀ CD₁ ∘ KEY) A
     as ineq.
-    eapply ler_trans. 1: exact ineq.
+    eapply Order.POrderTheory.le_trans. 1: exact ineq.
     clear ineq.
     eapply ler_add.
     - eapply single_key_a. all: eauto.
@@ -740,7 +739,7 @@ Section KEMDEM.
       unfold K₀, K₁.
       rewrite !link_assoc.
       rewrite Advantage_sym.
-      apply lerr.
+      apply Order.POrderTheory.lexx.
     Unshelve. all: exact fset0.
   Qed.
 
@@ -1040,13 +1039,13 @@ Section KEMDEM.
       (MOD_CCA KEM_DEM) ∘ par (KEM true) (DEM true) ∘ KEY
     ] (PKE_CCA KEM_DEM true) A
     as ineq.
-    eapply ler_trans. 1: exact ineq.
+    eapply Order.POrderTheory.le_trans. 1: exact ineq.
     clear ineq.
     rewrite PKE_CCA_perf. 2,3: auto.
     rewrite PKE_CCA_perf_true. 2,3: auto.
     rewrite GRing.addr0. rewrite GRing.add0r.
     (* Now we massage the expression to apply the single key lemma *)
-    eapply ler_trans.
+    eapply Order.POrderTheory.le_trans.
     - rewrite Advantage_sym.
       rewrite -Advantage_link.
       eapply single_key_b with (CK₁ := (KEM false).(pack)).

--- a/theories/Crypt/examples/OTP.v
+++ b/theories/Crypt/examples/OTP.v
@@ -28,7 +28,6 @@ Set Primitive Projections.
 
 Import Num.Def.
 Import Num.Theory.
-Import mc_1_10.Num.Theory.
 
 Import PackageNotation.
 

--- a/theories/Crypt/examples/PRF.v
+++ b/theories/Crypt/examples/PRF.v
@@ -40,7 +40,7 @@ Set Primitive Projections.
 
 Import Num.Def.
 Import Num.Theory.
-Import mc_1_10.Num.Theory.
+Import Order.POrderTheory.
 
 Section PRF_example.
 
@@ -410,7 +410,7 @@ Section PRF_example.
       MOD_CPA_tt_pkg ∘ EVAL true
     ] (IND_CPA true) A
     as ineq.
-    eapply ler_trans. 1: exact ineq.
+    eapply le_trans. 1: exact ineq.
     clear ineq.
     erewrite IND_CPA_equiv_false. all: eauto.
     2:{ simpl. unfold MOD_CPA_location. rewrite fset0U. auto. }

--- a/theories/Crypt/examples/RandomOracle.v
+++ b/theories/Crypt/examples/RandomOracle.v
@@ -19,7 +19,6 @@ Set Primitive Projections.
 
 Import Num.Def.
 Import Num.Theory.
-Import mc_1_10.Num.Theory.
 
 Import PackageNotation.
 

--- a/theories/Crypt/examples/SigmaProtocol.v
+++ b/theories/Crypt/examples/SigmaProtocol.v
@@ -25,7 +25,7 @@ Set Primitive Projections.
 
 Import Num.Def.
 Import Num.Theory.
-Import mc_1_10.Num.Theory.
+Import Order.POrderTheory.
 
 Import PackageNotation.
 
@@ -346,11 +346,11 @@ Module SigmaProtocol (π : SigmaProtocolParams)
         (Hiding_ideal ∘ Sigma_to_Com ∘ SHVZK_real)
       ] (Hiding_ideal ∘ Sigma_to_Com ∘ SHVZK_ideal) A
       as ineq.
-      eapply ler_trans. 1: exact ineq.
+      eapply le_trans. 1: exact ineq.
       clear ineq.
       rewrite <- !Advantage_link.
       eapply ler_add.
-      - rewrite GRing.addrC. eapply ler_add. 1: apply lerr.
+      - rewrite GRing.addrC. eapply ler_add. 1: apply lexx.
         specialize (Hadv (A ∘ Hiding_real ∘ Sigma_to_Com)).
         rewrite <- link_assoc. rewrite Advantage_sym.
         apply Hadv. ssprove_valid.
@@ -399,7 +399,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
       ssprove triangle (Com_Binding ∘ Adv) [::
         (Special_Soundness_t ∘ Adv)
       ] (Special_Soundness_f ∘ Adv) A as ineq.
-      eapply ler_trans. 1: exact ineq.
+      eapply le_trans. 1: exact ineq.
       clear ineq.
       rewrite ger_addr.
       apply eq_ler.

--- a/theories/Crypt/examples/SymmetricSchemeStateProb.v
+++ b/theories/Crypt/examples/SymmetricSchemeStateProb.v
@@ -64,7 +64,6 @@ Set Primitive Projections.
 
 Import Num.Def.
 Import Num.Theory.
-Import mc_1_10.Num.Theory.
 
 (* Local Open Scope ring_scope. *)
 

--- a/theories/Crypt/examples/SymmetricSchemeStateProbStdDistr.v
+++ b/theories/Crypt/examples/SymmetricSchemeStateProbStdDistr.v
@@ -57,7 +57,6 @@ Set Primitive Projections.
 
 Import Num.Def.
 Import Num.Theory.
-Import mc_1_10.Num.Theory.
 
 (* Local Open Scope ring_scope. *)
 

--- a/theories/Crypt/examples/deprecated/AsymmetricSchemeStateProb.v
+++ b/theories/Crypt/examples/deprecated/AsymmetricSchemeStateProb.v
@@ -55,7 +55,6 @@ Set Primitive Projections.
 
 Import Num.Def.
 Import Num.Theory.
-Import mc_1_10.Num.Theory.
 
 Local Open Scope ring_scope.
 

--- a/theories/Crypt/examples/deprecated/otp.v
+++ b/theories/Crypt/examples/deprecated/otp.v
@@ -19,7 +19,6 @@ From Crypt Require Import
      UniformDistr.
 
 Import Num.Theory.
-Import mc_1_10.Num.Theory.
 
 Local Open Scope ring_scope.
 

--- a/theories/Crypt/package/package_instance.v
+++ b/theories/Crypt/package/package_instance.v
@@ -35,7 +35,6 @@ Set Primitive Projections.
 Set Keyed Unification.
 
 Import Num.Theory.
-Import mc_1_10.Num.Theory.
 
 #[local] Open Scope ring_scope.
 Import GroupScope GRing.Theory.

--- a/theories/Crypt/package/pkg_advantage.v
+++ b/theories/Crypt/package/pkg_advantage.v
@@ -316,7 +316,7 @@ Proof.
   intros P l Q A.
   induction l as [| R l ih] in P, Q |- *.
   - simpl. auto.
-  - simpl. eapply mc_1_10.Num.Theory.ler_trans.
+  - simpl. eapply order.Order.POrderTheory.le_trans.
     + eapply Advantage_triangle.
     + eapply ler_add.
       * auto.
@@ -330,8 +330,8 @@ Lemma AdvantageE_le_0 :
 Proof.
   intros G₀ G₁ A h.
   unfold AdvantageE in *.
-  rewrite mc_1_10.Num.Theory.normr_le0 in h.
-  apply/mc_1_10.Num.Theory.normr0P. auto.
+  rewrite normr_le0 in h.
+  apply/normr0P. auto.
 Qed.
 
 Lemma Advantage_le_0 :

--- a/theories/Crypt/package/pkg_distr.v
+++ b/theories/Crypt/package/pkg_distr.v
@@ -228,7 +228,7 @@ Proof.
   simpl. rewrite GRing.mul1r.
   rewrite psum_fin. rewrite cardE. rewrite size_enum_ord. simpl.
   rewrite GRing.sumr_const. rewrite cardE. rewrite size_enum_ord.
-  rewrite -mc_1_10.Num.Theory.normrMn.
+  rewrite -normrMn.
   rewrite -GRing.Theory.mulr_natr.
   rewrite GRing.mulVf.
   2:{

--- a/theories/Crypt/package/pkg_rhl.v
+++ b/theories/Crypt/package/pkg_rhl.v
@@ -98,7 +98,7 @@ Proof.
     { destruct ((get_heap s₁ ℓ, s₁, (get_heap s₂ ℓ, s₂)) == (b₁, s₃, (b₂, s₄))) eqn:e.
       - move: e => /eqP e. assumption.
       - rewrite e in hd. cbn in hd.
-        rewrite mc_1_10.Num.Theory.ltrr in hd. discriminate.
+        rewrite order.Order.POrderTheory.ltxx in hd. discriminate.
     }
     inversion e. subst. intuition auto.
 Qed.
@@ -130,7 +130,7 @@ Proof.
     { destruct ((tt, set_heap s1 l v, (tt, set_heap s2 l v)) == (b1, s3, (b2, s4))) eqn:Heqd.
       - move: Heqd. move /eqP => Heqd. assumption.
       - rewrite Heqd in Hd. simpl in Hd.
-        rewrite mc_1_10.Num.Theory.ltrr in Hd. discriminate.
+        rewrite order.Order.POrderTheory.ltxx in Hd. discriminate.
     }
     inversion Heqs.
     intuition eauto.
@@ -178,21 +178,21 @@ Proof.
   assert (realsum.psum f ≠ 0) as Hneq.
   { intros Hgt.
     rewrite Hgt in H.
-    rewrite mc_1_10.Num.Theory.ltrr in H.
+    rewrite order.Order.POrderTheory.ltxx in H.
     auto. }
   destruct (realsum.neq0_psum (R:=R) Hneq) as [x Hx].
   exists x. specialize (Hpos x).
-  rewrite mc_1_10.Num.Theory.ler_eqVlt in Hpos.
+  rewrite order.Order.POrderTheory.le_eqVlt in Hpos.
   move: Hpos. move /orP => [H1 | H2].
   - move: H1. move /eqP => H1. rewrite -H1.
-    rewrite mc_1_10.Num.Theory.ltrr. auto.
+    rewrite order.Order.POrderTheory.ltxx. auto.
   - assumption.
 Qed.
 
 Lemma pmulr_me (x y : R) : 0 <= y -> (0 < y * x) -> (0 < x).
 Proof.
   rewrite le0r => /orP[/eqP->|].
-  - by rewrite GRing.mul0r mc_1_10.Num.Theory.ltrr.
+  - by rewrite GRing.mul0r order.Order.POrderTheory.ltxx.
   - intros. by rewrite -(pmulr_rgt0 x b).
 Qed.
 
@@ -201,7 +201,7 @@ Lemma ge0_eq {R : realType} {A : eqType} {x y : A} (H : 0 < ((x == y)%:R) :> R) 
 Proof.
   destruct (x == y) eqn:Heq.
   - move: Heq. by move /eqP.
-  - by rewrite mc_1_10.Num.Theory.ltrr in H.
+  - by rewrite order.Order.POrderTheory.ltxx in H.
 Qed.
 
 Lemma ne0_eq {R : ringType} {A : eqType} {x y : A} (H : ((x == y)%:R) ≠ (0 : R)) :
@@ -515,7 +515,7 @@ Proof.
   { intros x.
     assert (x - x = 0) as H3.
     { apply /eqP. rewrite GRing.subr_eq0. intuition. }
-    rewrite H3. apply mc_1_10.Num.Theory.normr0.
+    rewrite H3. apply normr0.
   }
   apply Hzero.
 Qed.
@@ -2260,7 +2260,7 @@ Proof.
       unfold SDistr_bind. rewrite dlet_null.
       reflexivity.
   - intros [? ?] [? ?]. rewrite dnullE.
-    rewrite mc_1_10.Num.Theory.ltrr. discriminate.
+    rewrite order.Order.POrderTheory.ltxx. discriminate.
 Qed.
 
 Lemma r_assert' :
@@ -2326,7 +2326,7 @@ Proof.
       unfold SDistr_bind. rewrite dlet_null.
       reflexivity.
   - intros [? ?] [? ?]. rewrite dnullE.
-    rewrite mc_1_10.Num.Theory.ltrr. discriminate.
+    rewrite order.Order.POrderTheory.ltxx. discriminate.
 Qed.
 
 Theorem r_assertD :
@@ -2381,7 +2381,7 @@ Proof.
         unfold SDistr_bind. rewrite dlet_null.
         reflexivity.
     + intros [? ?] [? ?]. rewrite dnullE.
-      rewrite mc_1_10.Num.Theory.ltrr. discriminate.
+      rewrite order.Order.POrderTheory.ltxx. discriminate.
 Qed.
 
 Lemma rswap_assertD_cmd_eq :
@@ -2453,7 +2453,7 @@ Proof.
         unfold SDistr_bind. rewrite dlet_null.
         reflexivity.
     + intros [? ?] [? ?]. rewrite dnullE.
-      rewrite mc_1_10.Num.Theory.ltrr. discriminate.
+      rewrite order.Order.POrderTheory.ltxx. discriminate.
 Qed.
 
 Lemma r_bind_assertD_sym :
@@ -2503,7 +2503,7 @@ Proof.
     end.
     2:{
       rewrite e in hh. simpl in hh.
-      rewrite mc_1_10.Num.Theory.ltrr in hh. discriminate.
+      rewrite order.Order.POrderTheory.ltxx in hh. discriminate.
     }
     move: e => /eqP e. inversion e.
     subst. reflexivity.
@@ -2576,7 +2576,7 @@ Proof.
     end.
     2:{
       rewrite e in hh. simpl in hh.
-      rewrite mc_1_10.Num.Theory.ltrr in hh. discriminate.
+      rewrite order.Order.POrderTheory.ltxx in hh. discriminate.
     }
     move: e => /eqP e. inversion e.
     subst.
@@ -2620,7 +2620,7 @@ Proof.
     end.
     2:{
       rewrite e in hh. simpl in hh.
-      rewrite mc_1_10.Num.Theory.ltrr in hh. discriminate.
+      rewrite order.Order.POrderTheory.ltxx in hh. discriminate.
     }
     move: e => /eqP e. noconf e.
     subst. f_equal.

--- a/theories/Crypt/package/pkg_user_util.v
+++ b/theories/Crypt/package/pkg_user_util.v
@@ -86,7 +86,7 @@ Require Equations.Prop.DepElim.
 
 Import Num.Def.
 Import Num.Theory.
-Import mc_1_10.Num.Theory.
+Import Order.POrderTheory.
 
 Set Equations With UIP.
 
@@ -838,7 +838,7 @@ Lemma eq_ler :
     x = y →
     x <= y.
 Proof.
-  intros x y e. subst. apply lerr.
+  intros x y e. subst. apply lexx.
 Qed.
 
 Ltac fdisjoint_auto :=

--- a/theories/Crypt/rhl_semantics/only_prob/SubDistr.v
+++ b/theories/Crypt/rhl_semantics/only_prob/SubDistr.v
@@ -6,7 +6,8 @@ From Relational Require Import OrderEnrichedCategory OrderEnrichedRelativeMonadE
 From Crypt Require Import ChoiceAsOrd Axioms.
 
 Import Num.Theory.
-Import mc_1_10.Num.Theory.
+Import Order.POrderTheory.
+
 Obligation Tactic := try (Tactics.program_simpl ; fail) ; simpl.
 
 (*
@@ -57,10 +58,10 @@ Section Carrier.
   Proof.
     constructor.
       vm_compute. intros de a. rewrite unlock_absord.
-      apply lerr.
+      apply lexx.
     vm_compute. intros de1 de2 de3 H12 H23 a.
     (* apply its_true_anyway. *) rewrite unlock_absord.
-    unshelve eapply ler_trans.
+    unshelve eapply le_trans.
       exact (de2 a).
     - pose (fromH12 := (H12 a)). (* apply since_its_true  in fromH12. *)
       erewrite unlock_absord in fromH12. assumption.

--- a/theories/Crypt/rhl_semantics/only_prob/Theta_dens.v
+++ b/theories/Crypt/rhl_semantics/only_prob/Theta_dens.v
@@ -8,7 +8,6 @@ From Crypt Require Import ChoiceAsOrd Axioms RelativeMonadMorph_prod FreeProbPro
 
 Import SPropNotations.
 Import Num.Theory.
-Import mc_1_10.Num.Theory.
 
 Local Open Scope ring_scope.
 

--- a/theories/Crypt/rhl_semantics/only_prob/Theta_exCP.v
+++ b/theories/Crypt/rhl_semantics/only_prob/Theta_exCP.v
@@ -7,7 +7,8 @@ From Crypt Require Import ChoiceAsOrd SubDistr Couplings Axioms.
 
 Import SPropNotations.
 Import Num.Theory.
-Import mc_1_10.Num.Theory.
+Import Order.POrderTheory.
+
 Local Open Scope ring_scope.
 
 
@@ -178,7 +179,7 @@ Proof.
   intuition. rewrite /SDistr_unit in H. rewrite dunit1E in H.
   case Hxy: (x==y).
     move: Hxy => /eqP Hxy //=.
-  rewrite Hxy /= in H. rewrite (ltrr 0) in H. discriminate.
+  rewrite Hxy /= in H. rewrite (ltxx 0) in H. discriminate.
 Qed.
 
 Import OrderEnrichedRelativeMonadExamplesNotation.

--- a/theories/Crypt/rhl_semantics/permissive/Permissive_prob.v
+++ b/theories/Crypt/rhl_semantics/permissive/Permissive_prob.v
@@ -31,7 +31,7 @@ Section Monotonic_spec.
     unfold SPropMonadicStructures.SProp_order in w.
   Abort.
 
-  Lemma monotonic_spec : forall (post post' : A0 * A1 -> Prop), 
+  Lemma monotonic_spec : forall (post post' : A0 * A1 -> Prop),
   (forall a01 : A0 * A1, post' a01 -> post a01) ->
   w∙1 post' -> w∙1 post.
   Proof.
@@ -39,9 +39,9 @@ Section Monotonic_spec.
     destruct w as [wmap wprop]. cbn.
     move: wprop.
     rewrite /Morphisms.Proper /Morphisms.respectful.
-    rewrite /Morphisms.pointwise_relation. 
+    rewrite /Morphisms.pointwise_relation.
     rewrite /SPropMonadicStructures.SProp_op_order /Basics.flip.
-    rewrite /SPropMonadicStructures.SProp_order.    
+    rewrite /SPropMonadicStructures.SProp_order.
     move=> wprop.
     apply wprop. assumption.
   Qed.
@@ -128,8 +128,8 @@ Section Permissive_theta.
   Proof.
     move: b => [bt | bf].
       by easy.
-    cbn in bf. 
-    rewrite mc_1_10.Num.Theory.ltrr in bf. assumption.
+    cbn in bf.
+    rewrite Order.POrderTheory.ltxx in bf. assumption.
   Qed.
 
   Program Definition θ_perm_carrier :
@@ -165,7 +165,7 @@ Section Permissive_theta.
     move=> [c0 c1] [c0' c1']. move=> [H0 H1]. move=> post.
     rewrite H0 H1. move=> H ; assumption.
   Qed.
-    
+
 
 
   Program Definition θ_perm: relativeLaxMonadMorphism Jprod cleanϕ SDistr_squ WRelProp :=
@@ -201,4 +201,4 @@ Section Permissive_theta.
     rename HnonzerC01 into Hecoupl.
     move: Hecoupl => [dc [dc_coupl dc_rest]].
   Abort.
-    
+

--- a/theories/Crypt/rules/RulesProb.v
+++ b/theories/Crypt/rules/RulesProb.v
@@ -35,7 +35,7 @@ From Crypt Require Import
 
 Import SPropNotations.
 Import Num.Theory.
-Import mc_1_10.Num.Theory.
+Import Order.POrderTheory.
 
 Local Open Scope ring_scope.
 
@@ -642,7 +642,7 @@ Proof.
     intuition. rewrite H0. reflexivity. auto.
     reflexivity.
     assert (d (x, y) = 0).
-    rewrite ltr_def in Hd.
+    rewrite lt_def in Hd.
     apply Bool.andb_false_iff in Hd.
     destruct Hd.
     ++ move: H. move/eqP. auto.
@@ -743,7 +743,7 @@ Proof.
        --- by inversion d.
     -- have Hd0 : 0 <= d(x1,x2) by inversion d.
        have [Hdor1 | Hdor2]: 0 == d(x1,x2) \/ 0 < d(x1,x2).
-       { rewrite ler_eqVlt in Hd0.
+       { rewrite le_eqVlt in Hd0.
            by move/orP: Hd0. }
        --- move/eqP : Hdor1 => Hdor1.
            by rewrite -Hdor1 !GRing.mulr0.

--- a/theories/Crypt/rules/RulesStateProb.v
+++ b/theories/Crypt/rules/RulesStateProb.v
@@ -650,7 +650,7 @@ Proof.
     intuition. rewrite H0. reflexivity. auto.
     reflexivity.
     assert (d (x, y) = 0).
-    rewrite mc_1_10.Num.Theory.ltr_def in Hd.
+    rewrite Order.POrderTheory.lt_def in Hd.
     apply Bool.andb_false_iff in Hd.
     destruct Hd.
     ++ move: H. move/eqP. auto.
@@ -778,7 +778,7 @@ Proof.
   move=> a1 a2. unfold coupling_self_SDistr. rewrite dmargin_psumE.
   move=> Hpsum.
   have Hpsum' : psum (fun x : A => ((x, x) == (a1, a2))%:R * d x) <> 0.
-    move=> abs. rewrite -abs in Hpsum. rewrite mc_1_10.Num.Theory.ltrr in Hpsum.
+    move=> abs. rewrite -abs in Hpsum. rewrite Order.POrderTheory.ltxx in Hpsum.
     discriminate.
   clear Hpsum.
   eapply neq0_psum in Hpsum'. destruct Hpsum'.
@@ -1589,7 +1589,7 @@ Proof.
   (f:=fun x0 => psum (fun y0 : Y => q y0 * dunit (T:=prod_choiceType X Y) (x0, y0) (x, y))) p).
   move=> x0. apply /andP. split.
   apply ge0_psum.
-  unshelve eapply mc_1_10.Num.Theory.ler_trans.
+  unshelve eapply Order.POrderTheory.le_trans.
     exact (psum q).
   eapply le_psum.
   move=> y0. apply/andP. split.

--- a/theories/Crypt/rules/UniformDistrLemmas.v
+++ b/theories/Crypt/rules/UniformDistrLemmas.v
@@ -35,7 +35,7 @@ From Crypt Require Import
 
 Import SPropNotations.
 Import Num.Theory.
-Import mc_1_10.Num.Theory.
+Import Order.POrderTheory.
 
 (* Notation "⟦ b ⟧" := (is_true_sprop b). *)
 (* Infix "-s>" := (s_impl) (right associativity, at level 86, only parsing). *)
@@ -117,7 +117,7 @@ Proof.
   split.
   - move => w; apply: r_nonneg.
   - move => J uniq_J. apply /idP.
-    apply: ler_trans.
+    apply: le_trans.
     -- by apply: (cardinality_bound J uniq_J r r_nonneg).
     -- rewrite /r -GRing.invf_div GRing.divr1 GRing.divff.
          by [].
@@ -245,7 +245,7 @@ Proof.
     -- exact r_nonneg.
     -- trivial.
   - move => J uniq_J.
-    apply: ler_trans.
+    apply: le_trans.
     apply: (gen_cardinality_bound J uniq_J _).
     -- move => [t1 t2] /=.
        destruct (f t1 == t2) eqn:Heq; auto. exact r_nonneg.
@@ -296,7 +296,7 @@ Lemma sampleFsq_support { F : finType} { w0 : F }
 Proof.
   simpl in H. rewrite /f_dprod /= in H.
   case (f a1 == a2) eqn:Heq; auto.
-    by rewrite ltrr in H.
+    by rewrite ltxx in H.
 Qed.
 
 Lemma support_sub_diag_mgs { A : choiceType }
@@ -312,7 +312,7 @@ Proof.
     + reflexivity.
     + move => y Hdd. specialize (Hsupp a y).
       assert (0 < d (a, y)) as Hd.
-      { rewrite ltr_def. apply /andP.
+      { rewrite lt_def. apply /andP.
         split.
         - assumption.
         - apply (ge0_mu d). }
@@ -323,7 +323,7 @@ Proof.
     + reflexivity.
     + move => y Hdd. specialize (Hsupp y a).
       assert (0 < d (y, a)) as Hd.
-      { rewrite ltr_def. apply /andP.
+      { rewrite lt_def. apply /andP.
         split.
         - assumption.
         - apply (ge0_mu d).  }

--- a/theories/Crypt/rules/UniformStateProb.v
+++ b/theories/Crypt/rules/UniformStateProb.v
@@ -108,7 +108,7 @@ Proof.
   2:{
     destruct (s == st). all: cbn.
     - apply (@ler01 R).
-    - apply mc_1_10.Num.Theory.lerr.
+    - apply Order.POrderTheory.lexx.
   }
   rewrite -dletE.
   rewrite dlet_dunit_id.
@@ -216,7 +216,7 @@ Proof.
     subst I. rewrite size_map in e3.
     rewrite -cardE in e3.
     rewrite item_addr0_mulr.
-    eapply mc_1_10.Num.Theory.ler_trans with (y := @r _ w0 *~ #|F1|).
+    eapply Order.POrderTheory.le_trans with (y := @r _ w0 *~ #|F1|).
     + rewrite -mulrzr. rewrite -[X in _<=X]mulrzr.
       rewrite ler_pmul2l.
       * rewrite ler_int. auto.
@@ -337,13 +337,13 @@ Proof.
     rewrite /UniformFsq_f /= in H.
     have hfoo1 : (st1 == s1).
     { destruct (st1 == s1) eqn:Heq; auto.
-      by rewrite Bool.andb_false_l  mc_1_10.Num.Theory.ltrr in H. }
+      by rewrite Bool.andb_false_l  Order.POrderTheory.ltxx in H. }
     have hfoo2 : (st2 == s2).
     { destruct (st2 == s2) eqn:Heq; auto.
-      by rewrite Bool.andb_false_r mc_1_10.Num.Theory.ltrr in H. }
+      by rewrite Bool.andb_false_r Order.POrderTheory.ltxx in H. }
     have hfoo3 : (f w1 == w2).
     { destruct (f w1 == w2) eqn:Heq; auto.
-      by rewrite Bool.andb_false_r  mc_1_10.Num.Theory.ltrr in H. }
+      by rewrite Bool.andb_false_r  Order.POrderTheory.ltxx in H. }
     move /eqP : hfoo1. move /eqP : hfoo2. move /eqP : hfoo3.
     move => hfoo3 hfoo2 hfoo1. subst.
     split; [assumption |  by rewrite refl_true ].
@@ -450,7 +450,7 @@ Proof.
         reflexivity.
     + intros [a1 s1'] [a2 s2'].
       rewrite dnullE.
-      rewrite mc_1_10.Num.Theory.ltrr.
+      rewrite Order.POrderTheory.ltxx.
       auto.
 Qed.
 

--- a/theories/Mon/sprop/FiniteProbabilities.v
+++ b/theories/Mon/sprop/FiniteProbabilities.v
@@ -10,7 +10,7 @@ Set Warnings "notation-overridden,ambiguous-paths".
 From Relational Require Import Commutativity.
 
 Import GRing.Theory Num.Theory.
-Import mc_1_10.Num.Theory.
+Import Order.POrderTheory.
 
 Local Open Scope ring_scope.
 
@@ -28,9 +28,9 @@ Section FinProb.
   Global Instance Irel_preorder : PreOrder Irel.
   Proof.
     constructor.
-    move=> ?; rewrite /Irel lerr //.
+    move=> ?; rewrite /Irel lexx //.
     move=> x y z ; rewrite /Irel.
-    apply ler_trans.
+    apply le_trans.
   Qed.
 
   Definition WI := @MonoCont I Irel _.


### PR DESCRIPTION
The goal is to remove step by the step the reliance on the compatibility module of mathcomp before we can update to newer versions of Coq and mathcomp.