### PR TITLE
Put # in front of val, def and put to avoid turning them into keywords

### DIFF
--- a/theories/Crypt/examples/AsymScheme.v
+++ b/theories/Crypt/examples/AsymScheme.v
@@ -139,22 +139,22 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
       L_locs
       [interface]
       [interface
-        val #[getpk_id] : 'unit → 'pubkey ;
-        val #[challenge_id] : 'plain × 'plain → 'cipher
+        #val #[getpk_id] : 'unit → 'pubkey ;
+        #val #[challenge_id] : 'plain × 'plain → 'cipher
       ]
     :=
     [package
-      def  #[getpk_id] (_ : 'unit) : 'pubkey
+      #def  #[getpk_id] (_ : 'unit) : 'pubkey
       {
         pk ← get pk_loc ;;
         ret pk
       } ;
 
-      def #[challenge_id] ( mL_mR : 'plain × 'plain ) : 'cipher
+      #def #[challenge_id] ( mL_mR : 'plain × 'plain ) : 'cipher
       {
         '(pk, sk) ← KeyGen ;;
-        put pk_loc := pk ;;
-        put sk_loc := sk ;;
+        #put pk_loc := pk ;;
+        #put sk_loc := sk ;;
         c ← Enc pk (fst mL_mR) ;;
         ret c
       }
@@ -165,22 +165,22 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
       L_locs
       [interface]
       [interface
-        val #[getpk_id] : 'unit → 'pubkey ;
-        val #[challenge_id] : 'plain × 'plain → 'cipher
+        #val #[getpk_id] : 'unit → 'pubkey ;
+        #val #[challenge_id] : 'plain × 'plain → 'cipher
       ]
     :=
     [package
-      def  #[getpk_id] (_ : 'unit) : 'pubkey
+      #def  #[getpk_id] (_ : 'unit) : 'pubkey
       {
         pk ← get pk_loc ;;
         ret pk
       } ;
 
-      def #[challenge_id] ( mL_mR : 'plain × 'plain ) : 'cipher
+      #def #[challenge_id] ( mL_mR : 'plain × 'plain ) : 'cipher
       {
         '(pk, sk) ← KeyGen ;;
-        put pk_loc := pk ;;
-        put sk_loc := sk ;;
+        #put pk_loc := pk ;;
+        #put sk_loc := sk ;;
         c ← Enc pk (snd mL_mR) ;;
         ret c
       }
@@ -188,8 +188,8 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
 
   Definition cpa_L_vs_R :
     loc_GamePair [interface
-      val #[getpk_id] : 'unit → 'pubkey ;
-      val #[challenge_id] : 'plain × 'plain → 'cipher
+      #val #[getpk_id] : 'unit → 'pubkey ;
+      #val #[challenge_id] : 'plain × 'plain → 'cipher
     ] :=
     λ b, if b then {locpackage L_pk_cpa_L} else {locpackage L_pk_cpa_R}.
 
@@ -202,8 +202,8 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
   Definition CPA_security : Prop :=
     ∀ LA A,
       ValidPackage LA [interface
-        val #[getpk_id] : 'unit → 'pubkey ;
-        val #[challenge_id] : 'plain × 'plain → 'cipher
+        #val #[getpk_id] : 'unit → 'pubkey ;
+        #val #[challenge_id] : 'plain × 'plain → 'cipher
       ] A_export A →
       fdisjoint LA (cpa_L_vs_R true).(locs) →
       fdisjoint LA (cpa_L_vs_R false).(locs) →
@@ -216,22 +216,22 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
     package L_locs
       [interface]
       [interface
-        val #[getpk_id] : 'unit → 'pubkey ;
-        val #[challenge_id] : 'plain → 'cipher
+        #val #[getpk_id] : 'unit → 'pubkey ;
+        #val #[challenge_id] : 'plain → 'cipher
       ]
     :=
     [package
-      def  #[getpk_id] (_ : 'unit) : 'pubkey
+      #def  #[getpk_id] (_ : 'unit) : 'pubkey
       {
         pk ← get pk_loc ;;
         ret pk
       } ;
 
-      def #[challenge_id] (m : 'plain) : 'cipher
+      #def #[challenge_id] (m : 'plain) : 'cipher
       {
         '(pk, sk) ← KeyGen ;;
-        put pk_loc := pk ;;
-        put sk_loc := sk ;;
+        #put pk_loc := pk ;;
+        #put sk_loc := sk ;;
         c ← Enc pk m ;;
         ret c
       }
@@ -241,31 +241,31 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
     package L_locs
       [interface]
       [interface
-        val #[getpk_id] : 'unit → 'pubkey ;
-        val #[challenge_id] : 'plain → 'cipher
+        #val #[getpk_id] : 'unit → 'pubkey ;
+        #val #[challenge_id] : 'plain → 'cipher
       ]
     :=
     [package
-      def  #[getpk_id] (_ : 'unit) : 'pubkey
+      #def  #[getpk_id] (_ : 'unit) : 'pubkey
       {
         pk ← get pk_loc ;;
         ret pk
       } ;
 
-      def #[challenge_id] (m : 'plain) : 'cipher
+      #def #[challenge_id] (m : 'plain) : 'cipher
       {
         '(pk, sk) ← KeyGen ;;
-         put pk_loc := pk ;;
-         put sk_loc := sk ;;
-         c ← sample uniform i_cipher ;;
-         ret c
+        #put pk_loc := pk ;;
+        #put sk_loc := sk ;;
+        c ← sample uniform i_cipher ;;
+        ret c
       }
     ].
 
   Definition cpa_real_vs_rand :
     loc_GamePair [interface
-      val #[getpk_id] : 'unit → 'pubkey ;
-      val #[challenge_id] : 'plain → 'cipher
+      #val #[getpk_id] : 'unit → 'pubkey ;
+      #val #[challenge_id] : 'plain → 'cipher
     ] :=
     λ b, if b then {locpackage L_pk_cpa_real } else {locpackage L_pk_cpa_rand }.
 
@@ -278,8 +278,8 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
   Definition CPA_rnd_cipher : Prop :=
     ∀ LA A,
       ValidPackage LA [interface
-        val #[getpk_id] : 'unit → 'pubkey ;
-        val #[challenge_id] : 'plain → 'cipher
+        #val #[getpk_id] : 'unit → 'pubkey ;
+        #val #[challenge_id] : 'plain → 'cipher
       ] A_export A →
       fdisjoint LA (cpa_real_vs_rand true).(locs) →
       fdisjoint LA (cpa_real_vs_rand false).(locs) →
@@ -294,24 +294,24 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
     package L_locs_counter
       [interface]
       [interface
-        val #[getpk_id] : 'unit → 'pubkey ;
-        val #[challenge_id] : 'plain × 'plain → 'cipher
+        #val #[getpk_id] : 'unit → 'pubkey ;
+        #val #[challenge_id] : 'plain × 'plain → 'cipher
       ]
     :=
     [package
-      def #[getpk_id] (_ : 'unit) : 'pubkey
+      #def #[getpk_id] (_ : 'unit) : 'pubkey
       {
         pk ← get pk_loc ;;
         ret pk
       } ;
-      def #[challenge_id] (mL_mR : 'plain × 'plain) : 'cipher
+      #def #[challenge_id] (mL_mR : 'plain × 'plain) : 'cipher
       {
         count ← get counter_loc ;;
-        put counter_loc := (count + 1)%N;;
+        #put counter_loc := (count + 1)%N;;
         #assert (count == 0)%N ;;
         '(pk, sk) ← KeyGen ;;
-        put pk_loc := pk ;;
-        put sk_loc := sk ;;
+        #put pk_loc := pk ;;
+        #put sk_loc := sk ;;
         c ← Enc pk (fst mL_mR) ;;
         ret c
       }
@@ -321,24 +321,24 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
     package L_locs_counter
       [interface]
       [interface
-        val #[getpk_id] : 'unit → 'pubkey ;
-        val #[challenge_id] : 'plain × 'plain → 'cipher
+        #val #[getpk_id] : 'unit → 'pubkey ;
+        #val #[challenge_id] : 'plain × 'plain → 'cipher
       ]
     :=
     [package
-      def  #[getpk_id] (_ : 'unit) : 'pubkey
+      #def #[getpk_id] (_ : 'unit) : 'pubkey
       {
         pk ← get pk_loc ;;
         ret pk
       } ;
-      def #[challenge_id] (mL_mR :  'plain × 'plain) : 'cipher
+      #def #[challenge_id] (mL_mR :  'plain × 'plain) : 'cipher
       {
         count ← get counter_loc ;;
-        put counter_loc := (count + 1)%N;;
+        #put counter_loc := (count + 1)%N;;
         #assert (count == 0)%N ;;
         '(pk, sk) ← KeyGen ;;
-        put pk_loc := pk ;;
-        put sk_loc := sk ;;
+        #put pk_loc := pk ;;
+        #put sk_loc := sk ;;
         c ← Enc pk (snd mL_mR) ;;
         ret c
       }
@@ -346,8 +346,8 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
 
   Definition ots_L_vs_R :
     loc_GamePair [interface
-      val #[getpk_id] : 'unit → 'pubkey ;
-      val #[challenge_id] :'plain × 'plain → 'cipher
+      #val #[getpk_id] : 'unit → 'pubkey ;
+      #val #[challenge_id] :'plain × 'plain → 'cipher
     ] :=
     λ b, if b then {locpackage L_pk_ots_L } else {locpackage L_pk_ots_R }.
 
@@ -360,8 +360,8 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
   Definition OT_secrecy : Prop :=
     ∀ LA A,
       ValidPackage LA [interface
-        val #[getpk_id] : 'unit → 'pubkey ;
-        val #[challenge_id] :'plain × 'plain → 'option 'cipher
+        #val #[getpk_id] : 'unit → 'pubkey ;
+        #val #[challenge_id] :'plain × 'plain → 'option 'cipher
       ] A_export A →
       fdisjoint LA (ots_L_vs_R true).(locs) →
       fdisjoint LA (ots_L_vs_R false).(locs) →
@@ -373,25 +373,25 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
     package L_locs_counter
       [interface]
       [interface
-        val #[getpk_id] : 'unit → 'pubkey ;
-        val #[challenge_id'] : 'plain → 'cipher
+        #val #[getpk_id] : 'unit → 'pubkey ;
+        #val #[challenge_id'] : 'plain → 'cipher
       ]
     :=
     [package
-      def  #[getpk_id] (_ : 'unit) : 'pubkey
+      #def  #[getpk_id] (_ : 'unit) : 'pubkey
       {
         pk ← get pk_loc ;;
         ret pk
       } ;
 
-      def #[challenge_id'] (m : 'plain) : 'cipher
+      #def #[challenge_id'] (m : 'plain) : 'cipher
       {
         count ← get counter_loc ;;
-        put counter_loc := (count + 1)%N;;
+        #put counter_loc := (count + 1)%N;;
         #assert (count == 0)%N ;;
         '(pk, sk) ← KeyGen ;;
-        put pk_loc := pk ;;
-        put sk_loc := sk ;;
+        #put pk_loc := pk ;;
+        #put sk_loc := sk ;;
         c ← Enc pk m ;;
         ret c
       }
@@ -401,25 +401,25 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
     package L_locs_counter
       [interface]
       [interface
-        val #[getpk_id] : 'unit → 'pubkey ;
-        val #[challenge_id'] : 'plain → 'cipher
+        #val #[getpk_id] : 'unit → 'pubkey ;
+        #val #[challenge_id'] : 'plain → 'cipher
       ]
     :=
     [package
-      def  #[getpk_id] (_ : 'unit) : 'pubkey
+      #def  #[getpk_id] (_ : 'unit) : 'pubkey
       {
         pk ← get pk_loc ;;
         ret pk
       } ;
 
-      def #[challenge_id'] (m : 'plain) : 'cipher
+      #def #[challenge_id'] (m : 'plain) : 'cipher
       {
         count ← get counter_loc ;;
-        put counter_loc := (count + 1)%N;;
+        #put counter_loc := (count + 1)%N;;
         #assert (count == 0)%N ;;
         '(pk, sk) ← KeyGen ;;
-        put pk_loc := pk ;;
-        put sk_loc := sk ;;
+        #put pk_loc := pk ;;
+        #put sk_loc := sk ;;
         c ← sample uniform i_cipher ;;
         ret c
       }
@@ -427,8 +427,8 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
 
   Definition ots_real_vs_rnd :
     loc_GamePair [interface
-      val #[getpk_id] : 'unit → 'pubkey ;
-      val #[challenge_id'] : 'plain → 'cipher
+      #val #[getpk_id] : 'unit → 'pubkey ;
+      #val #[challenge_id'] : 'plain → 'cipher
     ] :=
     λ b, if b then {locpackage L_pk_ots_real } else {locpackage L_pk_ots_rnd }.
 

--- a/theories/Crypt/examples/ElGamal.v
+++ b/theories/Crypt/examples/ElGamal.v
@@ -208,25 +208,25 @@ Definition DH_loc := fset [:: pk_loc ; sk_loc].
 
 Definition DH_real :
   package DH_loc [interface]
-    [interface val #[10] : 'unit → 'pubkey × 'cipher ] :=
+    [interface #val #[10] : 'unit → 'pubkey × 'cipher ] :=
     [package
-      def #[10] (_ : 'unit) : 'pubkey × 'cipher
+      #def #[10] (_ : 'unit) : 'pubkey × 'cipher
       {
         a ← sample uniform i_sk ;;
         let a := otf a in
         b ← sample uniform i_sk ;;
         let b := otf b in
-        put pk_loc := fto (g^+a) ;;
-        put sk_loc := fto a ;;
+        #put pk_loc := fto (g^+a) ;;
+        #put sk_loc := fto a ;;
         ret (fto (g^+a), fto (g^+b, g^+(a * b)))
       }
     ].
 
 Definition DH_rnd :
   package DH_loc [interface]
-    [interface val #[10] : 'unit → 'pubkey × 'cipher ] :=
+    [interface #val #[10] : 'unit → 'pubkey × 'cipher ] :=
     [package
-      def #[10] (_ : 'unit) : 'pubkey × 'cipher
+      #def #[10] (_ : 'unit) : 'pubkey × 'cipher
       {
         a ← sample uniform i_sk ;;
         let a := otf a in
@@ -234,32 +234,32 @@ Definition DH_rnd :
         let b := otf b in
         c ← sample uniform i_sk ;;
         let c := otf c  in
-        put pk_loc := fto (g^+a) ;;
-        put sk_loc := fto a ;;
+        #put pk_loc := fto (g^+a) ;;
+        #put sk_loc := fto a ;;
         ret (fto (g^+a), fto (g^+b, g^+c))
       }
     ].
 
 Definition Aux :
   package (fset [:: counter_loc ; pk_loc ])
-    [interface val #[10] : 'unit → 'pubkey × 'cipher]
+    [interface #val #[10] : 'unit → 'pubkey × 'cipher]
     [interface
-      val #[getpk_id] : 'unit → 'pubkey ;
-      val #[challenge_id'] : 'plain → 'cipher
+      #val #[getpk_id] : 'unit → 'pubkey ;
+      #val #[challenge_id'] : 'plain → 'cipher
     ]
   :=
   [package
-    def #[getpk_id] (_ : 'unit) : 'pubkey
+    #def #[getpk_id] (_ : 'unit) : 'pubkey
     {
       pk ← get pk_loc ;;
       ret pk
     } ;
 
-    def #[challenge_id'] (m : 'plain) : 'cipher
+    #def #[challenge_id'] (m : 'plain) : 'cipher
     {
       #import {sig #[10] : 'unit → 'pubkey × 'cipher } as query ;;
       count ← get counter_loc ;;
-      put counter_loc := (count + 1)%N ;;
+      #put counter_loc := (count + 1)%N ;;
       #assert (count == 0)%N ;;
       '(pk, c) ← query Datatypes.tt ;;
       @ret chCipher (fto ((otf c).1 , (otf m) * ((otf c).2)))
@@ -417,8 +417,8 @@ Qed.
 Theorem ElGamal_OT :
   ∀ LA A,
     ValidPackage LA [interface
-      val #[getpk_id] : 'unit → 'pubkey ;
-      val #[challenge_id'] : 'plain → 'cipher
+      #val #[getpk_id] : 'unit → 'pubkey ;
+      #val #[challenge_id'] : 'plain → 'cipher
     ] A_export A →
     fdisjoint LA (ots_real_vs_rnd true).(locs) →
     fdisjoint LA (ots_real_vs_rnd false).(locs) →

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -136,9 +136,9 @@ Section KEMDEM.
   Definition c_loc : Location := ('option 'cipher ; 4%N).
 
   (** Some shorthands *)
-  Definition IGEN := [interface val #[ GEN ] : 'unit → 'unit ].
-  Definition ISET := [interface val #[ SET ] : 'key → 'unit ].
-  Definition IGET := [interface val #[GET] : 'unit → 'key ].
+  Definition IGEN := [interface #val #[ GEN ] : 'unit → 'unit ].
+  Definition ISET := [interface #val #[ SET ] : 'key → 'unit ].
+  Definition IGET := [interface #val #[GET] : 'unit → 'key ].
 
   (** PKE scheme
 
@@ -220,28 +220,28 @@ Section KEMDEM.
   *)
   Definition KEY_out :=
     [interface
-      val #[ GEN ] : 'unit → 'unit ;
-      val #[ SET ] : 'key → 'unit ;
-      val #[ GET ] : 'unit → 'key
+      #val #[ GEN ] : 'unit → 'unit ;
+      #val #[ SET ] : 'key → 'unit ;
+      #val #[ GET ] : 'unit → 'key
     ].
 
   (** Definition of the KEY package *)
   Definition KEY : package KEY_loc [interface] KEY_out :=
     [package
-      def #[ GEN ] (_ : 'unit) : 'unit {
+      #def #[ GEN ] (_ : 'unit) : 'unit {
         k ← get k_loc ;;
         #assert (k == None) ;;
         k ← sample keyD ;;
-        put k_loc := Some k ;;
+        #put k_loc := Some k ;;
         @ret 'unit Datatypes.tt
       } ;
-      def #[ SET ] (k : 'key) : 'unit {
+      #def #[ SET ] (k : 'key) : 'unit {
         k' ← get k_loc ;;
         #assert (k' == None) ;;
-        put k_loc := Some k ;;
+        #put k_loc := Some k ;;
         @ret 'unit Datatypes.tt
       } ;
-      def #[ GET ] (_ : 'unit) : 'key {
+      #def #[ GET ] (_ : 'unit) : 'key {
         k ← get k_loc ;;
         #assert (isSome k) as kSome ;;
         @ret 'key (getSome k kSome)
@@ -271,9 +271,9 @@ Section KEMDEM.
   *)
   Definition KEM_out :=
     [interface
-      val #[ KEMGEN ] : 'unit → 'pkey ;
-      val #[ ENCAP ] : 'unit → 'ekey ;
-      val #[ DECAP ] : 'ekey → 'key
+      #val #[ KEMGEN ] : 'unit → 'pkey ;
+      #val #[ ENCAP ] : 'unit → 'ekey ;
+      #val #[ DECAP ] : 'ekey → 'key
     ].
 
   (** Here we add a hint to the [ssprove_valid_db] and [typeclass_instances]
@@ -290,15 +290,15 @@ Section KEMDEM.
 
   Definition KEM (b : bool) : package KEM_loc (KEM_in b) KEM_out :=
     [package
-      def #[ KEMGEN ] (_ : 'unit) : 'pkey {
+      #def #[ KEMGEN ] (_ : 'unit) : 'pkey {
         sk ← get sk_loc ;;
         #assert (sk == None) ;;
         '(pk, sk) ← η.(KEM_kgen) ;;
-        put pk_loc := Some pk ;;
-        put sk_loc := Some sk ;;
+        #put pk_loc := Some pk ;;
+        #put sk_loc := Some sk ;;
         @ret 'pkey pk
       } ;
-      def #[ ENCAP ] (_ : 'unit) : 'ekey {
+      #def #[ ENCAP ] (_ : 'unit) : 'ekey {
         #import {sig #[ SET ] : 'key → 'unit } as SET ;;
         #import {sig #[ GEN ] : 'unit → 'unit } as GEN ;;
         pk ← get pk_loc ;;
@@ -307,11 +307,11 @@ Section KEMDEM.
         ek ← get ek_loc ;;
         #assert (ek == None) ;;
         '(k, ek) ← η.(KEM_encap) pk ;;
-        put ek_loc := Some ek ;;
+        #put ek_loc := Some ek ;;
         (if b then SET k else GEN Datatypes.tt) ;;
         ret ek
       } ;
-      def #[ DECAP ] (ek' : 'ekey) : 'key {
+      #def #[ DECAP ] (ek' : 'ekey) : 'key {
         sk ← get sk_loc ;;
         #assert (isSome sk) as skSome ;;
         let sk := getSome sk skSome in
@@ -335,10 +335,10 @@ Section KEMDEM.
 
   Definition KEM_CCA_out :=
     [interface
-      val #[ KEMGEN ] : 'unit → 'pkey ;
-      val #[ ENCAP ] : 'unit → 'ekey ;
-      val #[ DECAP ] : 'ekey → 'key ;
-      val #[GET] : 'unit → 'key
+      #val #[ KEMGEN ] : 'unit → 'pkey ;
+      #val #[ ENCAP ] : 'unit → 'ekey ;
+      #val #[ DECAP ] : 'ekey → 'key ;
+      #val #[GET] : 'unit → 'key
     ].
 
   Definition KEM_CCA_loc :=
@@ -388,22 +388,22 @@ Section KEMDEM.
   *)
   Definition DEM_out :=
     [interface
-      val #[ ENC ] : 'plain → 'cipher ;
-      val #[ DEC ] : 'cipher → 'plain
+      #val #[ ENC ] : 'plain → 'cipher ;
+      #val #[ DEC ] : 'cipher → 'plain
     ].
 
   Definition DEM (b : bool) : package DEM_loc DEM_in DEM_out :=
     [package
-      def #[ ENC ] (m : 'plain) : 'cipher {
+      #def #[ ENC ] (m : 'plain) : 'cipher {
         #import {sig #[ GET ] : 'unit → 'key } as GET ;;
         c ← get c_loc ;;
         #assert (c == None) ;;
         k ← GET Datatypes.tt ;;
         let c := θ.(DEM_enc) k (if b then m else nullPlain) in
-        put c_loc := Some c ;;
+        #put c_loc := Some c ;;
         ret c
       } ;
-      def #[ DEC ] (c' : 'cipher) : 'plain {
+      #def #[ DEC ] (c' : 'cipher) : 'plain {
         #import {sig #[ GET ] : 'unit → 'key } as GET ;;
         c ← get c_loc ;;
         #assert (isSome c) as cSome ;;
@@ -424,9 +424,9 @@ Section KEMDEM.
 
   Definition DEM_CCA_out :=
     [interface
-      val #[ GEN ] : 'unit → 'unit ;
-      val #[ ENC ] : 'plain → 'cipher ;
-      val #[ DEC ] : 'cipher → 'plain
+      #val #[ GEN ] : 'unit → 'unit ;
+      #val #[ ENC ] : 'plain → 'cipher ;
+      #val #[ DEC ] : 'cipher → 'plain
     ].
 
   Definition DEM_CCA_loc :=
@@ -456,23 +456,23 @@ Section KEMDEM.
 
   Definition PKE_CCA_out :=
     [interface
-      val #[ PKGEN ] : 'unit → 'pkey ;
-      val #[ PKENC ] : 'plain → 'ekey × 'cipher ;
-      val #[ PKDEC ] : 'ekey × 'cipher → 'plain
+      #val #[ PKGEN ] : 'unit → 'pkey ;
+      #val #[ PKENC ] : 'plain → 'ekey × 'cipher ;
+      #val #[ PKDEC ] : 'ekey × 'cipher → 'plain
     ].
 
   Definition PKE_CCA_pkg (ζ : PKE_scheme) b :
     package PKE_CCA_loc [interface] PKE_CCA_out :=
     [package
-      def #[ PKGEN ] (_ : 'unit) : 'pkey {
+      #def #[ PKGEN ] (_ : 'unit) : 'pkey {
         sk ← get sk_loc ;;
         #assert (sk == None) ;;
         '(pk, sk) ← ζ.(PKE_kgen) ;;
-        put pk_loc := Some pk ;;
-        put sk_loc := Some sk ;;
+        #put pk_loc := Some pk ;;
+        #put sk_loc := Some sk ;;
         @ret 'pkey pk
       } ;
-      def #[ PKENC ] (m : 'plain) : 'ekey × 'cipher {
+      #def #[ PKENC ] (m : 'plain) : 'ekey × 'cipher {
         pk ← get pk_loc ;;
         #assert (isSome pk) as pkSome ;;
         let pk := getSome pk pkSome in
@@ -481,11 +481,11 @@ Section KEMDEM.
         c ← get c_loc ;;
         #assert (c == None) ;;
         '(ek, c) ← ζ.(PKE_enc) pk (if b then m else nullPlain) ;;
-        put ek_loc := Some ek ;;
-        put c_loc := Some c ;;
+        #put ek_loc := Some ek ;;
+        #put c_loc := Some c ;;
         @ret (chProd 'ekey 'cipher) (ek, c)
       } ;
-      def #[ PKDEC ] (c' : 'ekey × 'cipher) : 'plain {
+      #def #[ PKDEC ] (c' : 'ekey × 'cipher) : 'plain {
         sk ← get sk_loc ;;
         #assert (isSome sk) as skSome ;;
         let sk := getSome sk skSome in
@@ -510,11 +510,11 @@ Section KEMDEM.
 
   Definition MOD_CCA_in :=
     [interface
-      val #[ KEMGEN ] : 'unit → 'pkey ;
-      val #[ ENCAP ] : 'unit → 'ekey ;
-      val #[ DECAP ] : 'ekey → 'key ;
-      val #[ ENC ] : 'plain → 'cipher ;
-      val #[ DEC ] : 'cipher → 'plain
+      #val #[ KEMGEN ] : 'unit → 'pkey ;
+      #val #[ ENCAP ] : 'unit → 'ekey ;
+      #val #[ DECAP ] : 'ekey → 'key ;
+      #val #[ ENC ] : 'plain → 'cipher ;
+      #val #[ DEC ] : 'cipher → 'plain
     ].
 
   Definition MOD_CCA_out :=
@@ -523,13 +523,13 @@ Section KEMDEM.
   Definition MOD_CCA (ζ : PKE_scheme) :
     package MOD_CCA_loc MOD_CCA_in MOD_CCA_out :=
     [package
-      def #[ PKGEN ] (_ : 'unit) : 'pkey {
+      #def #[ PKGEN ] (_ : 'unit) : 'pkey {
         #import {sig #[ KEMGEN ] : 'unit → 'pkey } as KEMGEN ;;
         pk ← get pk_loc ;;
         #assert (pk == None) ;;
         KEMGEN Datatypes.tt
       } ;
-      def #[ PKENC ] (m : 'plain) : 'ekey × 'cipher {
+      #def #[ PKENC ] (m : 'plain) : 'ekey × 'cipher {
         #import {sig #[ ENCAP ] : 'unit → 'ekey } as ENCAP ;;
         #import {sig #[ ENC ] : 'plain → 'cipher } as ENC ;;
         pk ← get pk_loc ;;
@@ -539,12 +539,12 @@ Section KEMDEM.
         c ← get c_loc ;;
         #assert (c ==  None) ;;
         ek ← ENCAP Datatypes.tt ;;
-        put ek_loc := Some ek ;;
+        #put ek_loc := Some ek ;;
         c ← ENC m ;;
-        put c_loc := Some c ;;
+        #put c_loc := Some c ;;
         @ret (chProd 'ekey 'cipher) (ek, c)
       } ;
-      def #[ PKDEC ] ('(ek', c') : 'ekey × 'cipher) : 'plain {
+      #def #[ PKDEC ] ('(ek', c') : 'ekey × 'cipher) : 'plain {
         #import {sig #[ DECAP ] : 'ekey → 'key } as DECAP ;;
         #import {sig #[ DEC ] : 'cipher → 'plain } as DEC ;;
         pk ← get pk_loc ;;

--- a/theories/Crypt/examples/OTP.v
+++ b/theories/Crypt/examples/OTP.v
@@ -300,9 +300,9 @@ Section OTP_example.
   Definition IND_CPA_real :
     package IND_CPA_location
       [interface]
-      [interface val #[i1] : 'word → 'word ] :=
+      [interface #val #[i1] : 'word → 'word ] :=
     [package
-        def #[i1] (m : 'word) : 'word
+        #def #[i1] (m : 'word) : 'word
         {
           k_val ← sample uniform i_key ;;
           r ← Enc (ch2words m) (ch2key k_val) ;;
@@ -313,9 +313,9 @@ Section OTP_example.
   Definition IND_CPA_ideal :
     package IND_CPA_location
       [interface ]
-      [interface val #[i1] : 'word → 'word ] :=
+      [interface #val #[i1] : 'word → 'word ] :=
     [package
-      def #[i1] (m : 'word) : 'word
+      #def #[i1] (m : 'word) : 'word
       {
         m'    ← sample uniform i_words ;;
         k_val ← sample uniform i_key ;;
@@ -324,7 +324,7 @@ Section OTP_example.
       }
     ].
 
-  Definition IND_CPA : loc_GamePair [interface val #[i1] : 'word → 'word ] :=
+  Definition IND_CPA : loc_GamePair [interface #val #[i1] : 'word → 'word ] :=
     λ b, if b then {locpackage IND_CPA_real } else {locpackage IND_CPA_ideal }.
 
   #[local] Open Scope ring_scope.
@@ -361,7 +361,7 @@ Section OTP_example.
   Theorem unconditional_secrecy :
     ∀ LA A,
       ValidPackage LA
-        [interface val #[i1] : 'word → 'word ] A_export A →
+        [interface #val #[i1] : 'word → 'word ] A_export A →
       Advantage IND_CPA A = 0.
   Proof.
     intros LA A vA.

--- a/theories/Crypt/examples/PRF.v
+++ b/theories/Crypt/examples/PRF.v
@@ -211,15 +211,15 @@ Section PRF_example.
 
   Definition EVAL_pkg_tt :
     package EVAL_location_tt [interface]
-      [interface val #[i0] : 'word → 'key ] :=
+      [interface #val #[i0] : 'word → 'key ] :=
     [package
-      def #[i0] (r : 'word) : 'key
+      #def #[i0] (r : 'word) : 'key
       {
         k_init ← get key_location ;;
         match k_init with
         | None =>
             k ← sample uniform i_key ;;
-            put key_location := Some k ;;
+            #put key_location := Some k ;;
             ret (PRF r k)
         | Some k_val =>
             ret (PRF r k_val)
@@ -229,15 +229,15 @@ Section PRF_example.
 
   Definition EVAL_pkg_ff :
     package EVAL_location_ff [interface]
-      [interface val #[i0] : 'word → 'key ] :=
+      [interface #val #[i0] : 'word → 'key ] :=
     [package
-      def #[i0] (r : 'word) : 'key
+      #def #[i0] (r : 'word) : 'key
       {
         T ← get table_location ;;
         match getm T r with
         | None =>
             T_key ← sample uniform i_key ;;
-            put table_location := (setm T r T_key) ;;
+            #put table_location := (setm T r T_key) ;;
             ret T_key
         | Some T_key => ret T_key
         end
@@ -247,16 +247,16 @@ Section PRF_example.
   (* TODO Not the most satisfying, it would be nice to think of something else
     This might come with more automation to deal with the GamePair type.
   *)
-  Definition EVAL : loc_GamePair [interface val #[i0] : 'word → 'key ] :=
+  Definition EVAL : loc_GamePair [interface #val #[i0] : 'word → 'key ] :=
     λ b, if b then {locpackage EVAL_pkg_tt } else {locpackage EVAL_pkg_ff }.
 
   Definition MOD_CPA_location : {fset Location} := fset0.
 
   Definition MOD_CPA_tt_pkg :
-    package MOD_CPA_location [interface val #[i0] : 'word → 'key ]
-      [interface val #[i1] : 'word → 'word × 'word ] :=
+    package MOD_CPA_location [interface #val #[i0] : 'word → 'key ]
+      [interface #val #[i1] : 'word → 'word × 'word ] :=
     [package
-      def #[i1] (m : 'word) : 'word × 'word
+      #def #[i1] (m : 'word) : 'word × 'word
       {
         #import {sig #[i0] : 'word → 'key } as eval ;;
         r ← sample uniform i_words ;;
@@ -267,10 +267,10 @@ Section PRF_example.
     ].
 
   Definition MOD_CPA_ff_pkg :
-    package MOD_CPA_location [interface val #[i0] : 'word → 'key]
-      [interface val #[i1] : 'word → 'word × 'word ]:=
+    package MOD_CPA_location [interface #val #[i0] : 'word → 'key]
+      [interface #val #[i1] : 'word → 'word × 'word ]:=
     [package
-      def #[i1] (m : 'word) : 'word × 'word
+      #def #[i1] (m : 'word) : 'word × 'word
       {
         #import {sig #[i0] : 'word → 'key } as eval ;;
         r ← sample uniform i_words ;;
@@ -286,15 +286,15 @@ Section PRF_example.
   Definition IND_CPA_pkg_tt :
     package IND_CPA_location
       [interface]
-      [interface val #[i1] : 'word → 'word × 'word ] :=
+      [interface #val #[i1] : 'word → 'word × 'word ] :=
     [package
-      def #[i1] (m : 'word) : 'word × 'word
+      #def #[i1] (m : 'word) : 'word × 'word
       {
         k ← get key_location ;;
         match k with
         | None =>
           k_val ← sample uniform i_key ;;
-          put key_location := Some k_val ;;
+          #put key_location := Some k_val ;;
           enc m k_val
         | Some k_val =>
           enc m k_val
@@ -305,15 +305,15 @@ Section PRF_example.
   Definition IND_CPA_pkg_ff :
     package IND_CPA_location
       [interface]
-      [interface val #[i1] : 'word → 'word × 'word ] :=
+      [interface #val #[i1] : 'word → 'word × 'word ] :=
     [package
-      def #[i1] (m : 'word) : 'word × 'word
+      #def #[i1] (m : 'word) : 'word × 'word
       {
         k ← get key_location ;;
         match k with
         | None =>
           k_val ← sample uniform i_key ;;
-          put key_location := Some k_val ;;
+          #put key_location := Some k_val ;;
           m' ← sample uniform i_words ;;
           enc m' k_val
         | Some k_val =>
@@ -324,7 +324,7 @@ Section PRF_example.
     ].
 
   Definition IND_CPA :
-    loc_GamePair [interface val #[i1] : 'word → 'word × 'word ] :=
+    loc_GamePair [interface #val #[i1] : 'word → 'word × 'word ] :=
     λ b,
       if b then {locpackage IND_CPA_pkg_tt } else {locpackage IND_CPA_pkg_ff }.
 
@@ -393,7 +393,7 @@ Section PRF_example.
   Theorem security_based_on_prf :
     ∀ LA A,
       ValidPackage LA
-        [interface val #[i1] : 'word → 'word × 'word ] A_export A →
+        [interface #val #[i1] : 'word → 'word × 'word ] A_export A →
       fdisjoint LA (IND_CPA false).(locs) →
       fdisjoint LA (IND_CPA true).(locs) →
       Advantage IND_CPA A <=

--- a/theories/Crypt/examples/RandomOracle.v
+++ b/theories/Crypt/examples/RandomOracle.v
@@ -53,18 +53,18 @@ Module RO (π : ROParams).
 
   Definition RO_exports :=
     [interface
-      val #[ INIT ] : 'unit → 'unit ;
-      val #[ QUERY ] : 'query → 'random
+      #val #[ INIT ] : 'unit → 'unit ;
+      #val #[ QUERY ] : 'query → 'random
     ].
 
   Definition RO : package RO_locs [interface] RO_exports :=
     [package
-      def #[ INIT ] (_ : 'unit) : 'unit
+      #def #[ INIT ] (_ : 'unit) : 'unit
       {
-        put queries_loc := emptym ;;
+        #put queries_loc := emptym ;;
         ret Datatypes.tt
       } ;
-      def #[ QUERY ] (q : 'query) : 'random
+      #def #[ QUERY ] (q : 'query) : 'random
       {
         queries ← get queries_loc ;;
         match queries q with
@@ -72,7 +72,7 @@ Module RO (π : ROParams).
           ret r
         | None =>
           r ← sample uniform i_random ;;
-          put queries_loc := setm queries q r ;;
+          #put queries_loc := setm queries q r ;;
           ret r
         end
       }

--- a/theories/Crypt/examples/Schnorr.v
+++ b/theories/Crypt/examples/Schnorr.v
@@ -117,7 +117,7 @@ Module MyAlg <: SigmaProtocolAlgorithms MyParam.
     code Sigma_locs [interface] choiceMessage :=
     {code
       r ← sample uniform i_witness ;;
-      put commit_loc := r ;;
+      #put commit_loc := r ;;
       ret (fto (g ^+ (otf r)))
     }.
 
@@ -226,7 +226,7 @@ Qed.
 Theorem schnorr_SHVZK :
   ∀ LA A,
     ValidPackage LA [interface
-      val #[ TRANSCRIPT ] : chInput → chTranscript
+      #val #[ TRANSCRIPT ] : chInput → chTranscript
     ] A_export A →
     fdisjoint LA Sigma_locs →
     ɛ_SHVZK A = 0.
@@ -305,10 +305,10 @@ Qed.
 Lemma extractor_success:
   ∀ LA A LAdv Adv,
     ValidPackage LA [interface
-      val #[ SOUNDNESS ] : chStatement → 'bool
+      #val #[ SOUNDNESS ] : chStatement → 'bool
     ] A_export A →
     ValidPackage LAdv [interface] [interface
-      val #[ ADV ] : chStatement → chSoundness
+      #val #[ ADV ] : chStatement → chSoundness
     ] Adv →
     fdisjoint LA (Sigma_locs :|: LAdv) →
     ɛ_soundness A Adv = 0.
@@ -443,7 +443,7 @@ Qed.
 Lemma hiding_adv :
   ∀ LA A,
     ValidPackage LA [interface
-      val #[ HIDING ] : chInput → chMessage
+      #val #[ HIDING ] : chInput → chMessage
     ] A_export A →
     fdisjoint LA Com_locs →
     fdisjoint LA Sigma_locs →
@@ -494,7 +494,7 @@ Qed.
 Theorem schnorr_com_hiding :
   ∀ LA A,
     ValidPackage LA [interface
-      val #[ HIDING ] : chInput → chMessage
+      #val #[ HIDING ] : chInput → chMessage
     ] A_export A →
     fdisjoint LA Com_locs →
     fdisjoint LA Sigma_locs →
@@ -528,10 +528,10 @@ Qed.
 Theorem schnorr_com_binding :
   ∀ LA A LAdv Adv,
     ValidPackage LA [interface
-      val #[ SOUNDNESS ] : chStatement → 'bool
+      #val #[ SOUNDNESS ] : chStatement → 'bool
     ] A_export A →
     ValidPackage LAdv [interface] [interface
-      val #[ ADV ] : chStatement → chSoundness
+      #val #[ ADV ] : chStatement → chSoundness
     ] Adv →
     fdisjoint LA (Sigma_locs :|: LAdv) →
     AdvantageE (Com_Binding ∘ Adv) (Special_Soundness_f ∘ Adv) A <= 0.

--- a/theories/Crypt/examples/SigmaProtocol.v
+++ b/theories/Crypt/examples/SigmaProtocol.v
@@ -140,10 +140,10 @@ Module SigmaProtocol (π : SigmaProtocolParams)
   Definition SHVZK_real:
     package Sigma_locs
       [interface]
-      [interface val #[ TRANSCRIPT ] : chInput → chTranscript]
+      [interface #val #[ TRANSCRIPT ] : chInput → chTranscript]
     :=
     [package
-      def #[ TRANSCRIPT ] (hwe : chInput) : chTranscript
+      #def #[ TRANSCRIPT ] (hwe : chInput) : chTranscript
       {
         let '(h,w,e) := hwe in
         #assert (R (otf h) (otf w)) ;;
@@ -156,10 +156,10 @@ Module SigmaProtocol (π : SigmaProtocolParams)
   Definition SHVZK_ideal:
     package Simulator_locs
       [interface]
-      [interface val #[ TRANSCRIPT ] : chInput → chTranscript]
+      [interface #val #[ TRANSCRIPT ] : chInput → chTranscript]
     :=
     [package
-      def #[ TRANSCRIPT ] (hwe : chInput) : chTranscript
+      #def #[ TRANSCRIPT ] (hwe : chInput) : chTranscript
       {
         let '(h, w, e) := hwe in
         #assert (R (otf h) (otf w)) ;;
@@ -173,11 +173,11 @@ Module SigmaProtocol (π : SigmaProtocolParams)
 
   Definition Special_Soundness_f :
     package Sigma_locs
-      [interface val #[ ADV ] : chStatement → chSoundness ]
-      [interface val #[ SOUNDNESS ] : chStatement → 'bool ]
+      [interface #val #[ ADV ] : chStatement → chSoundness ]
+      [interface #val #[ SOUNDNESS ] : chStatement → 'bool ]
     :=
     [package
-      def #[ SOUNDNESS ] (h : chStatement) : 'bool
+      #def #[ SOUNDNESS ] (h : chStatement) : 'bool
       {
         #import {sig #[ ADV ] : chStatement → chSoundness } as A ;;
         '(a, ((e, z), (e', z'))) ← A h ;;
@@ -194,11 +194,11 @@ Module SigmaProtocol (π : SigmaProtocolParams)
 
   Definition Special_Soundness_t :
     package Sigma_locs
-      [interface val #[ ADV ] : chStatement → chSoundness ]
-      [interface val #[ SOUNDNESS ] : chStatement → 'bool ]
+      [interface #val #[ ADV ] : chStatement → chSoundness ]
+      [interface #val #[ SOUNDNESS ] : chStatement → 'bool ]
     :=
     [package
-      def #[ SOUNDNESS ] (h : chStatement) : 'bool
+      #def #[ SOUNDNESS ] (h : chStatement) : 'bool
       {
         #import {sig #[ ADV ] : chStatement → chSoundness } as A ;;
         '(a, ((e, z), (e', z'))) ← A(h) ;;
@@ -244,23 +244,23 @@ Module SigmaProtocol (π : SigmaProtocolParams)
 
     Definition Sigma_to_Com:
       package Com_locs
-        [interface val #[ TRANSCRIPT ] : chInput → chTranscript]
+        [interface #val #[ TRANSCRIPT ] : chInput → chTranscript]
         [interface
-          val #[ COM ] : chInput → chMessage ;
-          val #[ OPEN ] : 'unit → chOpen ;
-          val #[ VER ] : chTranscript → 'bool
+          #val #[ COM ] : chInput → chMessage ;
+          #val #[ OPEN ] : 'unit → chOpen ;
+          #val #[ VER ] : chTranscript → 'bool
         ]
       :=
       [package
-        def #[ COM ] (hwe : chInput) : chMessage
+        #def #[ COM ] (hwe : chInput) : chMessage
         {
           #import {sig #[ TRANSCRIPT ] : chInput → chTranscript } as run ;;
           '(h,a,e,z) ← run hwe ;;
-          put challenge_loc := Some e ;;
-          put response_loc := Some z ;;
+          #put challenge_loc := Some e ;;
+          #put response_loc := Some z ;;
           ret a
         } ;
-        def #[ OPEN ] (_ : 'unit) : chOpen
+        #def #[ OPEN ] (_ : 'unit) : chOpen
         {
           o_e ← get challenge_loc ;;
           o_z ← get response_loc ;;
@@ -270,7 +270,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
           end
         }
         ;
-        def #[ VER ] (t : chTranscript) : 'bool
+        #def #[ VER ] (t : chTranscript) : 'bool
         {
           let '(h,a,e,z) := t in
           ret (otf (Verify h a e z))
@@ -281,14 +281,14 @@ Module SigmaProtocol (π : SigmaProtocolParams)
     Definition Hiding_real :
       package fset0
         [interface
-          val #[ COM ] : chInput → chMessage ;
-          val #[ OPEN ] : 'unit → chOpen ;
-          val #[ VER ] : chTranscript → 'bool
+          #val #[ COM ] : chInput → chMessage ;
+          #val #[ OPEN ] : 'unit → chOpen ;
+          #val #[ VER ] : chTranscript → 'bool
         ]
-        [interface val #[ HIDING ] : chInput → chMessage ]
+        [interface #val #[ HIDING ] : chInput → chMessage ]
       :=
       [package
-        def #[ HIDING ] (hwe : chInput) : chMessage
+        #def #[ HIDING ] (hwe : chInput) : chMessage
         {
           #import {sig #[ COM ] : chInput → chMessage } as com ;;
           a ← com hwe ;;
@@ -300,14 +300,14 @@ Module SigmaProtocol (π : SigmaProtocolParams)
     Definition Hiding_ideal :
       package fset0
         [interface
-          val #[ COM ] : chInput → chMessage ;
-          val #[ OPEN ] : 'unit → chOpen ;
-          val #[ VER ] : chTranscript → 'bool
+          #val #[ COM ] : chInput → chMessage ;
+          #val #[ OPEN ] : 'unit → chOpen ;
+          #val #[ VER ] : chTranscript → 'bool
         ]
-        [interface val #[ HIDING ] : chInput → chMessage]
+        [interface #val #[ HIDING ] : chInput → chMessage]
       :=
       [package
-        def #[ HIDING ] (hwe : chInput) : chMessage
+        #def #[ HIDING ] (hwe : chInput) : chMessage
         {
           #import {sig #[ COM ] : chInput → chMessage } as com ;;
           let '(h,w,_) := hwe in
@@ -325,11 +325,11 @@ Module SigmaProtocol (π : SigmaProtocolParams)
     Theorem commitment_hiding :
       ∀ LA A eps,
         ValidPackage LA [interface
-          val #[ HIDING ] : chInput → chMessage
+          #val #[ HIDING ] : chInput → chMessage
         ] A_export A →
         (∀ B,
           ValidPackage (LA :|: Com_locs) [interface
-            val #[ TRANSCRIPT ] : chInput → chTranscript
+            #val #[ TRANSCRIPT ] : chInput → chTranscript
           ] A_export B →
           ɛ_SHVZK B <= eps
         ) →
@@ -369,11 +369,11 @@ Module SigmaProtocol (π : SigmaProtocolParams)
 
     Definition Com_Binding :
       package Sigma_locs
-        [interface val #[ ADV ] : chStatement → chSoundness ]
-        [interface val #[ SOUNDNESS ] : chStatement → 'bool ]
+        [interface #val #[ ADV ] : chStatement → chSoundness ]
+        [interface #val #[ SOUNDNESS ] : chStatement → 'bool ]
       :=
       [package
-        def #[ SOUNDNESS ] (h : chStatement) : 'bool
+        #def #[ SOUNDNESS ] (h : chStatement) : 'bool
         {
           #import {sig #[ ADV ] : chStatement → chSoundness} as A ;;
           '(a, ((e, z), (e', z'))) ← A h ;;
@@ -386,10 +386,10 @@ Module SigmaProtocol (π : SigmaProtocolParams)
     Lemma commitment_binding :
       ∀ LA A LAdv Adv,
         ValidPackage LA [interface
-          val #[ SOUNDNESS ] : chStatement → 'bool
+          #val #[ SOUNDNESS ] : chStatement → 'bool
         ] A_export A →
         ValidPackage LAdv [interface] [interface
-          val #[ ADV ] : chStatement → chSoundness
+          #val #[ ADV ] : chStatement → chSoundness
         ] Adv →
         fdisjoint LA (Sigma_locs :|: LAdv) →
         AdvantageE (Com_Binding ∘ Adv) (Special_Soundness_f ∘ Adv) A <=
@@ -477,23 +477,23 @@ Module SigmaProtocol (π : SigmaProtocolParams)
     Definition Fiat_Shamir :
       package Sigma_locs
         [interface
-          val #[ INIT ] : 'unit → 'unit ;
-          val #[ QUERY ] : 'query → 'random
+          #val #[ INIT ] : 'unit → 'unit ;
+          #val #[ QUERY ] : 'query → 'random
         ]
         [interface
-          val #[ VERIFY ] : chTranscript → 'bool ;
-          val #[ RUN ] : chRelation → chTranscript
+          #val #[ VERIFY ] : chTranscript → 'bool ;
+          #val #[ RUN ] : chRelation → chTranscript
         ]
       :=
       [package
-        def #[ VERIFY ] (t : chTranscript) : 'bool
+        #def #[ VERIFY ] (t : chTranscript) : 'bool
         {
           #import {sig #[ QUERY ] : 'query → 'random } as RO_query ;;
           let '(h,a,e,z) := t in
           e ← RO_query (prod_assoc (h, a)) ;;
           ret (otf (Verify h a e z))
         } ;
-        def #[ RUN ] (hw : chRelation) : chTranscript
+        #def #[ RUN ] (hw : chRelation) : chTranscript
         {
           #import {sig #[ INIT ] : 'unit → 'unit } as RO_init ;;
           #import {sig #[ QUERY ] : 'query → 'random } as RO_query ;;
@@ -511,17 +511,17 @@ Module SigmaProtocol (π : SigmaProtocolParams)
       package Sigma_locs
         [interface]
         [interface
-          val #[ VERIFY ] : chTranscript → 'bool ;
-          val #[ RUN ] : chRelation → chTranscript
+          #val #[ VERIFY ] : chTranscript → 'bool ;
+          #val #[ RUN ] : chRelation → chTranscript
         ]
       :=
       [package
-        def #[ VERIFY ] (t : chTranscript) : 'bool
+        #def #[ VERIFY ] (t : chTranscript) : 'bool
         {
           let '(h,a,e,z) := t in
           ret (otf (Verify h a e z))
         } ;
-        def #[ RUN ] (hw : chRelation) : chTranscript
+        #def #[ RUN ] (hw : chRelation) : chTranscript
         {
           let '(h,w) := hw in
           #assert (R (otf h) (otf w)) ;;
@@ -534,11 +534,11 @@ Module SigmaProtocol (π : SigmaProtocolParams)
 
     Definition SHVZK_real_aux :
       package Sigma_locs
-        [interface val #[ TRANSCRIPT ] : chInput → chTranscript ]
-        [interface val #[ RUN ] : chRelation → chTranscript ]
+        [interface #val #[ TRANSCRIPT ] : chInput → chTranscript ]
+        [interface #val #[ RUN ] : chRelation → chTranscript ]
       :=
       [package
-        def #[ RUN ] (hw : chRelation) : chTranscript
+        #def #[ RUN ] (hw : chRelation) : chTranscript
         {
           #import {sig #[ TRANSCRIPT ] : chInput → chTranscript } as SHVZK ;;
           e ← sample uniform i_random ;;
@@ -550,7 +550,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
     Lemma run_interactive_shvzk :
       ∀ LA A,
         ValidPackage LA [interface
-          val #[ RUN ] : chRelation → chTranscript
+          #val #[ RUN ] : chRelation → chTranscript
         ] A_export A →
         fdisjoint LA Sigma_locs →
         AdvantageE RUN_interactive (SHVZK_real_aux ∘ SHVZK_real) A = 0.
@@ -593,7 +593,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
     Theorem fiat_shamir_correct :
       ∀ LA A ,
         ValidPackage LA [interface
-          val #[ RUN ] : chRelation → chTranscript
+          #val #[ RUN ] : chRelation → chTranscript
         ] A_export A →
         fdisjoint LA (Sigma_locs :|: RO_locs) →
         fdisjoint Sigma_locs RO_locs →

--- a/theories/Crypt/examples/package_usage_example.v
+++ b/theories/Crypt/examples/package_usage_example.v
@@ -22,18 +22,18 @@ Set Primitive Projections.
 #[local] Open Scope package_scope.
 
 Definition I0 : Interface :=
-  [interface val #[3] : 'nat → 'nat].
+  [interface #val #[3] : 'nat → 'nat].
 
 Definition I1 : Interface :=
   [interface
-    val #[0] : 'bool → 'bool ;
-    val #[1] : 'nat → 'unit ;
-    val #[2] : 'unit → 'bool
+    #val #[0] : 'bool → 'bool ;
+    #val #[1] : 'nat → 'unit ;
+    #val #[2] : 'unit → 'bool
   ].
 
 Definition I2 : Interface :=
   [interface
-    val #[4] : 'bool × 'bool → 'bool
+    #val #[4] : 'bool × 'bool → 'bool
   ].
 
 Definition pempty : package fset0 [interface] [interface] :=
@@ -41,20 +41,20 @@ Definition pempty : package fset0 [interface] [interface] :=
 
 Definition p0 : package fset0 [interface] I0 :=
   [package
-    def #[3] (x : 'nat) : 'nat {
+    #def #[3] (x : 'nat) : 'nat {
       ret x
     }
   ].
 
 Definition p1 : package fset0 [interface] I1 :=
   [package
-    def #[0] (z : 'bool) : 'bool {
+    #def #[0] (z : 'bool) : 'bool {
       ret z
     } ;
-    def #[1] (y : 'nat) : 'unit {
+    #def #[1] (y : 'nat) : 'unit {
       ret Datatypes.tt
     } ;
-    def #[2] (u : 'unit) : 'bool {
+    #def #[2] (u : 'unit) : 'bool {
       ret false
     }
   ].
@@ -67,7 +67,7 @@ Definition bar (b : bool) : code fset0 [interface] nat_choiceType :=
 
 Definition p2 : package fset0 [interface] I2 :=
   [package
-    def #[4] (x : 'bool × 'bool) : 'bool {
+    #def #[4] (x : 'bool × 'bool) : 'bool {
       let '(u,v) := x in ret v
     }
   ].
@@ -75,21 +75,21 @@ Definition p2 : package fset0 [interface] I2 :=
 Definition test₁ :
   package
     [fset (chNat; 0)]
-    [interface val #[0] : 'nat → 'nat]
+    [interface #val #[0] : 'nat → 'nat]
     [interface
-      val #[1] : 'nat → 'nat ;
-      val #[2] : 'unit → 'unit
+      #val #[1] : 'nat → 'nat ;
+      #val #[2] : 'unit → 'unit
     ]
   :=
   [package
-    def #[1] (x : 'nat) : 'nat {
+    #def #[1] (x : 'nat) : 'nat {
       getr ('nat; 0) (λ n : nat,
         opr (0, ('nat, 'nat)) n (λ m,
           putr ('nat; 0) m (ret m)
         )
       )
     } ;
-    def #[2] (_ : 'unit) : 'unit {
+    #def #[2] (_ : 'unit) : 'unit {
       putr ('nat; 0) 0 (ret Datatypes.tt)
     }
   ].
@@ -99,27 +99,27 @@ Definition sig := {sig #[0] : 'nat → 'nat }.
 #[program] Definition test₂ :
   package
     [fset ('nat; 0)]
-    [interface val #[0] : 'nat → 'nat ]
+    [interface #val #[0] : 'nat → 'nat ]
     [interface
-      val #[1] : 'nat → 'nat ;
-      val #[2] : 'unit → 'option ('fin 2) ;
-      val #[3] : {map 'nat → 'nat} → 'option 'nat
+      #val #[1] : 'nat → 'nat ;
+      #val #[2] : 'unit → 'option ('fin 2) ;
+      #val #[3] : {map 'nat → 'nat} → 'option 'nat
     ]
   :=
   [package
-    def #[1] (x : 'nat) : 'nat {
+    #def #[1] (x : 'nat) : 'nat {
       n ← get ('nat ; 0) ;;
       m ← op sig ⋅ n ;;
       n ← get ('nat ; 0) ;;
       m ← op sig ⋅ n ;;
-      put ('nat ; 0) := m ;;
+      #put ('nat ; 0) := m ;;
       ret m
     } ;
-    def #[2] (_ : 'unit) : 'option ('fin 2) {
-      put ('nat ; 0) := 0 ;;
+    #def #[2] (_ : 'unit) : 'option ('fin 2) {
+      #put ('nat ; 0) := 0 ;;
       ret (Some (gfin 1))
     } ;
-    def #[3] (m : {map 'nat → 'nat}) : 'option 'nat {
+    #def #[3] (m : {map 'nat → 'nat}) : 'option 'nat {
       ret (getm m 0)
     }
   ].
@@ -129,16 +129,16 @@ Definition test₃ :
   package
     fset0
     [interface
-      val #[0] : 'nat → 'bool ;
-      val #[1] : 'bool → 'unit
+      #val #[0] : 'nat → 'bool ;
+      #val #[1] : 'bool → 'unit
     ]
     [interface
-      val #[2] : 'nat → 'nat ;
-      val #[3] : 'bool × 'bool → 'bool
+      #val #[2] : 'nat → 'nat ;
+      #val #[3] : 'bool × 'bool → 'bool
     ]
   :=
   [package
-    def #[2] (n : 'nat) : 'nat {
+    #def #[2] (n : 'nat) : 'nat {
       #import {sig #[0] : 'nat → 'bool } as f ;;
       #import {sig #[1] : 'bool → 'unit } as g ;;
       b ← f n ;;
@@ -147,7 +147,7 @@ Definition test₃ :
         ret 0
       else ret n
     } ;
-    def #[3] ('(b₀,b₁) : 'bool × 'bool) : 'bool {
+    #def #[3] ('(b₀,b₁) : 'bool × 'bool) : 'bool {
       ret b₀
     }
   ].
@@ -157,10 +157,10 @@ Definition test₃ :
 *)
 Definition test₄ : package fset0 [interface] _ :=
   [package
-    def #[ 0 ] (n : 'nat) : 'nat {
+    #def #[ 0 ] (n : 'nat) : 'nat {
       ret (n + n)%N
     } ;
-    def #[ 1 ] (b : 'bool) : 'nat {
+    #def #[ 1 ] (b : 'bool) : 'nat {
       if b then ret 0 else ret 13
     }
   ].

--- a/theories/Crypt/package/pkg_notation.v
+++ b/theories/Crypt/package/pkg_notation.v
@@ -37,7 +37,7 @@
     An interface can be provided using the following sequence notation:
     [interface d1 ; ... ; dn]
     where d1 to dn are prototypes or function signatures of the form
-    val #[n] : S → T
+    #val #[n] : S → T
     where S and T are both given using the type syntax above
     and n is a natural number used as an identifier.
 
@@ -46,7 +46,7 @@
     A package can bve provided using the following sequence notation;
     [package d1 ; ... dn]
     where d1 to dn are function declarations of the form
-    def #[n] (x : A) : B {
+    #def #[n] (x : A) : B {
       e
     }
     where n is a natural number used as an identifier, A and B are types
@@ -68,7 +68,7 @@
       c ;; k
 
     - Managing state:
-      put n := u ;; c
+      #put n := u ;; c
       x ← get n ;; c
       correspond respectively to updating and reading the state location n.
 
@@ -174,11 +174,11 @@ Module PackageNotation.
     format "[ interface  '[' x1  ;  '/' x2  ;  '/' ..  ;  '/' xn ']'  ]")
     : package_scope.
 
-  Notation "'val' #[ f ] : A → B" :=
+  Notation "'#val' #[ f ] : A → B" :=
     (f, (A, B))
     (in custom interface at level 0,
     f constr, A custom pack_type, B custom pack_type,
-    format "val  #[ f ]  :  A  →  B").
+    format "#val  #[ f ]  :  A  →  B").
 
   Notation "[ 'package' ]" :=
     (mkpackage (mkfmap [::]) _)
@@ -199,18 +199,18 @@ Module PackageNotation.
     format "[ package  '[' x1  ;  '/' x2  ;  '/' ..  ;  '/' xn  ']' ]")
     : package_scope.
 
-  Notation " 'def' #[ f ] ( x : A ) : B { e }" :=
+  Notation " '#def' #[ f ] ( x : A ) : B { e }" :=
     ((f, mkdef A B (λ x, e)))
     (in custom package at level 0,
     f constr, e constr, x name, A custom pack_type, B custom pack_type,
-    format "def  #[ f ]  ( x : A )  :  B  { '[' '/'  e  '/' ']' }")
+    format "#def  #[ f ]  ( x : A )  :  B  { '[' '/'  e  '/' ']' }")
     : package_scope.
 
-  Notation " 'def' #[ f ] ( ' p : A ) : B { e }" :=
+  Notation " '#def' #[ f ] ( ' p : A ) : B { e }" :=
     ((f, mkdef A B (λ x, let p := x in e)))
     (in custom package at level 0,
     f constr, e constr, p pattern, A custom pack_type, B custom pack_type,
-    format "def  #[ f ]  ( ' p : A )  :  B  { '[' '/'  e  '/' ']' }")
+    format "#def  #[ f ]  ( ' p : A )  :  B  { '[' '/'  e  '/' ']' }")
     : package_scope.
 
   Notation "#[ f ] : A → B" :=
@@ -242,10 +242,10 @@ Module PackageNotation.
     format "e1  ;;  '//' e2")
     : package_scope.
 
-  Notation "'put' n ':=' u ;; c" :=
+  Notation "'#put' n ':=' u ;; c" :=
     (putr n u c)
     (at level 100, u at next level, right associativity,
-    format "put  n  :=  u  ;;  '//' c")
+    format "#put  n  :=  u  ;;  '//' c")
     : package_scope.
 
   Notation "x ← 'get' n ;; c" :=
@@ -307,7 +307,6 @@ Module PackageNotation.
   (* TODO Use ;; for this, and a longer notation or none at all for
     bind. Bind is just a tool to compose codes while this is to compose
     commands and code, much more practical.
-    TODO: Maybe not add things such as get/put/cmd to the grammar.
   *)
   Notation "e1 ;' e2" :=
     (_ ← cmd e1 ;; e2)%pack
@@ -329,6 +328,6 @@ Module PackageNotation.
     cbn. exists n. exact h.
   Defined.
 
-  Notation gfin n := (@give_fin _ n _).
+  Notation gfin n := (@give_fin n _).
 
 End PackageNotation.

--- a/theories/Crypt/package/pkg_rhl.v
+++ b/theories/Crypt/package/pkg_rhl.v
@@ -1582,12 +1582,12 @@ Qed.
 Lemma r_put_lhs :
   ∀ {A B : choiceType} ℓ v r₀ r₁ (pre : precond) (post : postcond A B),
     ⊢ ⦃ λ '(s₀, s₁), (set_lhs ℓ v pre) (s₀, s₁) ⦄ r₀ ≈ r₁ ⦃ post ⦄ →
-    ⊢ ⦃ λ '(s₀, s₁), pre (s₀, s₁) ⦄ put ℓ := v ;; r₀ ≈ r₁ ⦃ post ⦄.
+    ⊢ ⦃ λ '(s₀, s₁), pre (s₀, s₁) ⦄ #put ℓ := v ;; r₀ ≈ r₁ ⦃ post ⦄.
 Proof.
   intros A B ℓ v r₀ r₁ pre post h.
   change (
     ⊢ ⦃ λ '(s₀, s₁), pre (s₀, s₁) ⦄
-      (put ℓ := v ;; ret Datatypes.tt) ;; r₀ ≈ ret Datatypes.tt ;; r₁
+      (#put ℓ := v ;; ret Datatypes.tt) ;; r₀ ≈ ret Datatypes.tt ;; r₁
     ⦃ post ⦄
   ).
   eapply r_bind with (mid :=
@@ -1611,12 +1611,12 @@ Qed.
 Lemma r_put_rhs :
   ∀ {A B : choiceType} ℓ v r₀ r₁ (pre : precond) (post : postcond A B),
     ⊢ ⦃ λ '(s₀, s₁), (set_rhs ℓ v pre) (s₀, s₁) ⦄ r₀ ≈ r₁ ⦃ post ⦄ →
-    ⊢ ⦃ λ '(s₀, s₁), pre (s₀, s₁) ⦄ r₀ ≈ put ℓ := v ;; r₁ ⦃ post ⦄.
+    ⊢ ⦃ λ '(s₀, s₁), pre (s₀, s₁) ⦄ r₀ ≈ #put ℓ := v ;; r₁ ⦃ post ⦄.
 Proof.
   intros A B ℓ v r₀ r₁ pre post h.
   change (
     ⊢ ⦃ λ '(s₀, s₁), pre (s₀, s₁) ⦄
-      ret Datatypes.tt ;; r₀ ≈ (put ℓ := v ;; ret Datatypes.tt) ;; r₁
+      ret Datatypes.tt ;; r₀ ≈ (#put ℓ := v ;; ret Datatypes.tt) ;; r₁
     ⦃ post ⦄
   ).
   eapply r_bind with (mid :=
@@ -1643,7 +1643,7 @@ Lemma r_put_vs_put :
       r₀ ≈ r₁
     ⦃ post ⦄ →
     ⊢ ⦃ λ '(s₀, s₁), pre (s₀, s₁) ⦄
-      put ℓ := v ;; r₀ ≈ put ℓ' := v' ;; r₁
+      #put ℓ := v ;; r₀ ≈ #put ℓ' := v' ;; r₁
     ⦃ post ⦄.
 Proof.
   intros A B ℓ v ℓ' v' r₀ r₁ pre post h.
@@ -2526,8 +2526,8 @@ Qed.
 Lemma contract_put :
   ∀ A ℓ v v' (r : raw_code A),
     ⊢ ⦃ λ '(h₀, h₁), h₀ = h₁ ⦄
-      put ℓ := v' ;; r ≈
-      put ℓ := v ;; put ℓ := v' ;; r
+      #put ℓ := v' ;; r ≈
+      #put ℓ := v ;; #put ℓ := v' ;; r
     ⦃ eq ⦄.
 Proof.
   intros A ℓ v v' r.
@@ -2546,8 +2546,8 @@ Lemma r_put_swap :
   ∀ ℓ ℓ' v v' (A : choiceType) (u : A),
     ℓ != ℓ' →
     ⊢ ⦃ λ '(h₀, h₁), h₀ = h₁ ⦄
-      put ℓ := v ;; put ℓ' := v' ;; ret u ≈
-      put ℓ' := v' ;; put ℓ := v ;; ret u
+      #put ℓ := v ;; #put ℓ' := v' ;; ret u ≈
+      #put ℓ' := v' ;; #put ℓ := v ;; ret u
     ⦃ eq ⦄.
 Proof.
   intros ℓ ℓ' v v' A u ne.
@@ -2588,8 +2588,8 @@ Lemma r_get_put_swap :
   ∀ ℓ ℓ' v,
     ℓ' != ℓ →
     ⊢ ⦃ λ '(h₀, h₁), h₀ = h₁ ⦄
-      x ← get ℓ' ;; put ℓ := v ;; ret x ≈
-      put ℓ := v ;; x ← get ℓ' ;; ret x
+      x ← get ℓ' ;; #put ℓ := v ;; ret x ≈
+      #put ℓ := v ;; x ← get ℓ' ;; ret x
     ⦃ eq ⦄.
 Proof.
   intros ℓ ℓ' v ne.
@@ -2632,8 +2632,8 @@ Lemma r_put_get_swap :
   ∀ ℓ ℓ' v,
     ℓ' != ℓ →
     ⊢ ⦃ λ '(h₀, h₁), h₀ = h₁ ⦄
-      put ℓ := v ;; x ← get ℓ' ;; ret x ≈
-      x ← get ℓ' ;; put ℓ := v ;; ret x
+      #put ℓ := v ;; x ← get ℓ' ;; ret x ≈
+      x ← get ℓ' ;; #put ℓ := v ;; ret x
     ⦃ eq ⦄.
 Proof.
   intros ℓ ℓ' v ne.
@@ -2647,8 +2647,8 @@ Lemma r_get_put_swap' :
   ∀ ℓ ℓ' v,
     ℓ' != ℓ →
     ⊢ ⦃ λ '(h₀, h₁), h₀ = h₁ ⦄
-      x ← get ℓ' ;; put ℓ := v ;; ret (x, Datatypes.tt) ≈
-      put ℓ := v ;; x ← get ℓ' ;; ret (x, Datatypes.tt)
+      x ← get ℓ' ;; #put ℓ := v ;; ret (x, Datatypes.tt) ≈
+      #put ℓ := v ;; x ← get ℓ' ;; ret (x, Datatypes.tt)
     ⦃ eq ⦄.
 Proof.
   intros ℓ ℓ' v ne.
@@ -2663,8 +2663,8 @@ Lemma r_put_get_swap' :
   ∀ ℓ ℓ' v,
     ℓ' != ℓ →
     ⊢ ⦃ λ '(h₀, h₁), h₀ = h₁ ⦄
-      put ℓ := v ;; x ← get ℓ' ;; ret (Datatypes.tt, x) ≈
-      x ← get ℓ' ;; put ℓ := v ;; ret (Datatypes.tt, x)
+      #put ℓ := v ;; x ← get ℓ' ;; ret (Datatypes.tt, x) ≈
+      x ← get ℓ' ;; #put ℓ := v ;; ret (Datatypes.tt, x)
     ⦃ eq ⦄.
 Proof.
   intros ℓ ℓ' v ne.
@@ -2678,8 +2678,8 @@ Qed.
 Lemma r_put_get :
   ∀ A ℓ v (r : _ → raw_code A),
     ⊢ ⦃ λ '(h₀, h₁), h₀ = h₁ ⦄
-      put ℓ := v ;; r v ≈
-      put ℓ := v ;; x ← get ℓ ;; r x
+      #put ℓ := v ;; r v ≈
+      #put ℓ := v ;; x ← get ℓ ;; r x
     ⦃ eq ⦄.
 Proof.
   intros A ℓ v r.

--- a/theories/Crypt/package/pkg_user_util.v
+++ b/theories/Crypt/package/pkg_user_util.v
@@ -230,7 +230,7 @@ Ltac ssprove_match_commut_gen1 :=
       let x' := fresh x in
       eapply (f_equal (getr _)) ;
       eapply functional_extensionality with (f := λ x', _) ; intro x'
-    | put ?ℓ := ?v ;; _ =>
+    | #put ?ℓ := ?v ;; _ =>
       eapply (f_equal (putr _ _))
     | @assertD ?A ?b (λ x, _) =>
       let x' := fresh x in
@@ -296,7 +296,7 @@ Ltac ssprove_code_simpl :=
 Ltac cmd_bind_simpl_once :=
   try change (cmd_bind (cmd_sample ?op) ?k) with (sampler op k) ;
   try change (cmd_bind (cmd_get ?ℓ) ?k) with (getr ℓ k) ;
-  try change (cmd_bind (cmd_put ?ℓ ?v) ?k) with (put ℓ := v ;; k Datatypes.tt).
+  try change (cmd_bind (cmd_put ?ℓ ?v) ?k) with (#put ℓ := v ;; k Datatypes.tt).
 
 Ltac cmd_bind_simpl :=
   repeat cmd_bind_simpl_once.
@@ -312,7 +312,7 @@ Ltac ssprove_sync_eq :=
     lazymatch c with
     | x ← sample ?op ;; _ =>
       eapply (rsame_head_cmd (cmd_sample op))
-    | put ?ℓ := ?v ;; _ =>
+    | #put ?ℓ := ?v ;; _ =>
       eapply (@rsame_head_cmd _ _ (λ z, _) (λ z, _) (cmd_put ℓ v)) ; intros _
     | x ← get ?ℓ ;; _ =>
       eapply (rsame_head_cmd (cmd_get ℓ))
@@ -355,7 +355,7 @@ Ltac ssprove_sync :=
         eapply cmd_sample_preserve_pre
       | idtac
       ]
-    | put ?ℓ := ?v ;; _ =>
+    | #put ?ℓ := ?v ;; _ =>
       eapply (@rsame_head_cmd_alt _ _ (λ z, _) (λ z, _) (cmd_put ℓ v)) ; [
         eapply cmd_put_preserve_pre ; ssprove_invariant
       | intros _
@@ -385,31 +385,31 @@ Ltac ssprove_rswap_cmd_eq_rhs :=
       eapply (rswap_cmd_eq _ _ _ (cmd_sample op') (cmd_sample op))
     | x ← sample ?op ;; y ← get ?ℓ ;;  _ =>
       eapply (rswap_cmd_eq _ _ _ (cmd_get ℓ) (cmd_sample op))
-    | x ← sample ?op ;; put ?ℓ := ?v ;;  _ =>
+    | x ← sample ?op ;; #put ?ℓ := ?v ;;  _ =>
       eapply (rswap_cmd_eq _ _ _ (cmd_put ℓ v) (cmd_sample op) (λ x y, _))
     | x ← get ?ℓ ;; y ← sample ?op ;;  _ =>
       eapply (rswap_cmd_eq _ _ _ (cmd_sample op) (cmd_get ℓ))
     | x ← get ?ℓ ;; y ← get ?ℓ' ;;  _ =>
       eapply (rswap_cmd_eq _ _ _ (cmd_get ℓ') (cmd_get ℓ))
-    | x ← get ?ℓ ;; put ?ℓ' := ?v ;;  _ =>
+    | x ← get ?ℓ ;; #put ?ℓ' := ?v ;;  _ =>
       eapply (rswap_cmd_eq _ _ _ (cmd_put ℓ' v) (cmd_get ℓ) (λ x y, _))
-    | put ?ℓ := ?v ;; x ← sample ?op ;;  _ =>
+    | #put ?ℓ := ?v ;; x ← sample ?op ;;  _ =>
       eapply (rswap_cmd_eq _ _ _ (cmd_sample op) (cmd_put ℓ v) (λ x y, _))
-    | put ?ℓ := ?v ;; x ← get ?ℓ' ;;  _ =>
+    | #put ?ℓ := ?v ;; x ← get ?ℓ' ;;  _ =>
       eapply (rswap_cmd_eq _ _ _ (cmd_get ℓ') (cmd_put ℓ v) (λ x y, _))
-    | put ?ℓ := ?v ;; put ?ℓ' := ?v' ;;  _ =>
+    | #put ?ℓ := ?v ;; #put ?ℓ' := ?v' ;;  _ =>
       eapply (rswap_cmd_eq _ _ _ (cmd_put ℓ' v') (cmd_put ℓ v) (λ x y, _))
     | @assertD ?A ?b (λ e, x ← sample ?op ;; _) =>
       eapply (rswap_cmd_assertD_eq _ A b (cmd_sample op) (λ x y, _))
     | @assertD ?A ?b (λ e, x ← get ?ℓ ;; _) =>
       eapply (rswap_cmd_assertD_eq _ A b (cmd_get ℓ) (λ x y, _))
-    | @assertD ?A ?b (λ e, put ?ℓ := ?v ;; _) =>
+    | @assertD ?A ?b (λ e, #put ?ℓ := ?v ;; _) =>
       eapply (rswap_cmd_assertD_eq _ A b (cmd_put ℓ v) (λ x y, _))
     | x ← sample ?op ;; @assertD ?A ?b _ =>
       eapply (rswap_assertD_cmd_eq _ A b (cmd_sample op) (λ x y, _))
     | x ← get ?ℓ ;; @assertD ?A ?b _ =>
       eapply (rswap_assertD_cmd_eq _ A b (cmd_get ℓ) (λ x y, _))
-    | put ?ℓ := ?v ;; @assertD ?A ?b _ =>
+    | #put ?ℓ := ?v ;; @assertD ?A ?b _ =>
       eapply (rswap_assertD_cmd_eq _ A b (cmd_put ℓ v) (λ x y, _))
     | @assertD ?A ?b (λ e, #assert _ as e' ;; _) =>
       eapply (rswap_assertD_assertD_eq A _ _ (λ e' e, _))
@@ -417,13 +417,13 @@ Ltac ssprove_rswap_cmd_eq_rhs :=
       eapply (rswap_cmd_bind_eq (cmd_sample op) c)
     | x ← ?c ;; y ← get ?ℓ ;; _ =>
       eapply (rswap_cmd_bind_eq (cmd_get ℓ) c)
-    | x ← ?c ;; put ?ℓ := ?v ;; _ =>
+    | x ← ?c ;; #put ?ℓ := ?v ;; _ =>
       eapply (rswap_cmd_bind_eq (cmd_put ℓ v) c (λ x y, _))
     | x ← sample ?op ;; y ← ?c ;; _ =>
       eapply (rswap_bind_cmd_eq c (cmd_sample op))
     | x ← get ?ℓ ;; y ← ?c ;; _ =>
       eapply (rswap_bind_cmd_eq c (cmd_get ℓ))
-    | put ?ℓ := ?v ;; y ← ?c ;; _ =>
+    | #put ?ℓ := ?v ;; y ← ?c ;; _ =>
       eapply (rswap_bind_cmd_eq c (cmd_put ℓ v) (λ x y, _))
     | _ => fail "No swappable pair found."
     end
@@ -618,7 +618,7 @@ Ltac ssprove_code_simpl_more_aux :=
     | x ← sample ?op ;; _ =>
       let x' := fresh x in
       ssprove_sync_eq ; intro x'
-    | put ?ℓ := ?v ;; _ =>
+    | #put ?ℓ := ?v ;; _ =>
       ssprove_sync_eq
     | x ← get ?ℓ ;; _ =>
       let x' := fresh x in


### PR DESCRIPTION
This was something we needed to do and which will help avoid conflicts in the grammar.
For instance, with the notations imported it was impossible to define or to refer to anything named `val`.