### PR TITLE
Rename chUniverse to choice_type

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -38,7 +38,7 @@ will expose below.
 
 The main notion of code is defined as the type `raw_code A` which represents
 a program returning a value of type `A`. This type `A` is typically—but not
-limited to—of type `chUniverse`.
+limited to—of type `choice_code`.
 
 
 Before detailing how to construct them, here is a first example with no
@@ -83,7 +83,7 @@ Injects any pure value into `raw_code`.
 
 #### Memory access
 
-A `Location` is a pair of a type in `chUniverse` and a natural number
+A `Location` is a pair of a type in `choice_code` and a natural number
 representing an identifier, for instance `('nat ; 12) : Location`.
 One can *read* memory as follows:
 ```coq
@@ -111,7 +111,7 @@ Here `op : Op` is a (sub-)distribution. See [Distributions].
 
 #### Failure
 ```coq
-fail : ∀ {A : chUniverse}, raw_code A
+fail : ∀ {A : choice_code}, raw_code A
 ```
 Represents a failure in a program. It is obtained by sampling on the null
 sub-distribution.
@@ -162,7 +162,7 @@ constructions when `v` is concrete.
 
 ### Specialised types
 
-We have a special type called `chUniverse` which contains *codes* for specific
+We have a special type called `choice_code` which contains *codes* for specific
 types that we use in our packages. These are the types used in `Location`
 and in `opsig` or even in `Op`.
 
@@ -196,7 +196,7 @@ When defining signatures (`opsig`), interfaces (see [Valid code]), or packages
 #### Signatures
 
 A signature (`opsig`) is given by an identifier (a natural number), an
-argument type and a return type (both in `chUniverse`).
+argument type and a return type (both in `choice_code`).
 Once can for instance write `(37, ('nat, chProd 'unit 'unit))`.
 
 We provide the following nicer notation:
@@ -207,7 +207,7 @@ We provide the following nicer notation:
 ### Distributions
 
 The user can sample using pretty much any distribution that can be expressed
-in `mathcomp-analysis` provided that its support is in `chUniverse`.
+in `mathcomp-analysis` provided that its support is in `choice_code`.
 Writing them by hand might not be very convenient.
 
 For the time being we provide `uniform n` which represents a uniform
@@ -251,7 +251,7 @@ where the `dᵢ` are signatures, given using a special syntax:
 val #[ id ] : src → tgt
 ```
 where `id` is a natural number / identifier, and `src` and `tgt` are codes of
-types in `chUniverse` given using the special syntax (see [Specialised types]).
+types in `choice_code` given using the special syntax (see [Specialised types]).
 
 Here are examples of interfaces:
 ```coq
@@ -369,7 +369,7 @@ where the `dᵢ` are declarations, given using a special syntax:
 def #[ id ] (x : src) : tgt { e }
 ```
 where `id` is a natural number / identifier, and `src` and `tgt` are codes of
-types in `chUniverse` given using the special syntax (see [Specialised types]),
+types in `choice_code` given using the special syntax (see [Specialised types]),
 while `e` is a regular Coq expression corresponding to the body of the function,
 with `x` bound inside it.
 As seen in the example, `x` can be matched against in the declaration by using

--- a/DOC.md
+++ b/DOC.md
@@ -38,7 +38,7 @@ will expose below.
 
 The main notion of code is defined as the type `raw_code A` which represents
 a program returning a value of type `A`. This type `A` is typically—but not
-limited to—of type `choice_code`.
+limited to—of type `choice_type`.
 
 
 Before detailing how to construct them, here is a first example with no
@@ -83,7 +83,7 @@ Injects any pure value into `raw_code`.
 
 #### Memory access
 
-A `Location` is a pair of a type in `choice_code` and a natural number
+A `Location` is a pair of a type in `choice_type` and a natural number
 representing an identifier, for instance `('nat ; 12) : Location`.
 One can *read* memory as follows:
 ```coq
@@ -111,7 +111,7 @@ Here `op : Op` is a (sub-)distribution. See [Distributions].
 
 #### Failure
 ```coq
-fail : ∀ {A : choice_code}, raw_code A
+fail : ∀ {A : choice_type}, raw_code A
 ```
 Represents a failure in a program. It is obtained by sampling on the null
 sub-distribution.
@@ -162,7 +162,7 @@ constructions when `v` is concrete.
 
 ### Specialised types
 
-We have a special type called `choice_code` which contains *codes* for specific
+We have a special type called `choice_type` which contains *codes* for specific
 types that we use in our packages. These are the types used in `Location`
 and in `opsig` or even in `Op`.
 
@@ -196,7 +196,7 @@ When defining signatures (`opsig`), interfaces (see [Valid code]), or packages
 #### Signatures
 
 A signature (`opsig`) is given by an identifier (a natural number), an
-argument type and a return type (both in `choice_code`).
+argument type and a return type (both in `choice_type`).
 Once can for instance write `(37, ('nat, chProd 'unit 'unit))`.
 
 We provide the following nicer notation:
@@ -207,7 +207,7 @@ We provide the following nicer notation:
 ### Distributions
 
 The user can sample using pretty much any distribution that can be expressed
-in `mathcomp-analysis` provided that its support is in `choice_code`.
+in `mathcomp-analysis` provided that its support is in `choice_type`.
 Writing them by hand might not be very convenient.
 
 For the time being we provide `uniform n` which represents a uniform
@@ -251,7 +251,7 @@ where the `dᵢ` are signatures, given using a special syntax:
 val #[ id ] : src → tgt
 ```
 where `id` is a natural number / identifier, and `src` and `tgt` are codes of
-types in `choice_code` given using the special syntax (see [Specialised types]).
+types in `choice_type` given using the special syntax (see [Specialised types]).
 
 Here are examples of interfaces:
 ```coq
@@ -369,7 +369,7 @@ where the `dᵢ` are declarations, given using a special syntax:
 def #[ id ] (x : src) : tgt { e }
 ```
 where `id` is a natural number / identifier, and `src` and `tgt` are codes of
-types in `choice_code` given using the special syntax (see [Specialised types]),
+types in `choice_type` given using the special syntax (see [Specialised types]),
 while `e` is a regular Coq expression corresponding to the body of the function,
 with `x` bound inside it.
 As seen in the example, `x` can be matched against in the declaration by using

--- a/_CoqProject
+++ b/_CoqProject
@@ -22,7 +22,7 @@ theories/Relational/Commutativity.v
 
 theories/Crypt/Prelude.v
 theories/Crypt/Axioms.v
-theories/Crypt/choice_code.v
+theories/Crypt/choice_type.v
 
 # Categorical semantics
 

--- a/_CoqProject
+++ b/_CoqProject
@@ -22,7 +22,7 @@ theories/Relational/Commutativity.v
 
 theories/Crypt/Prelude.v
 theories/Crypt/Axioms.v
-theories/Crypt/chUniverse.v
+theories/Crypt/choice_code.v
 
 # Categorical semantics
 

--- a/theories/Crypt/Package.v
+++ b/theories/Crypt/Package.v
@@ -1,4 +1,4 @@
 From Crypt Require Export
-  chUniverse pkg_core_definition pkg_tactics pkg_semantics pkg_lookup
+  choice_code pkg_core_definition pkg_tactics pkg_semantics pkg_lookup
   pkg_advantage pkg_heap pkg_distr pkg_invariants pkg_rhl pkg_user_util
   pkg_notation.

--- a/theories/Crypt/Package.v
+++ b/theories/Crypt/Package.v
@@ -1,4 +1,4 @@
 From Crypt Require Export
-  choice_code pkg_core_definition pkg_tactics pkg_semantics pkg_lookup
+  choice_type pkg_core_definition pkg_tactics pkg_semantics pkg_lookup
   pkg_advantage pkg_heap pkg_distr pkg_invariants pkg_rhl pkg_user_util
   pkg_notation.

--- a/theories/Crypt/choice_code.v
+++ b/theories/Crypt/choice_code.v
@@ -1,6 +1,8 @@
-(*
-  This file defines an inductive type [chUniverse] and a total order on that type, which
-  is then used to show that [chUniverse] forms a [choiceType].
+(**
+  This file defines an inductive type [choice_code] corresponding to codes for
+  choice types.
+  We give a total order on this type, which is then used to show that
+  [choice_code] forms a [choiceType].
  *)
 
 
@@ -31,16 +33,16 @@ Open Scope type_scope.
 
 (* Basic structure *)
 
-Inductive chUniverse :=
+Inductive choice_code :=
 | chUnit
 | chNat
 | chBool
-| chProd (A B : chUniverse)
-| chMap (A B : chUniverse)
-| chOption (A : chUniverse)
+| chProd (A B : choice_code)
+| chMap (A B : choice_code)
+| chOption (A : choice_code)
 | chFin (n : positive).
 
-Derive NoConfusion NoConfusionHom for chUniverse.
+Derive NoConfusion NoConfusionHom for choice_code.
 
 (* Definition void_leq (x y : void) := true. *)
 
@@ -50,7 +52,7 @@ Derive NoConfusion NoConfusionHom for chUniverse.
 (* Definition void_ordMixin := OrdMixin void_leqP. *)
 (* Canonical void_ordType := Eval hnf in OrdType void void_ordMixin. *)
 
-Fixpoint chElement_ordType (U : chUniverse) : ordType :=
+Fixpoint chElement_ordType (U : choice_code) : ordType :=
   match U with
   | chUnit => unit_ordType
   | chNat => nat_ordType
@@ -61,7 +63,7 @@ Fixpoint chElement_ordType (U : chUniverse) : ordType :=
   | chFin n => [ordType of ordinal n.(pos) ]
   end.
 
-Fixpoint chElement (U : chUniverse) : choiceType :=
+Fixpoint chElement (U : choice_code) : choiceType :=
   match U with
   | chUnit => unit_choiceType
   | chNat => nat_choiceType
@@ -72,10 +74,10 @@ Fixpoint chElement (U : chUniverse) : choiceType :=
   | chFin n => [choiceType of ordinal n.(pos) ]
   end.
 
-Coercion chElement : chUniverse >-> choiceType.
+Coercion chElement : choice_code >-> choiceType.
 
-(* Canonical element in a type of the chUniverse *)
-#[program] Fixpoint chCanonical (T : chUniverse) : T :=
+(* Canonical element in a type of the choice_code *)
+#[program] Fixpoint chCanonical (T : choice_code) : T :=
   match T with
   | chUnit => Datatypes.tt
   | chNat => 0
@@ -93,24 +95,24 @@ Next Obligation.
   unfold Positive in h. auto.
 Defined.
 
-Section chUniverseTypes.
+Section choice_codeTypes.
 
-  Fixpoint chUniverse_test (u v : chUniverse) : bool :=
+  Fixpoint choice_code_test (u v : choice_code) : bool :=
     match u, v with
     | chNat , chNat => true
     | chUnit , chUnit => true
     | chBool , chBool => true
-    | chProd a b , chProd a' b' => chUniverse_test a a' && chUniverse_test b b'
-    | chMap a b , chMap a' b' => chUniverse_test a a' && chUniverse_test b b'
-    | chOption a, chOption a' => chUniverse_test a a'
+    | chProd a b , chProd a' b' => choice_code_test a a' && choice_code_test b b'
+    | chMap a b , chMap a' b' => choice_code_test a a' && choice_code_test b b'
+    | chOption a, chOption a' => choice_code_test a a'
     | chFin n, chFin n' => n == n'
     | _ , _ => false
     end.
 
-  Definition chUniverse_eq : rel chUniverse :=
-    fun u v => chUniverse_test u v.
+  Definition choice_code_eq : rel choice_code :=
+    fun u v => choice_code_test u v.
 
-  Lemma chUniverse_eqP : Equality.axiom chUniverse_eq.
+  Lemma choice_code_eqP : Equality.axiom choice_code_eq.
   Proof.
     move=> x y.
     induction x as [ | | | x1 ih1 x2 ih2 | x1 ih1 x2 ih2 | x1 ih1 | x1]
@@ -139,19 +141,19 @@ Section chUniverseTypes.
         apply e. inversion h. reflexivity.
   Qed.
 
-  Lemma chUniverse_refl :
-    ∀ u, chUniverse_eq u u.
+  Lemma choice_code_refl :
+    ∀ u, choice_code_eq u u.
   Proof.
-    intros u. destruct chUniverse_eq eqn:e.
+    intros u. destruct choice_code_eq eqn:e.
     - constructor.
-    - move: e => /chUniverse_eqP []. reflexivity.
+    - move: e => /choice_code_eqP []. reflexivity.
   Qed.
 
-  Canonical chUniverse_eqMixin := EqMixin chUniverse_eqP.
-  Canonical chUniverse_eqType :=
-    Eval hnf in EqType chUniverse chUniverse_eqMixin.
+  Canonical choice_code_eqMixin := EqMixin choice_code_eqP.
+  Canonical choice_code_eqType :=
+    Eval hnf in EqType choice_code choice_code_eqMixin.
 
-  Fixpoint chUniverse_lt (t1 t2 : chUniverse) :=
+  Fixpoint choice_code_lt (t1 t2 : choice_code) :=
   match t1, t2 with
   | chUnit, chUnit => false
   | chUnit, _ => true
@@ -166,23 +168,23 @@ Section chUniverseTypes.
   | chProd _ _, chBool => false
   | chProd _ _, chNat => false
   | chProd u1 u2, chProd w1 w2 =>
-    (chUniverse_lt u1 w1) ||
-    (chUniverse_eq u1 w1 && chUniverse_lt u2 w2)
+    (choice_code_lt u1 w1) ||
+    (choice_code_eq u1 w1 && choice_code_lt u2 w2)
   | chProd _ _, _ => true
   | chMap _ _, chUnit => false
   | chMap _ _, chBool => false
   | chMap _ _, chNat => false
   | chMap _ _, chProd _ _ => false
   | chMap u1 u2, chMap w1 w2 =>
-    (chUniverse_lt u1 w1) ||
-    (chUniverse_eq u1 w1 && chUniverse_lt u2 w2)
+    (choice_code_lt u1 w1) ||
+    (choice_code_eq u1 w1 && choice_code_lt u2 w2)
   | chMap _ _, _ => true
   | chOption _, chUnit => false
   | chOption _, chBool => false
   | chOption _, chNat => false
   | chOption _, chProd _ _ => false
   | chOption _, chMap _ _ => false
-  | chOption u, chOption w => chUniverse_lt u w
+  | chOption u, chOption w => choice_code_lt u w
   | chOption _, _ => true
   | chFin n, chUnit => false
   | chFin n, chBool => false
@@ -193,10 +195,10 @@ Section chUniverseTypes.
   | chFin n, chFin n' => n < n'
   end.
 
-  Definition chUniverse_leq (t1 t2 : chUniverse) :=
-    chUniverse_eq t1 t2 || chUniverse_lt t1 t2.
+  Definition choice_code_leq (t1 t2 : choice_code) :=
+    choice_code_eq t1 t2 || choice_code_lt t1 t2.
 
-  Lemma chUniverse_lt_transitive : transitive (T:=chUniverse) chUniverse_lt.
+  Lemma choice_code_lt_transitive : transitive (T:=choice_code) choice_code_lt.
   Proof.
     intros v u w h1 h2.
     induction u as [ | | | u1 ih1 u2 ih2 | u1 ih1 u2 ih2 | u ih | u]
@@ -247,8 +249,8 @@ Section chUniverseTypes.
       eapply ltn_trans. all: eauto.
   Qed.
 
-  Lemma chUniverse_lt_areflexive :
-    ∀ x, ~~ chUniverse_lt x x.
+  Lemma choice_code_lt_areflexive :
+    ∀ x, ~~ choice_code_lt x x.
   Proof.
     intros x.
     induction x as [ | | | x1 ih1 x2 ih2 | x1 ih1 x2 ih2 | x ih | x] in |- *.
@@ -266,9 +268,9 @@ Section chUniverseTypes.
     - rewrite ltnn. auto.
   Qed.
 
-  Lemma chUniverse_lt_total_holds :
+  Lemma choice_code_lt_total_holds :
     ∀ x y,
-      ~~ (chUniverse_test x y) ==> (chUniverse_lt x y || chUniverse_lt y x).
+      ~~ (choice_code_test x y) ==> (choice_code_lt x y || choice_code_lt y x).
   Proof.
     intros x y.
     induction x as [ | | | x1 ih1 x2 ih2| x1 ih1 x2 ih2| x ih| x]
@@ -280,7 +282,7 @@ Section chUniverseTypes.
       apply/implyP.
       move /nandP => H.
       apply/orP.
-      destruct (chUniverse_test x1 y1) eqn:Heq.
+      destruct (choice_code_test x1 y1) eqn:Heq.
       + destruct H. 1: discriminate.
         move: ih2. move /implyP => ih2.
         specialize (ih2 H).
@@ -315,7 +317,7 @@ Section chUniverseTypes.
       apply/implyP.
       move /nandP => H.
       apply/orP.
-      destruct (chUniverse_test x1 y1) eqn:Heq.
+      destruct (choice_code_test x1 y1) eqn:Heq.
       + destruct H. 1: discriminate.
         move: ih2. move /implyP => ih2.
         specialize (ih2 H).
@@ -345,64 +347,64 @@ Section chUniverseTypes.
               +++ left. apply/orP. left. assumption.
               +++ right. apply/orP. left. assumption.
     - destruct y. all: try (intuition; reflexivity).
-      unfold chUniverse_lt.
-      unfold chUniverse_test.
+      unfold choice_code_lt.
+      unfold choice_code_test.
       rewrite -neq_ltn.
       apply /implyP. auto.
   Qed.
 
-  Lemma chUniverse_lt_asymmetric :
+  Lemma choice_code_lt_asymmetric :
     ∀ x y,
-      (chUniverse_lt x y ==> ~~ chUniverse_lt y x).
+      (choice_code_lt x y ==> ~~ choice_code_lt y x).
   Proof.
     intros x y.
     apply /implyP. move => H.
-    destruct (~~ chUniverse_lt y x) eqn:Heq.
+    destruct (~~ choice_code_lt y x) eqn:Heq.
     - intuition.
     - move: Heq. move /negP /negP => Heq.
-      pose  (chUniverse_lt_areflexive x) as Harefl.
+      pose  (choice_code_lt_areflexive x) as Harefl.
       move: Harefl. apply /implyP. rewrite implyNb.
       apply /orP. left.
-      apply (chUniverse_lt_transitive _ _ _ H Heq).
+      apply (choice_code_lt_transitive _ _ _ H Heq).
   Qed.
 
-  Lemma chUniverse_lt_total_not_holds :
+  Lemma choice_code_lt_total_not_holds :
     ∀ x y,
-      ~~ (chUniverse_test x y) ==> (~~ (chUniverse_lt x y && chUniverse_lt y x)).
+      ~~ (choice_code_test x y) ==> (~~ (choice_code_lt x y && choice_code_lt y x)).
   Proof.
     intros x y. apply /implyP. intros Hneq.
-    pose (chUniverse_lt_total_holds x y) as Htot.
+    pose (choice_code_lt_total_holds x y) as Htot.
     move: Htot. move /implyP => Htot. specialize (Htot Hneq).
     move: Htot. move /orP => Htot. apply /nandP. destruct Htot.
-    - right. pose (chUniverse_lt_asymmetric x y) as Hasym.
+    - right. pose (choice_code_lt_asymmetric x y) as Hasym.
       move: Hasym. move /implyP => Hasym. specialize (Hasym H). assumption.
-    - left. pose (chUniverse_lt_asymmetric y x) as Hasym.
+    - left. pose (choice_code_lt_asymmetric y x) as Hasym.
       move: Hasym. move /implyP => Hasym. specialize (Hasym H). assumption.
   Qed.
 
-  Lemma chUniverse_lt_tot :
+  Lemma choice_code_lt_tot :
     ∀ x y,
-      (chUniverse_lt x y || chUniverse_lt y x || chUniverse_eq x y).
+      (choice_code_lt x y || choice_code_lt y x || choice_code_eq x y).
   Proof.
     intros x y.
-    destruct (chUniverse_eq x y) eqn:H.
+    destruct (choice_code_eq x y) eqn:H.
     - intuition.
     - apply/orP.
       left.
-      unfold chUniverse_eq in H.
-      pose (chUniverse_lt_total_holds x y).
+      unfold choice_code_eq in H.
+      pose (choice_code_lt_total_holds x y).
       move: i. move /implyP => i.
       apply i. apply/negP.
       intuition. move: H0. rewrite H. intuition.
   Qed.
 
-  Lemma chUniverse_leqP : Ord.axioms chUniverse_leq.
+  Lemma choice_code_leqP : Ord.axioms choice_code_leq.
   Proof.
     split => //.
-    - intro x. unfold chUniverse_leq.
+    - intro x. unfold choice_code_leq.
       apply/orP. left. apply /eqP. reflexivity.
     - intros v u w h1 h2.
-      move: h1 h2. unfold chUniverse_leq.
+      move: h1 h2. unfold choice_code_leq.
       move /orP => h1. move /orP => h2.
       destruct h1.
       + move: H. move /eqP => H. destruct H.
@@ -410,18 +412,18 @@ Section chUniverseTypes.
       + destruct h2.
         * move: H0. move /eqP => H0. destruct H0.
           apply/orP. right. assumption.
-        * apply/orP. right. exact (chUniverse_lt_transitive _ _ _ H H0).
+        * apply/orP. right. exact (choice_code_lt_transitive _ _ _ H H0).
     - unfold antisymmetric.
-      move => x y. unfold chUniverse_leq. move/andP => [h1 h2].
-      move: h1 h2. unfold chUniverse_leq.
+      move => x y. unfold choice_code_leq. move/andP => [h1 h2].
+      move: h1 h2. unfold choice_code_leq.
       move /orP => h1. move /orP => h2.
       destruct h1.
       1:{ move: H. move /eqP. intuition auto. }
       destruct h2.
       1:{ move: H0. move /eqP. intuition auto. }
-      destruct (~~ (chUniverse_test x y)) eqn:Heq.
+      destruct (~~ (choice_code_test x y)) eqn:Heq.
       + move: Heq. move /idP => Heq.
-        pose (chUniverse_lt_total_not_holds x y) as Hp.
+        pose (choice_code_lt_total_not_holds x y) as Hp.
         move: Hp. move /implyP => Hp. specialize (Hp Heq).
         move: Hp. move /nandP => Hp.
         destruct Hp.
@@ -431,8 +433,8 @@ Section chUniverseTypes.
           discriminate.
       + move: Heq. move /eqP. auto.
     - unfold total.
-      intros x y. unfold chUniverse_leq.
-      pose (chUniverse_lt_tot x y).
+      intros x y. unfold choice_code_leq.
+      pose (choice_code_lt_tot x y).
       move: i. move /orP => H.
       destruct H.
       + move: H. move /orP => H.
@@ -443,7 +445,7 @@ Section chUniverseTypes.
   Qed.
 
 
-  Fixpoint encode (t : chUniverse) : GenTree.tree nat :=
+  Fixpoint encode (t : choice_code) : GenTree.tree nat :=
   match t with
   | chUnit => GenTree.Leaf 1
   | chBool => GenTree.Leaf 2
@@ -454,7 +456,7 @@ Section chUniverseTypes.
   | chFin n => GenTree.Leaf ((4 + n) - 1)%N
   end.
 
-  Fixpoint decode (t : GenTree.tree nat) : option chUniverse :=
+  Fixpoint decode (t : GenTree.tree nat) : option choice_code :=
     match t with
     | GenTree.Leaf 1 => Some chUnit
     | GenTree.Leaf 2 => Some chBool
@@ -494,12 +496,12 @@ Section chUniverseTypes.
         rewrite -subnE subn0. repeat f_equal. apply eq_irrelevance.
   Defined.
 
-  Definition chUniverse_choiceMixin := PcanChoiceMixin codeK.
-  Canonical chUniverse_choiceType :=
-    ChoiceType chUniverse chUniverse_choiceMixin.
+  Definition choice_code_choiceMixin := PcanChoiceMixin codeK.
+  Canonical choice_code_choiceType :=
+    ChoiceType choice_code choice_code_choiceMixin.
 
-  Definition chUniverse_ordMixin := OrdMixin chUniverse_leqP.
-  Canonical chUniverse_ordType :=
-    Eval hnf in OrdType chUniverse chUniverse_ordMixin.
+  Definition choice_code_ordMixin := OrdMixin choice_code_leqP.
+  Canonical choice_code_ordType :=
+    Eval hnf in OrdType choice_code choice_code_ordMixin.
 
-End chUniverseTypes.
+End choice_codeTypes.

--- a/theories/Crypt/choice_type.v
+++ b/theories/Crypt/choice_type.v
@@ -1,8 +1,8 @@
 (**
-  This file defines an inductive type [choice_code] corresponding to codes for
+  This file defines an inductive type [choice_type] corresponding to codes for
   choice types.
   We give a total order on this type, which is then used to show that
-  [choice_code] forms a [choiceType].
+  [choice_type] forms a [choiceType].
  *)
 
 
@@ -33,16 +33,16 @@ Open Scope type_scope.
 
 (* Basic structure *)
 
-Inductive choice_code :=
+Inductive choice_type :=
 | chUnit
 | chNat
 | chBool
-| chProd (A B : choice_code)
-| chMap (A B : choice_code)
-| chOption (A : choice_code)
+| chProd (A B : choice_type)
+| chMap (A B : choice_type)
+| chOption (A : choice_type)
 | chFin (n : positive).
 
-Derive NoConfusion NoConfusionHom for choice_code.
+Derive NoConfusion NoConfusionHom for choice_type.
 
 (* Definition void_leq (x y : void) := true. *)
 
@@ -52,7 +52,7 @@ Derive NoConfusion NoConfusionHom for choice_code.
 (* Definition void_ordMixin := OrdMixin void_leqP. *)
 (* Canonical void_ordType := Eval hnf in OrdType void void_ordMixin. *)
 
-Fixpoint chElement_ordType (U : choice_code) : ordType :=
+Fixpoint chElement_ordType (U : choice_type) : ordType :=
   match U with
   | chUnit => unit_ordType
   | chNat => nat_ordType
@@ -63,7 +63,7 @@ Fixpoint chElement_ordType (U : choice_code) : ordType :=
   | chFin n => [ordType of ordinal n.(pos) ]
   end.
 
-Fixpoint chElement (U : choice_code) : choiceType :=
+Fixpoint chElement (U : choice_type) : choiceType :=
   match U with
   | chUnit => unit_choiceType
   | chNat => nat_choiceType
@@ -74,10 +74,10 @@ Fixpoint chElement (U : choice_code) : choiceType :=
   | chFin n => [choiceType of ordinal n.(pos) ]
   end.
 
-Coercion chElement : choice_code >-> choiceType.
+Coercion chElement : choice_type >-> choiceType.
 
-(* Canonical element in a type of the choice_code *)
-#[program] Fixpoint chCanonical (T : choice_code) : T :=
+(* Canonical element in a type of the choice_type *)
+#[program] Fixpoint chCanonical (T : choice_type) : T :=
   match T with
   | chUnit => Datatypes.tt
   | chNat => 0
@@ -95,24 +95,24 @@ Next Obligation.
   unfold Positive in h. auto.
 Defined.
 
-Section choice_codeTypes.
+Section choice_typeTypes.
 
-  Fixpoint choice_code_test (u v : choice_code) : bool :=
+  Fixpoint choice_type_test (u v : choice_type) : bool :=
     match u, v with
     | chNat , chNat => true
     | chUnit , chUnit => true
     | chBool , chBool => true
-    | chProd a b , chProd a' b' => choice_code_test a a' && choice_code_test b b'
-    | chMap a b , chMap a' b' => choice_code_test a a' && choice_code_test b b'
-    | chOption a, chOption a' => choice_code_test a a'
+    | chProd a b , chProd a' b' => choice_type_test a a' && choice_type_test b b'
+    | chMap a b , chMap a' b' => choice_type_test a a' && choice_type_test b b'
+    | chOption a, chOption a' => choice_type_test a a'
     | chFin n, chFin n' => n == n'
     | _ , _ => false
     end.
 
-  Definition choice_code_eq : rel choice_code :=
-    fun u v => choice_code_test u v.
+  Definition choice_type_eq : rel choice_type :=
+    fun u v => choice_type_test u v.
 
-  Lemma choice_code_eqP : Equality.axiom choice_code_eq.
+  Lemma choice_type_eqP : Equality.axiom choice_type_eq.
   Proof.
     move=> x y.
     induction x as [ | | | x1 ih1 x2 ih2 | x1 ih1 x2 ih2 | x1 ih1 | x1]
@@ -141,19 +141,19 @@ Section choice_codeTypes.
         apply e. inversion h. reflexivity.
   Qed.
 
-  Lemma choice_code_refl :
-    ∀ u, choice_code_eq u u.
+  Lemma choice_type_refl :
+    ∀ u, choice_type_eq u u.
   Proof.
-    intros u. destruct choice_code_eq eqn:e.
+    intros u. destruct choice_type_eq eqn:e.
     - constructor.
-    - move: e => /choice_code_eqP []. reflexivity.
+    - move: e => /choice_type_eqP []. reflexivity.
   Qed.
 
-  Canonical choice_code_eqMixin := EqMixin choice_code_eqP.
-  Canonical choice_code_eqType :=
-    Eval hnf in EqType choice_code choice_code_eqMixin.
+  Canonical choice_type_eqMixin := EqMixin choice_type_eqP.
+  Canonical choice_type_eqType :=
+    Eval hnf in EqType choice_type choice_type_eqMixin.
 
-  Fixpoint choice_code_lt (t1 t2 : choice_code) :=
+  Fixpoint choice_type_lt (t1 t2 : choice_type) :=
   match t1, t2 with
   | chUnit, chUnit => false
   | chUnit, _ => true
@@ -168,23 +168,23 @@ Section choice_codeTypes.
   | chProd _ _, chBool => false
   | chProd _ _, chNat => false
   | chProd u1 u2, chProd w1 w2 =>
-    (choice_code_lt u1 w1) ||
-    (choice_code_eq u1 w1 && choice_code_lt u2 w2)
+    (choice_type_lt u1 w1) ||
+    (choice_type_eq u1 w1 && choice_type_lt u2 w2)
   | chProd _ _, _ => true
   | chMap _ _, chUnit => false
   | chMap _ _, chBool => false
   | chMap _ _, chNat => false
   | chMap _ _, chProd _ _ => false
   | chMap u1 u2, chMap w1 w2 =>
-    (choice_code_lt u1 w1) ||
-    (choice_code_eq u1 w1 && choice_code_lt u2 w2)
+    (choice_type_lt u1 w1) ||
+    (choice_type_eq u1 w1 && choice_type_lt u2 w2)
   | chMap _ _, _ => true
   | chOption _, chUnit => false
   | chOption _, chBool => false
   | chOption _, chNat => false
   | chOption _, chProd _ _ => false
   | chOption _, chMap _ _ => false
-  | chOption u, chOption w => choice_code_lt u w
+  | chOption u, chOption w => choice_type_lt u w
   | chOption _, _ => true
   | chFin n, chUnit => false
   | chFin n, chBool => false
@@ -195,10 +195,10 @@ Section choice_codeTypes.
   | chFin n, chFin n' => n < n'
   end.
 
-  Definition choice_code_leq (t1 t2 : choice_code) :=
-    choice_code_eq t1 t2 || choice_code_lt t1 t2.
+  Definition choice_type_leq (t1 t2 : choice_type) :=
+    choice_type_eq t1 t2 || choice_type_lt t1 t2.
 
-  Lemma choice_code_lt_transitive : transitive (T:=choice_code) choice_code_lt.
+  Lemma choice_type_lt_transitive : transitive (T:=choice_type) choice_type_lt.
   Proof.
     intros v u w h1 h2.
     induction u as [ | | | u1 ih1 u2 ih2 | u1 ih1 u2 ih2 | u ih | u]
@@ -249,8 +249,8 @@ Section choice_codeTypes.
       eapply ltn_trans. all: eauto.
   Qed.
 
-  Lemma choice_code_lt_areflexive :
-    ∀ x, ~~ choice_code_lt x x.
+  Lemma choice_type_lt_areflexive :
+    ∀ x, ~~ choice_type_lt x x.
   Proof.
     intros x.
     induction x as [ | | | x1 ih1 x2 ih2 | x1 ih1 x2 ih2 | x ih | x] in |- *.
@@ -268,9 +268,9 @@ Section choice_codeTypes.
     - rewrite ltnn. auto.
   Qed.
 
-  Lemma choice_code_lt_total_holds :
+  Lemma choice_type_lt_total_holds :
     ∀ x y,
-      ~~ (choice_code_test x y) ==> (choice_code_lt x y || choice_code_lt y x).
+      ~~ (choice_type_test x y) ==> (choice_type_lt x y || choice_type_lt y x).
   Proof.
     intros x y.
     induction x as [ | | | x1 ih1 x2 ih2| x1 ih1 x2 ih2| x ih| x]
@@ -282,7 +282,7 @@ Section choice_codeTypes.
       apply/implyP.
       move /nandP => H.
       apply/orP.
-      destruct (choice_code_test x1 y1) eqn:Heq.
+      destruct (choice_type_test x1 y1) eqn:Heq.
       + destruct H. 1: discriminate.
         move: ih2. move /implyP => ih2.
         specialize (ih2 H).
@@ -317,7 +317,7 @@ Section choice_codeTypes.
       apply/implyP.
       move /nandP => H.
       apply/orP.
-      destruct (choice_code_test x1 y1) eqn:Heq.
+      destruct (choice_type_test x1 y1) eqn:Heq.
       + destruct H. 1: discriminate.
         move: ih2. move /implyP => ih2.
         specialize (ih2 H).
@@ -347,64 +347,64 @@ Section choice_codeTypes.
               +++ left. apply/orP. left. assumption.
               +++ right. apply/orP. left. assumption.
     - destruct y. all: try (intuition; reflexivity).
-      unfold choice_code_lt.
-      unfold choice_code_test.
+      unfold choice_type_lt.
+      unfold choice_type_test.
       rewrite -neq_ltn.
       apply /implyP. auto.
   Qed.
 
-  Lemma choice_code_lt_asymmetric :
+  Lemma choice_type_lt_asymmetric :
     ∀ x y,
-      (choice_code_lt x y ==> ~~ choice_code_lt y x).
+      (choice_type_lt x y ==> ~~ choice_type_lt y x).
   Proof.
     intros x y.
     apply /implyP. move => H.
-    destruct (~~ choice_code_lt y x) eqn:Heq.
+    destruct (~~ choice_type_lt y x) eqn:Heq.
     - intuition.
     - move: Heq. move /negP /negP => Heq.
-      pose  (choice_code_lt_areflexive x) as Harefl.
+      pose  (choice_type_lt_areflexive x) as Harefl.
       move: Harefl. apply /implyP. rewrite implyNb.
       apply /orP. left.
-      apply (choice_code_lt_transitive _ _ _ H Heq).
+      apply (choice_type_lt_transitive _ _ _ H Heq).
   Qed.
 
-  Lemma choice_code_lt_total_not_holds :
+  Lemma choice_type_lt_total_not_holds :
     ∀ x y,
-      ~~ (choice_code_test x y) ==> (~~ (choice_code_lt x y && choice_code_lt y x)).
+      ~~ (choice_type_test x y) ==> (~~ (choice_type_lt x y && choice_type_lt y x)).
   Proof.
     intros x y. apply /implyP. intros Hneq.
-    pose (choice_code_lt_total_holds x y) as Htot.
+    pose (choice_type_lt_total_holds x y) as Htot.
     move: Htot. move /implyP => Htot. specialize (Htot Hneq).
     move: Htot. move /orP => Htot. apply /nandP. destruct Htot.
-    - right. pose (choice_code_lt_asymmetric x y) as Hasym.
+    - right. pose (choice_type_lt_asymmetric x y) as Hasym.
       move: Hasym. move /implyP => Hasym. specialize (Hasym H). assumption.
-    - left. pose (choice_code_lt_asymmetric y x) as Hasym.
+    - left. pose (choice_type_lt_asymmetric y x) as Hasym.
       move: Hasym. move /implyP => Hasym. specialize (Hasym H). assumption.
   Qed.
 
-  Lemma choice_code_lt_tot :
+  Lemma choice_type_lt_tot :
     ∀ x y,
-      (choice_code_lt x y || choice_code_lt y x || choice_code_eq x y).
+      (choice_type_lt x y || choice_type_lt y x || choice_type_eq x y).
   Proof.
     intros x y.
-    destruct (choice_code_eq x y) eqn:H.
+    destruct (choice_type_eq x y) eqn:H.
     - intuition.
     - apply/orP.
       left.
-      unfold choice_code_eq in H.
-      pose (choice_code_lt_total_holds x y).
+      unfold choice_type_eq in H.
+      pose (choice_type_lt_total_holds x y).
       move: i. move /implyP => i.
       apply i. apply/negP.
       intuition. move: H0. rewrite H. intuition.
   Qed.
 
-  Lemma choice_code_leqP : Ord.axioms choice_code_leq.
+  Lemma choice_type_leqP : Ord.axioms choice_type_leq.
   Proof.
     split => //.
-    - intro x. unfold choice_code_leq.
+    - intro x. unfold choice_type_leq.
       apply/orP. left. apply /eqP. reflexivity.
     - intros v u w h1 h2.
-      move: h1 h2. unfold choice_code_leq.
+      move: h1 h2. unfold choice_type_leq.
       move /orP => h1. move /orP => h2.
       destruct h1.
       + move: H. move /eqP => H. destruct H.
@@ -412,18 +412,18 @@ Section choice_codeTypes.
       + destruct h2.
         * move: H0. move /eqP => H0. destruct H0.
           apply/orP. right. assumption.
-        * apply/orP. right. exact (choice_code_lt_transitive _ _ _ H H0).
+        * apply/orP. right. exact (choice_type_lt_transitive _ _ _ H H0).
     - unfold antisymmetric.
-      move => x y. unfold choice_code_leq. move/andP => [h1 h2].
-      move: h1 h2. unfold choice_code_leq.
+      move => x y. unfold choice_type_leq. move/andP => [h1 h2].
+      move: h1 h2. unfold choice_type_leq.
       move /orP => h1. move /orP => h2.
       destruct h1.
       1:{ move: H. move /eqP. intuition auto. }
       destruct h2.
       1:{ move: H0. move /eqP. intuition auto. }
-      destruct (~~ (choice_code_test x y)) eqn:Heq.
+      destruct (~~ (choice_type_test x y)) eqn:Heq.
       + move: Heq. move /idP => Heq.
-        pose (choice_code_lt_total_not_holds x y) as Hp.
+        pose (choice_type_lt_total_not_holds x y) as Hp.
         move: Hp. move /implyP => Hp. specialize (Hp Heq).
         move: Hp. move /nandP => Hp.
         destruct Hp.
@@ -433,8 +433,8 @@ Section choice_codeTypes.
           discriminate.
       + move: Heq. move /eqP. auto.
     - unfold total.
-      intros x y. unfold choice_code_leq.
-      pose (choice_code_lt_tot x y).
+      intros x y. unfold choice_type_leq.
+      pose (choice_type_lt_tot x y).
       move: i. move /orP => H.
       destruct H.
       + move: H. move /orP => H.
@@ -445,7 +445,7 @@ Section choice_codeTypes.
   Qed.
 
 
-  Fixpoint encode (t : choice_code) : GenTree.tree nat :=
+  Fixpoint encode (t : choice_type) : GenTree.tree nat :=
   match t with
   | chUnit => GenTree.Leaf 1
   | chBool => GenTree.Leaf 2
@@ -456,7 +456,7 @@ Section choice_codeTypes.
   | chFin n => GenTree.Leaf ((4 + n) - 1)%N
   end.
 
-  Fixpoint decode (t : GenTree.tree nat) : option choice_code :=
+  Fixpoint decode (t : GenTree.tree nat) : option choice_type :=
     match t with
     | GenTree.Leaf 1 => Some chUnit
     | GenTree.Leaf 2 => Some chBool
@@ -496,12 +496,12 @@ Section choice_codeTypes.
         rewrite -subnE subn0. repeat f_equal. apply eq_irrelevance.
   Defined.
 
-  Definition choice_code_choiceMixin := PcanChoiceMixin codeK.
-  Canonical choice_code_choiceType :=
-    ChoiceType choice_code choice_code_choiceMixin.
+  Definition choice_type_choiceMixin := PcanChoiceMixin codeK.
+  Canonical choice_type_choiceType :=
+    ChoiceType choice_type choice_type_choiceMixin.
 
-  Definition choice_code_ordMixin := OrdMixin choice_code_leqP.
-  Canonical choice_code_ordType :=
-    Eval hnf in OrdType choice_code choice_code_ordMixin.
+  Definition choice_type_ordMixin := OrdMixin choice_type_leqP.
+  Canonical choice_type_ordType :=
+    Eval hnf in OrdType choice_type choice_type_ordMixin.
 
-End choice_codeTypes.
+End choice_typeTypes.

--- a/theories/Crypt/examples/AsymScheme.v
+++ b/theories/Crypt/examples/AsymScheme.v
@@ -21,7 +21,7 @@ Set Warnings "notation-overridden,ambiguous-paths".
 
 From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
   UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb UniformStateProb
-  pkg_core_definition chUniverse pkg_composition pkg_rhl
+  pkg_core_definition choice_code pkg_composition pkg_rhl
   Package Prelude.
 
 From Coq Require Import Utf8.
@@ -58,8 +58,8 @@ Module Type AsymmetricSchemeAlgorithms (π : AsymmetricSchemeParams).
 
   Local Open Scope package_scope.
 
-  (* chX is the chUniverse in bijection with X  *)
-  (* Parameters chPlain chCipher chPubKey chSecKey : chUniverse. *)
+  (* chX is the choice_code in bijection with X  *)
+  (* Parameters chPlain chCipher chPubKey chSecKey : choice_code. *)
   Parameter Plain_pos : Positive #|Plain|.
   Parameter Cipher_pos : Positive #|Cipher|.
   Parameter PubKey_pos : Positive #|PubKey|.

--- a/theories/Crypt/examples/AsymScheme.v
+++ b/theories/Crypt/examples/AsymScheme.v
@@ -21,7 +21,7 @@ Set Warnings "notation-overridden,ambiguous-paths".
 
 From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
   UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb UniformStateProb
-  pkg_core_definition choice_code pkg_composition pkg_rhl
+  pkg_core_definition choice_type pkg_composition pkg_rhl
   Package Prelude.
 
 From Coq Require Import Utf8.
@@ -58,8 +58,8 @@ Module Type AsymmetricSchemeAlgorithms (π : AsymmetricSchemeParams).
 
   Local Open Scope package_scope.
 
-  (* chX is the choice_code in bijection with X  *)
-  (* Parameters chPlain chCipher chPubKey chSecKey : choice_code. *)
+  (* chX is the choice_type in bijection with X  *)
+  (* Parameters chPlain chCipher chPubKey chSecKey : choice_type. *)
   Parameter Plain_pos : Positive #|Plain|.
   Parameter Cipher_pos : Positive #|Cipher|.
   Parameter PubKey_pos : Positive #|PubKey|.

--- a/theories/Crypt/examples/ElGamal.v
+++ b/theories/Crypt/examples/ElGamal.v
@@ -16,7 +16,7 @@ From Mon Require Import SPropBase.
 
 From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
   UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb UniformStateProb
-  pkg_core_definition chUniverse pkg_composition pkg_rhl Package Prelude
+  pkg_core_definition choice_code pkg_composition pkg_rhl Package Prelude
   AsymScheme.
 
 From Coq Require Import Utf8.
@@ -117,10 +117,10 @@ Module MyAlg <: AsymmetricSchemeAlgorithms MyParam.
     exact _.
   Qed.
 
-  Definition chPlain  : chUniverse := 'fin #|gT|.
-  Definition chPubKey : chUniverse := 'fin #|gT|.
-  Definition chCipher : chUniverse := 'fin #|Cipher|.
-  Definition chSecKey : chUniverse := 'fin #|SecKey|.
+  Definition chPlain  : choice_code := 'fin #|gT|.
+  Definition chPubKey : choice_code := 'fin #|gT|.
+  Definition chCipher : choice_code := 'fin #|Cipher|.
+  Definition chSecKey : choice_code := 'fin #|SecKey|.
 
   Definition counter_loc : Location := ('nat ; 0%N).
   Definition pk_loc : Location := (chPubKey ; 1%N).

--- a/theories/Crypt/examples/ElGamal.v
+++ b/theories/Crypt/examples/ElGamal.v
@@ -16,7 +16,7 @@ From Mon Require Import SPropBase.
 
 From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
   UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb UniformStateProb
-  pkg_core_definition choice_code pkg_composition pkg_rhl Package Prelude
+  pkg_core_definition choice_type pkg_composition pkg_rhl Package Prelude
   AsymScheme.
 
 From Coq Require Import Utf8.
@@ -117,10 +117,10 @@ Module MyAlg <: AsymmetricSchemeAlgorithms MyParam.
     exact _.
   Qed.
 
-  Definition chPlain  : choice_code := 'fin #|gT|.
-  Definition chPubKey : choice_code := 'fin #|gT|.
-  Definition chCipher : choice_code := 'fin #|Cipher|.
-  Definition chSecKey : choice_code := 'fin #|SecKey|.
+  Definition chPlain  : choice_type := 'fin #|gT|.
+  Definition chPubKey : choice_type := 'fin #|gT|.
+  Definition chCipher : choice_type := 'fin #|Cipher|.
+  Definition chSecKey : choice_type := 'fin #|SecKey|.
 
   Definition counter_loc : Location := ('nat ; 0%N).
   Definition pk_loc : Location := (chPubKey ; 1%N).

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -60,10 +60,10 @@ Section KEMDEM.
   Definition chKey := keyD.π1.
 
   (** Public and secret key *)
-  Context (chPKey chSKey : chUniverse).
+  Context (chPKey chSKey : choice_code).
 
   (** Plain text *)
-  Context (chPlain : chUniverse).
+  Context (chPlain : choice_code).
 
   (** We additionally require a "zero" in chPlain.
 

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -60,10 +60,10 @@ Section KEMDEM.
   Definition chKey := keyD.π1.
 
   (** Public and secret key *)
-  Context (chPKey chSKey : choice_code).
+  Context (chPKey chSKey : choice_type).
 
   (** Plain text *)
-  Context (chPlain : choice_code).
+  Context (chPlain : choice_type).
 
   (** We additionally require a "zero" in chPlain.
 

--- a/theories/Crypt/examples/PRF.v
+++ b/theories/Crypt/examples/PRF.v
@@ -20,7 +20,7 @@ Set Warnings "notation-overridden,ambiguous-paths".
 From Mon Require Import SPropBase.
 From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
   UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb
-  pkg_core_definition choice_code pkg_composition pkg_rhl Package Prelude.
+  pkg_core_definition choice_type pkg_composition pkg_rhl Package Prelude.
 
 From Coq Require Import Utf8.
 From extructures Require Import ord fset fmap.
@@ -48,10 +48,10 @@ Section PRF_example.
 
   Definition Words_N : nat := 2^n.
   Definition Words_N_pos : Positive Words_N := _.
-  Definition Words : choice_code := chFin (mkpos Words_N).
+  Definition Words : choice_type := chFin (mkpos Words_N).
   Definition Key_N : nat := 2^n.
   Definition Key_N_pos : Positive Key_N := _.
-  Definition Key : choice_code := chFin (mkpos Key_N).
+  Definition Key : choice_type := chFin (mkpos Key_N).
 
   (* TW: Is this normal that this definition is so big? *)
   #[program] Definition plus : Words → Key → Words :=

--- a/theories/Crypt/examples/PRF.v
+++ b/theories/Crypt/examples/PRF.v
@@ -20,7 +20,7 @@ Set Warnings "notation-overridden,ambiguous-paths".
 From Mon Require Import SPropBase.
 From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
   UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb
-  pkg_core_definition chUniverse pkg_composition pkg_rhl Package Prelude.
+  pkg_core_definition choice_code pkg_composition pkg_rhl Package Prelude.
 
 From Coq Require Import Utf8.
 From extructures Require Import ord fset fmap.
@@ -48,10 +48,10 @@ Section PRF_example.
 
   Definition Words_N : nat := 2^n.
   Definition Words_N_pos : Positive Words_N := _.
-  Definition Words : chUniverse := chFin (mkpos Words_N).
+  Definition Words : choice_code := chFin (mkpos Words_N).
   Definition Key_N : nat := 2^n.
   Definition Key_N_pos : Positive Key_N := _.
-  Definition Key : chUniverse := chFin (mkpos Key_N).
+  Definition Key : choice_code := chFin (mkpos Key_N).
 
   (* TW: Is this normal that this definition is so big? *)
   #[program] Definition plus : Words → Key → Words :=

--- a/theories/Crypt/examples/RandomOracle.v
+++ b/theories/Crypt/examples/RandomOracle.v
@@ -7,7 +7,7 @@ Set Warnings "notation-overridden,ambiguous-paths".
 
 From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
   UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb UniformStateProb
-  pkg_core_definition chUniverse pkg_composition pkg_rhl
+  pkg_core_definition choice_code pkg_composition pkg_rhl
   Package Prelude.
 
 From Coq Require Import Utf8.

--- a/theories/Crypt/examples/RandomOracle.v
+++ b/theories/Crypt/examples/RandomOracle.v
@@ -7,7 +7,7 @@ Set Warnings "notation-overridden,ambiguous-paths".
 
 From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
   UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb UniformStateProb
-  pkg_core_definition choice_code pkg_composition pkg_rhl
+  pkg_core_definition choice_type pkg_composition pkg_rhl
   Package Prelude.
 
 From Coq Require Import Utf8.

--- a/theories/Crypt/examples/Schnorr.v
+++ b/theories/Crypt/examples/Schnorr.v
@@ -11,7 +11,7 @@ From Mon Require Import SPropBase.
 
 From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
   UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb UniformStateProb
-  pkg_core_definition choice_code pkg_composition pkg_rhl Package Prelude
+  pkg_core_definition choice_type pkg_composition pkg_rhl Package Prelude
   SigmaProtocol.
 
 From Coq Require Import Utf8.
@@ -92,12 +92,12 @@ Module MyAlg <: SigmaProtocolAlgorithms MyParam.
 
   #[local] Existing Instance Bool_pos.
 
-  Definition choiceWitness : choice_code := 'fin #|Witness|.
-  Definition choiceStatement : choice_code := 'fin #|Statement|.
-  Definition choiceMessage : choice_code := 'fin #|Message|.
-  Definition choiceChallenge : choice_code := 'fin #|Challenge|.
-  Definition choiceResponse : choice_code := 'fin #|Response|.
-  Definition choiceTranscript : choice_code :=
+  Definition choiceWitness : choice_type := 'fin #|Witness|.
+  Definition choiceStatement : choice_type := 'fin #|Statement|.
+  Definition choiceMessage : choice_type := 'fin #|Message|.
+  Definition choiceChallenge : choice_type := 'fin #|Challenge|.
+  Definition choiceResponse : choice_type := 'fin #|Response|.
+  Definition choiceTranscript : choice_type :=
     chProd
       (chProd (chProd choiceStatement choiceMessage) choiceChallenge)
       choiceResponse.
@@ -321,7 +321,7 @@ Proof.
   (* We need to ensure that the composition is valid. *)
   destruct (Adv ADV) as [[? []]|].
   2:{ apply r_ret. auto. }
-  repeat destruct choice_code_eqP.
+  repeat destruct choice_type_eqP.
   2,3: apply r_ret ; auto.
   apply rsame_head. intros [s [[s0 s3] [s1 s2]]].
   ssprove_code_simpl. simpl.

--- a/theories/Crypt/examples/Schnorr.v
+++ b/theories/Crypt/examples/Schnorr.v
@@ -11,7 +11,7 @@ From Mon Require Import SPropBase.
 
 From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
   UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb UniformStateProb
-  pkg_core_definition chUniverse pkg_composition pkg_rhl Package Prelude
+  pkg_core_definition choice_code pkg_composition pkg_rhl Package Prelude
   SigmaProtocol.
 
 From Coq Require Import Utf8.
@@ -92,12 +92,12 @@ Module MyAlg <: SigmaProtocolAlgorithms MyParam.
 
   #[local] Existing Instance Bool_pos.
 
-  Definition choiceWitness : chUniverse := 'fin #|Witness|.
-  Definition choiceStatement : chUniverse := 'fin #|Statement|.
-  Definition choiceMessage : chUniverse := 'fin #|Message|.
-  Definition choiceChallenge : chUniverse := 'fin #|Challenge|.
-  Definition choiceResponse : chUniverse := 'fin #|Response|.
-  Definition choiceTranscript : chUniverse :=
+  Definition choiceWitness : choice_code := 'fin #|Witness|.
+  Definition choiceStatement : choice_code := 'fin #|Statement|.
+  Definition choiceMessage : choice_code := 'fin #|Message|.
+  Definition choiceChallenge : choice_code := 'fin #|Challenge|.
+  Definition choiceResponse : choice_code := 'fin #|Response|.
+  Definition choiceTranscript : choice_code :=
     chProd
       (chProd (chProd choiceStatement choiceMessage) choiceChallenge)
       choiceResponse.
@@ -321,7 +321,7 @@ Proof.
   (* We need to ensure that the composition is valid. *)
   destruct (Adv ADV) as [[? []]|].
   2:{ apply r_ret. auto. }
-  repeat destruct chUniverse_eqP.
+  repeat destruct choice_code_eqP.
   2,3: apply r_ret ; auto.
   apply rsame_head. intros [s [[s0 s3] [s1 s2]]].
   ssprove_code_simpl. simpl.

--- a/theories/Crypt/examples/SigmaProtocol.v
+++ b/theories/Crypt/examples/SigmaProtocol.v
@@ -8,7 +8,7 @@ Set Warnings "notation-overridden,ambiguous-paths".
 
 From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
   UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb UniformStateProb
-  pkg_core_definition choice_code pkg_composition pkg_rhl
+  pkg_core_definition choice_type pkg_composition pkg_rhl
   Package Prelude RandomOracle.
 
 From Coq Require Import Utf8.
@@ -419,7 +419,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
       destruct (Adv ADV) as [[? []]|].
       2:{ apply r_ret. intuition auto. }
 
-      repeat destruct choice_code_eqP.
+      repeat destruct choice_type_eqP.
       2:{ apply r_ret. intuition auto. }
       2:{ apply r_ret. intuition auto. }
 

--- a/theories/Crypt/examples/SigmaProtocol.v
+++ b/theories/Crypt/examples/SigmaProtocol.v
@@ -8,7 +8,7 @@ Set Warnings "notation-overridden,ambiguous-paths".
 
 From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
   UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb UniformStateProb
-  pkg_core_definition chUniverse pkg_composition pkg_rhl
+  pkg_core_definition choice_code pkg_composition pkg_rhl
   Package Prelude RandomOracle.
 
 From Coq Require Import Utf8.
@@ -419,7 +419,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
       destruct (Adv ADV) as [[? []]|].
       2:{ apply r_ret. intuition auto. }
 
-      repeat destruct chUniverse_eqP.
+      repeat destruct choice_code_eqP.
       2:{ apply r_ret. intuition auto. }
       2:{ apply r_ret. intuition auto. }
 

--- a/theories/Crypt/package/pkg_advantage.v
+++ b/theories/Crypt/package/pkg_advantage.v
@@ -12,7 +12,7 @@ From extructures Require Import ord fset fmap.
 From Mon Require Import SPropBase.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd SubDistr Couplings
   RulesStateProb UniformStateProb UniformDistrLemmas StateTransfThetaDens
-  StateTransformingLaxMorph choice_code pkg_core_definition pkg_notation
+  StateTransformingLaxMorph choice_type pkg_core_definition pkg_notation
   pkg_tactics pkg_composition pkg_heap pkg_semantics pkg_lookup.
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.

--- a/theories/Crypt/package/pkg_advantage.v
+++ b/theories/Crypt/package/pkg_advantage.v
@@ -12,7 +12,7 @@ From extructures Require Import ord fset fmap.
 From Mon Require Import SPropBase.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd SubDistr Couplings
   RulesStateProb UniformStateProb UniformDistrLemmas StateTransfThetaDens
-  StateTransformingLaxMorph chUniverse pkg_core_definition pkg_notation
+  StateTransformingLaxMorph choice_code pkg_core_definition pkg_notation
   pkg_tactics pkg_composition pkg_heap pkg_semantics pkg_lookup.
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.

--- a/theories/Crypt/package/pkg_composition.v
+++ b/theories/Crypt/package/pkg_composition.v
@@ -16,7 +16,7 @@ Set Warnings "ambiguous-paths,notation-overridden,notation-incompatible-format".
 From extructures Require Import ord fset fmap.
 From Mon Require Import SPropBase.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd
-  StateTransformingLaxMorph chUniverse pkg_core_definition
+  StateTransformingLaxMorph choice_code pkg_core_definition
   RulesStateProb.
 From Equations Require Import Equations.
 Require Equations.Prop.DepElim.
@@ -29,7 +29,7 @@ Set Bullet Behavior "Strict Subproofs".
 Set Default Goal Selector "!".
 Set Primitive Projections.
 
-Definition cast_fun {So To St Tt : chUniverse}
+Definition cast_fun {So To St Tt : choice_code}
   (hS : St = So) (hT : Tt = To) (f : St → raw_code Tt) :
   So → raw_code To.
 Proof.
@@ -41,7 +41,7 @@ Definition lookup_op (p: raw_package) (o : opsig) :
   let '(n, (So, To)) := o in
   match p n with
   | Some (St ; Tt ; f) =>
-    match chUniverse_eqP St So, chUniverse_eqP Tt To with
+    match choice_code_eqP St So, choice_code_eqP Tt To with
     | ReflectT hS, ReflectT hT => Some (cast_fun hS hT f)
     | _,_ => None
     end
@@ -69,8 +69,8 @@ Proof.
   intros p o f e.
   destruct o as [id [S T]]. cbn in *.
   destruct (p id) as [[S' [T' g]]|] eqn:e1. 2: discriminate.
-  destruct chUniverse_eqP. 2: discriminate.
-  destruct chUniverse_eqP. 2: discriminate.
+  destruct choice_code_eqP. 2: discriminate.
+  destruct choice_code_eqP. 2: discriminate.
   noconf e. subst.
   reflexivity.
 Qed.
@@ -90,9 +90,9 @@ Proof.
   destruct hp as [f [ef hf]].
   exists f. intuition auto. cbn.
   destruct (p n) as [[St [Tt ft]]|] eqn:e. 2: discriminate.
-  destruct chUniverse_eqP.
+  destruct choice_code_eqP.
   2:{ inversion ef. congruence. }
-  destruct chUniverse_eqP.
+  destruct choice_code_eqP.
   2:{ inversion ef. congruence. }
   subst. cbn. noconf ef.
   reflexivity.
@@ -106,8 +106,8 @@ Proof.
   intros p [n [So To]] f. unfold lookup_op.
   rewrite mapmE. destruct (p n) as [[St [Tt ft]]|] eqn:e.
   2:{ cbn. reflexivity. }
-  cbn. destruct chUniverse_eqP. 2: reflexivity.
-  destruct chUniverse_eqP. 2: reflexivity.
+  cbn. destruct choice_code_eqP. 2: reflexivity.
+  destruct choice_code_eqP. 2: reflexivity.
   cbn. subst. cbn. reflexivity.
 Qed.
 
@@ -314,12 +314,12 @@ Proof.
   destruct (p n) as [[S1 [T1 f1]]|] eqn:e. 2: reflexivity.
   cbn.
   destruct ((n, (S1, T1)) \in E) eqn:e1.
-  - rewrite e1. destruct chUniverse_eqP. 2: reflexivity.
-    destruct chUniverse_eqP. 2: reflexivity.
+  - rewrite e1. destruct choice_code_eqP. 2: reflexivity.
+    destruct choice_code_eqP. 2: reflexivity.
     cbn. subst. cbn. rewrite e1. reflexivity.
   - rewrite e1.
-    destruct chUniverse_eqP. 2: reflexivity.
-    destruct chUniverse_eqP. 2: reflexivity.
+    destruct choice_code_eqP. 2: reflexivity.
+    destruct choice_code_eqP. 2: reflexivity.
     subst. rewrite e1. cbn. reflexivity.
 Qed.
 
@@ -747,7 +747,7 @@ Local Open Scope type_scope.
 (* TODO: Still works, but outdated. *)
 
 Definition typed_function L I :=
-  ∑ (S T : chUniverse), S → code L I T.
+  ∑ (S T : choice_code), S → code L I T.
 
 Equations? map_interface (I : seq opsig) {A} (f : ∀ x, x \in I → A) :
   seq A :=
@@ -861,7 +861,7 @@ Defined.
 (* Identity package *)
 
 (* Maybe lock this definition? *)
-Definition mkdef (A B : chUniverse) (f : A → raw_code B)
+Definition mkdef (A B : choice_code) (f : A → raw_code B)
   : typed_raw_function :=
   (A ; B ; f).
 
@@ -938,13 +938,13 @@ Proof.
   unfold lookup_op. rewrite IDE.
   destruct getm_def as [[So To]|] eqn:e.
   - cbn. apply getm_def_in in e as h1.
-    destruct chUniverse_eqP.
+    destruct choice_code_eqP.
     2:{
       destruct ((n, (S, T)) \in I) eqn:e1.
       2:{ rewrite e1. reflexivity. }
       specialize (h _ _ _ h1 e1). noconf h. congruence.
     }
-    destruct chUniverse_eqP.
+    destruct choice_code_eqP.
     2:{
       destruct ((n, (S, T)) \in I) eqn:e1.
       2:{ rewrite e1. reflexivity. }
@@ -1049,8 +1049,8 @@ Proof.
     specialize (hp _ hi) as h'. cbn in h'.
     destruct h' as [f [ef hf]].
     cbn. destruct (p n) as [[St [Tt g]]|] eqn:e1. 2: discriminate.
-    destruct chUniverse_eqP. 2:{ noconf ef. contradiction. }
-    destruct chUniverse_eqP. 2:{ noconf ef. contradiction. }
+    destruct choice_code_eqP. 2:{ noconf ef. contradiction. }
+    destruct choice_code_eqP. 2:{ noconf ef. contradiction. }
     subst. cbn.
     f_equal. f_equal. f_equal.
     extensionality x.

--- a/theories/Crypt/package/pkg_composition.v
+++ b/theories/Crypt/package/pkg_composition.v
@@ -16,7 +16,7 @@ Set Warnings "ambiguous-paths,notation-overridden,notation-incompatible-format".
 From extructures Require Import ord fset fmap.
 From Mon Require Import SPropBase.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd
-  StateTransformingLaxMorph choice_code pkg_core_definition
+  StateTransformingLaxMorph choice_type pkg_core_definition
   RulesStateProb.
 From Equations Require Import Equations.
 Require Equations.Prop.DepElim.
@@ -29,7 +29,7 @@ Set Bullet Behavior "Strict Subproofs".
 Set Default Goal Selector "!".
 Set Primitive Projections.
 
-Definition cast_fun {So To St Tt : choice_code}
+Definition cast_fun {So To St Tt : choice_type}
   (hS : St = So) (hT : Tt = To) (f : St → raw_code Tt) :
   So → raw_code To.
 Proof.
@@ -41,7 +41,7 @@ Definition lookup_op (p: raw_package) (o : opsig) :
   let '(n, (So, To)) := o in
   match p n with
   | Some (St ; Tt ; f) =>
-    match choice_code_eqP St So, choice_code_eqP Tt To with
+    match choice_type_eqP St So, choice_type_eqP Tt To with
     | ReflectT hS, ReflectT hT => Some (cast_fun hS hT f)
     | _,_ => None
     end
@@ -69,8 +69,8 @@ Proof.
   intros p o f e.
   destruct o as [id [S T]]. cbn in *.
   destruct (p id) as [[S' [T' g]]|] eqn:e1. 2: discriminate.
-  destruct choice_code_eqP. 2: discriminate.
-  destruct choice_code_eqP. 2: discriminate.
+  destruct choice_type_eqP. 2: discriminate.
+  destruct choice_type_eqP. 2: discriminate.
   noconf e. subst.
   reflexivity.
 Qed.
@@ -90,9 +90,9 @@ Proof.
   destruct hp as [f [ef hf]].
   exists f. intuition auto. cbn.
   destruct (p n) as [[St [Tt ft]]|] eqn:e. 2: discriminate.
-  destruct choice_code_eqP.
+  destruct choice_type_eqP.
   2:{ inversion ef. congruence. }
-  destruct choice_code_eqP.
+  destruct choice_type_eqP.
   2:{ inversion ef. congruence. }
   subst. cbn. noconf ef.
   reflexivity.
@@ -106,8 +106,8 @@ Proof.
   intros p [n [So To]] f. unfold lookup_op.
   rewrite mapmE. destruct (p n) as [[St [Tt ft]]|] eqn:e.
   2:{ cbn. reflexivity. }
-  cbn. destruct choice_code_eqP. 2: reflexivity.
-  destruct choice_code_eqP. 2: reflexivity.
+  cbn. destruct choice_type_eqP. 2: reflexivity.
+  destruct choice_type_eqP. 2: reflexivity.
   cbn. subst. cbn. reflexivity.
 Qed.
 
@@ -314,12 +314,12 @@ Proof.
   destruct (p n) as [[S1 [T1 f1]]|] eqn:e. 2: reflexivity.
   cbn.
   destruct ((n, (S1, T1)) \in E) eqn:e1.
-  - rewrite e1. destruct choice_code_eqP. 2: reflexivity.
-    destruct choice_code_eqP. 2: reflexivity.
+  - rewrite e1. destruct choice_type_eqP. 2: reflexivity.
+    destruct choice_type_eqP. 2: reflexivity.
     cbn. subst. cbn. rewrite e1. reflexivity.
   - rewrite e1.
-    destruct choice_code_eqP. 2: reflexivity.
-    destruct choice_code_eqP. 2: reflexivity.
+    destruct choice_type_eqP. 2: reflexivity.
+    destruct choice_type_eqP. 2: reflexivity.
     subst. rewrite e1. cbn. reflexivity.
 Qed.
 
@@ -747,7 +747,7 @@ Local Open Scope type_scope.
 (* TODO: Still works, but outdated. *)
 
 Definition typed_function L I :=
-  ∑ (S T : choice_code), S → code L I T.
+  ∑ (S T : choice_type), S → code L I T.
 
 Equations? map_interface (I : seq opsig) {A} (f : ∀ x, x \in I → A) :
   seq A :=
@@ -861,7 +861,7 @@ Defined.
 (* Identity package *)
 
 (* Maybe lock this definition? *)
-Definition mkdef (A B : choice_code) (f : A → raw_code B)
+Definition mkdef (A B : choice_type) (f : A → raw_code B)
   : typed_raw_function :=
   (A ; B ; f).
 
@@ -938,13 +938,13 @@ Proof.
   unfold lookup_op. rewrite IDE.
   destruct getm_def as [[So To]|] eqn:e.
   - cbn. apply getm_def_in in e as h1.
-    destruct choice_code_eqP.
+    destruct choice_type_eqP.
     2:{
       destruct ((n, (S, T)) \in I) eqn:e1.
       2:{ rewrite e1. reflexivity. }
       specialize (h _ _ _ h1 e1). noconf h. congruence.
     }
-    destruct choice_code_eqP.
+    destruct choice_type_eqP.
     2:{
       destruct ((n, (S, T)) \in I) eqn:e1.
       2:{ rewrite e1. reflexivity. }
@@ -1049,8 +1049,8 @@ Proof.
     specialize (hp _ hi) as h'. cbn in h'.
     destruct h' as [f [ef hf]].
     cbn. destruct (p n) as [[St [Tt g]]|] eqn:e1. 2: discriminate.
-    destruct choice_code_eqP. 2:{ noconf ef. contradiction. }
-    destruct choice_code_eqP. 2:{ noconf ef. contradiction. }
+    destruct choice_type_eqP. 2:{ noconf ef. contradiction. }
+    destruct choice_type_eqP. 2:{ noconf ef. contradiction. }
     subst. cbn.
     f_equal. f_equal. f_equal.
     extensionality x.

--- a/theories/Crypt/package/pkg_core_definition.v
+++ b/theories/Crypt/package/pkg_core_definition.v
@@ -15,7 +15,7 @@ Set Warnings "ambiguous-paths,notation-overridden,notation-incompatible-format".
 From extructures Require Import ord fset fmap.
 From Mon Require Import SPropBase.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd RulesStateProb StateTransformingLaxMorph
-     chUniverse.
+     choice_code.
 
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.
@@ -38,35 +38,35 @@ Set Primitive Projections.
 Definition ident := nat.
 
 (* Signature of an operation, including the identifier *)
-Definition opsig := ident * (chUniverse * chUniverse).
+Definition opsig := ident * (choice_code * choice_code).
 (* Record opsig := mkop {
 ident : nat ;
-src : chUniverse ;
-tgt : chUniverse
+src : choice_code ;
+tgt : choice_code
 }. *)
 
 Definition mkopsig id S T : opsig := (id, (S, T)).
 
-Definition Location := ∑ (t : chUniverse), nat.
+Definition Location := ∑ (t : choice_code), nat.
 
 Definition loc_type (l : Location) := l.π1.
 
-Coercion loc_type : Location >-> chUniverse.
+Coercion loc_type : Location >-> choice_code.
 
-Definition Value (t : chUniverse) := chElement t.
+Definition Value (t : choice_code) := chElement t.
 
 Definition Interface := {fset opsig}.
 
 Definition ide (v : opsig) : ident :=
   let '(n, _) := v in n.
 
-Definition chsrc (v : opsig) : chUniverse :=
+Definition chsrc (v : opsig) : choice_code :=
   let '(n, (s, t)) := v in s.
 
 Definition src (v : opsig) : choiceType :=
   chsrc v.
 
-Definition chtgt (v : opsig) : chUniverse :=
+Definition chtgt (v : opsig) : choice_code :=
   let '(n, (s, t)) := v in t.
 
 Definition tgt (v : opsig) : choiceType :=
@@ -131,7 +131,7 @@ Section FreeModule.
         valid_code (sampler op k)
   .
 
-  Derive NoConfusion NoConfusionHom for chUniverse.
+  Derive NoConfusion NoConfusionHom for choice_code.
   Derive NoConfusion NoConfusionHom EqDec for nat.
   Derive NoConfusion NoConfusionHom for raw_code.
   Derive Signature for valid_code.
@@ -624,7 +624,7 @@ Section FreeMap.
 End FreeMap.
 
 Definition typed_raw_function :=
-  ∑ (S T : chUniverse), S → raw_code T.
+  ∑ (S T : choice_code), S → raw_code T.
 
 Definition raw_package :=
   {fmap ident -> typed_raw_function }.

--- a/theories/Crypt/package/pkg_core_definition.v
+++ b/theories/Crypt/package/pkg_core_definition.v
@@ -15,7 +15,7 @@ Set Warnings "ambiguous-paths,notation-overridden,notation-incompatible-format".
 From extructures Require Import ord fset fmap.
 From Mon Require Import SPropBase.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd RulesStateProb StateTransformingLaxMorph
-     choice_code.
+     choice_type.
 
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.
@@ -38,35 +38,35 @@ Set Primitive Projections.
 Definition ident := nat.
 
 (* Signature of an operation, including the identifier *)
-Definition opsig := ident * (choice_code * choice_code).
+Definition opsig := ident * (choice_type * choice_type).
 (* Record opsig := mkop {
 ident : nat ;
-src : choice_code ;
-tgt : choice_code
+src : choice_type ;
+tgt : choice_type
 }. *)
 
 Definition mkopsig id S T : opsig := (id, (S, T)).
 
-Definition Location := ∑ (t : choice_code), nat.
+Definition Location := ∑ (t : choice_type), nat.
 
 Definition loc_type (l : Location) := l.π1.
 
-Coercion loc_type : Location >-> choice_code.
+Coercion loc_type : Location >-> choice_type.
 
-Definition Value (t : choice_code) := chElement t.
+Definition Value (t : choice_type) := chElement t.
 
 Definition Interface := {fset opsig}.
 
 Definition ide (v : opsig) : ident :=
   let '(n, _) := v in n.
 
-Definition chsrc (v : opsig) : choice_code :=
+Definition chsrc (v : opsig) : choice_type :=
   let '(n, (s, t)) := v in s.
 
 Definition src (v : opsig) : choiceType :=
   chsrc v.
 
-Definition chtgt (v : opsig) : choice_code :=
+Definition chtgt (v : opsig) : choice_type :=
   let '(n, (s, t)) := v in t.
 
 Definition tgt (v : opsig) : choiceType :=
@@ -131,7 +131,7 @@ Section FreeModule.
         valid_code (sampler op k)
   .
 
-  Derive NoConfusion NoConfusionHom for choice_code.
+  Derive NoConfusion NoConfusionHom for choice_type.
   Derive NoConfusion NoConfusionHom EqDec for nat.
   Derive NoConfusion NoConfusionHom for raw_code.
   Derive Signature for valid_code.
@@ -624,7 +624,7 @@ Section FreeMap.
 End FreeMap.
 
 Definition typed_raw_function :=
-  ∑ (S T : choice_code), S → raw_code T.
+  ∑ (S T : choice_type), S → raw_code T.
 
 Definition raw_package :=
   {fmap ident -> typed_raw_function }.

--- a/theories/Crypt/package/pkg_distr.v
+++ b/theories/Crypt/package/pkg_distr.v
@@ -15,7 +15,7 @@ From extructures Require Import ord fset fmap.
 From Mon Require Import SPropBase.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd SubDistr Couplings
   RulesStateProb UniformStateProb UniformDistrLemmas StateTransfThetaDens
-  StateTransformingLaxMorph choice_code pkg_core_definition pkg_notation
+  StateTransformingLaxMorph choice_type pkg_core_definition pkg_notation
   pkg_tactics pkg_composition pkg_heap pkg_semantics pkg_lookup pkg_advantage.
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.
@@ -156,15 +156,15 @@ Qed.
 
 (** Fail and Assert *)
 
-(* fail at any type in the choice_code *)
-Definition fail {A : choice_code} : raw_code A :=
+(* fail at any type in the choice_type *)
+Definition fail {A : choice_type} : raw_code A :=
   x ← sample (A ; dnull) ;; ret x.
 
 Definition assert b : raw_code 'unit :=
   if b then ret Datatypes.tt else @fail 'unit.
 
 (* Dependent version of assert *)
-Definition assertD {A : choice_code} b (k : b = true → raw_code A) : raw_code A :=
+Definition assertD {A : choice_type} b (k : b = true → raw_code A) : raw_code A :=
   (if b as b' return b = b' → raw_code A then k else λ _, fail) erefl.
 
 Lemma valid_fail :

--- a/theories/Crypt/package/pkg_distr.v
+++ b/theories/Crypt/package/pkg_distr.v
@@ -15,7 +15,7 @@ From extructures Require Import ord fset fmap.
 From Mon Require Import SPropBase.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd SubDistr Couplings
   RulesStateProb UniformStateProb UniformDistrLemmas StateTransfThetaDens
-  StateTransformingLaxMorph chUniverse pkg_core_definition pkg_notation
+  StateTransformingLaxMorph choice_code pkg_core_definition pkg_notation
   pkg_tactics pkg_composition pkg_heap pkg_semantics pkg_lookup pkg_advantage.
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.
@@ -156,15 +156,15 @@ Qed.
 
 (** Fail and Assert *)
 
-(* fail at any type in the chUniverse *)
-Definition fail {A : chUniverse} : raw_code A :=
+(* fail at any type in the choice_code *)
+Definition fail {A : choice_code} : raw_code A :=
   x ← sample (A ; dnull) ;; ret x.
 
 Definition assert b : raw_code 'unit :=
   if b then ret Datatypes.tt else @fail 'unit.
 
 (* Dependent version of assert *)
-Definition assertD {A : chUniverse} b (k : b = true → raw_code A) : raw_code A :=
+Definition assertD {A : choice_code} b (k : b = true → raw_code A) : raw_code A :=
   (if b as b' return b = b' → raw_code A then k else λ _, fail) erefl.
 
 Lemma valid_fail :

--- a/theories/Crypt/package/pkg_heap.v
+++ b/theories/Crypt/package/pkg_heap.v
@@ -15,7 +15,7 @@ From extructures Require Import ord fset fmap.
 From Mon Require Import SPropBase.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd SubDistr Couplings
   RulesStateProb UniformStateProb UniformDistrLemmas StateTransfThetaDens
-  StateTransformingLaxMorph chUniverse pkg_core_definition pkg_notation
+  StateTransformingLaxMorph choice_code pkg_core_definition pkg_notation
   pkg_tactics pkg_composition.
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.
@@ -34,7 +34,7 @@ Set Bullet Behavior "Strict Subproofs".
 Set Default Goal Selector "!".
 Set Primitive Projections.
 
-Definition pointed_value := ∑ (t : chUniverse), t.
+Definition pointed_value := ∑ (t : choice_code), t.
 
 Definition raw_heap := {fmap Location -> pointed_value}.
 Definition raw_heap_choiceType := [choiceType of raw_heap].
@@ -51,7 +51,7 @@ Definition valid_location (h : raw_heap) (l : Location) :=
 Definition valid_heap : pred raw_heap :=
   λ h, domm h == fset_filter (valid_location h) (domm h).
 
-Definition heap_defaults := ∀ a : chUniverse, a.
+Definition heap_defaults := ∀ a : choice_code, a.
 
 Definition heap_init : heap_defaults.
 Proof.
@@ -155,7 +155,7 @@ Next Obligation.
     unfold valid_location.
     rewrite setmE.
     destruct (x == l) eqn:H.
-    + cbn. move: H. move /eqP => H. subst. apply chUniverse_refl.
+    + cbn. move: H. move /eqP => H. subst. apply choice_code_refl.
     + move: Heq. move /idP /fsetU1P => Heq.
       destruct Heq.
       * move: H. move /eqP => H. contradiction.

--- a/theories/Crypt/package/pkg_heap.v
+++ b/theories/Crypt/package/pkg_heap.v
@@ -15,7 +15,7 @@ From extructures Require Import ord fset fmap.
 From Mon Require Import SPropBase.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd SubDistr Couplings
   RulesStateProb UniformStateProb UniformDistrLemmas StateTransfThetaDens
-  StateTransformingLaxMorph choice_code pkg_core_definition pkg_notation
+  StateTransformingLaxMorph choice_type pkg_core_definition pkg_notation
   pkg_tactics pkg_composition.
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.
@@ -34,7 +34,7 @@ Set Bullet Behavior "Strict Subproofs".
 Set Default Goal Selector "!".
 Set Primitive Projections.
 
-Definition pointed_value := ∑ (t : choice_code), t.
+Definition pointed_value := ∑ (t : choice_type), t.
 
 Definition raw_heap := {fmap Location -> pointed_value}.
 Definition raw_heap_choiceType := [choiceType of raw_heap].
@@ -51,7 +51,7 @@ Definition valid_location (h : raw_heap) (l : Location) :=
 Definition valid_heap : pred raw_heap :=
   λ h, domm h == fset_filter (valid_location h) (domm h).
 
-Definition heap_defaults := ∀ a : choice_code, a.
+Definition heap_defaults := ∀ a : choice_type, a.
 
 Definition heap_init : heap_defaults.
 Proof.
@@ -155,7 +155,7 @@ Next Obligation.
     unfold valid_location.
     rewrite setmE.
     destruct (x == l) eqn:H.
-    + cbn. move: H. move /eqP => H. subst. apply choice_code_refl.
+    + cbn. move: H. move /eqP => H. subst. apply choice_type_refl.
     + move: Heq. move /idP /fsetU1P => Heq.
       destruct Heq.
       * move: H. move /eqP => H. contradiction.

--- a/theories/Crypt/package/pkg_invariants.v
+++ b/theories/Crypt/package/pkg_invariants.v
@@ -15,7 +15,7 @@ From extructures Require Import ord fset fmap.
 From Mon Require Import SPropBase.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd SubDistr Couplings
   RulesStateProb UniformStateProb UniformDistrLemmas StateTransfThetaDens
-  StateTransformingLaxMorph chUniverse pkg_core_definition pkg_notation
+  StateTransformingLaxMorph choice_code pkg_core_definition pkg_notation
   pkg_tactics pkg_composition pkg_heap pkg_semantics pkg_lookup pkg_advantage.
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.

--- a/theories/Crypt/package/pkg_invariants.v
+++ b/theories/Crypt/package/pkg_invariants.v
@@ -15,7 +15,7 @@ From extructures Require Import ord fset fmap.
 From Mon Require Import SPropBase.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd SubDistr Couplings
   RulesStateProb UniformStateProb UniformDistrLemmas StateTransfThetaDens
-  StateTransformingLaxMorph choice_code pkg_core_definition pkg_notation
+  StateTransformingLaxMorph choice_type pkg_core_definition pkg_notation
   pkg_tactics pkg_composition pkg_heap pkg_semantics pkg_lookup pkg_advantage.
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.

--- a/theories/Crypt/package/pkg_lookup.v
+++ b/theories/Crypt/package/pkg_lookup.v
@@ -12,7 +12,7 @@ From extructures Require Import ord fset fmap.
 From Mon Require Import SPropBase.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd SubDistr Couplings
   RulesStateProb UniformStateProb UniformDistrLemmas StateTransfThetaDens
-  StateTransformingLaxMorph choice_code pkg_core_definition pkg_notation
+  StateTransformingLaxMorph choice_type pkg_core_definition pkg_notation
   pkg_tactics pkg_composition pkg_heap pkg_semantics.
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.
@@ -56,9 +56,9 @@ Proof.
   specialize (hp _ ho). cbn in hp. destruct hp as [f [ef hf]].
   cbn in e. destruct (p n) as [[St [Tt g]]|] eqn:e2.
   2: discriminate.
-  destruct choice_code_eqP.
+  destruct choice_type_eqP.
   2:{ noconf ef. congruence. }
-  destruct choice_code_eqP.
+  destruct choice_type_eqP.
   2:{ noconf ef. congruence. }
   discriminate.
 Qed.
@@ -119,17 +119,17 @@ Proof.
       destruct (p1 id) eqn:Hp1id.
       2: { inversion Hf. }
       destruct t as [S' [T' f']].
-      destruct choice_code_eqP.
+      destruct choice_type_eqP.
       2:{ noconf ef. congruence. }
-      destruct choice_code_eqP.
+      destruct choice_type_eqP.
       2:{ noconf ef. congruence. }
       noconf e. noconf e0.
       repeat f_equal. inversion Hf.
       rewrite -H0. reflexivity. }
     rewrite H in Hg.
-    destruct choice_code_eqP.
+    destruct choice_type_eqP.
     2:{ noconf ef. congruence. }
-    destruct choice_code_eqP.
+    destruct choice_type_eqP.
     2:{ noconf ef. congruence. }
     noconf e. noconf e0.
     inversion Hg.
@@ -153,9 +153,9 @@ Proof.
     destruct H as [f [H1 H2]].
     unfold lookup_op in e.
     rewrite H1 in e.
-    destruct choice_code_eqP.
+    destruct choice_type_eqP.
     2:{ noconf ef. congruence. }
-    destruct choice_code_eqP.
+    destruct choice_type_eqP.
     2:{ noconf ef. congruence. }
     discriminate.
   }
@@ -168,9 +168,9 @@ Proof.
     destruct H as [f' [H1 H2]].
     unfold lookup_op in el.
     rewrite H1 in el.
-    destruct choice_code_eqP.
+    destruct choice_type_eqP.
     2:{ noconf ef. congruence. }
-    destruct choice_code_eqP.
+    destruct choice_type_eqP.
     2:{ noconf ef. congruence. }
     discriminate.
   }
@@ -194,9 +194,9 @@ Proof.
     destruct H as [f [H1 H2]].
     unfold lookup_op in e.
     rewrite H1 in e.
-    destruct choice_code_eqP.
+    destruct choice_type_eqP.
     2:{ noconf ef. congruence. }
-    destruct choice_code_eqP.
+    destruct choice_type_eqP.
     2:{ noconf ef. congruence. }
     discriminate.
   }
@@ -223,9 +223,9 @@ Proof.
     destruct H as [f [H1 H2]].
     unfold lookup_op in e.
     rewrite H1 in e.
-    destruct choice_code_eqP.
+    destruct choice_type_eqP.
     2:{ noconf ef. congruence. }
-    destruct choice_code_eqP.
+    destruct choice_type_eqP.
     2:{ noconf ef. congruence. }
     discriminate.
   }
@@ -287,8 +287,8 @@ Proof.
   unfold lookup_op. unfold link.
   rewrite mapmE.
   destruct (p id) as [[S' [T' g]]|] eqn:e. 2: reflexivity.
-  simpl. destruct choice_code_eqP. 2: reflexivity.
-  destruct choice_code_eqP. 2: reflexivity.
+  simpl. destruct choice_type_eqP. 2: reflexivity.
+  destruct choice_type_eqP. 2: reflexivity.
   subst. cbn. reflexivity.
 Qed.
 
@@ -319,9 +319,9 @@ Proof.
     specialize (hp _ ho). cbn in hp. destruct hp as [f [ef hf]].
     cbn in e. destruct (p n) as [[St [Tt g]]|] eqn:e2.
     2: discriminate.
-    destruct choice_code_eqP.
+    destruct choice_type_eqP.
     2:{ noconf ef. congruence. }
-    destruct choice_code_eqP.
+    destruct choice_type_eqP.
     2:{ noconf ef. congruence. }
     discriminate.
   }
@@ -343,9 +343,9 @@ Proof.
   intros p id S T f e.
   unfold lookup_op.
   destruct (p id) as [[S' [T' g]]|] eqn:e1. 2: discriminate.
-  destruct choice_code_eqP.
+  destruct choice_type_eqP.
   2:{ noconf e. contradiction. }
-  destruct choice_code_eqP.
+  destruct choice_type_eqP.
   2:{ noconf e. contradiction. }
   subst.
   noconf e.

--- a/theories/Crypt/package/pkg_lookup.v
+++ b/theories/Crypt/package/pkg_lookup.v
@@ -12,7 +12,7 @@ From extructures Require Import ord fset fmap.
 From Mon Require Import SPropBase.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd SubDistr Couplings
   RulesStateProb UniformStateProb UniformDistrLemmas StateTransfThetaDens
-  StateTransformingLaxMorph chUniverse pkg_core_definition pkg_notation
+  StateTransformingLaxMorph choice_code pkg_core_definition pkg_notation
   pkg_tactics pkg_composition pkg_heap pkg_semantics.
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.
@@ -56,9 +56,9 @@ Proof.
   specialize (hp _ ho). cbn in hp. destruct hp as [f [ef hf]].
   cbn in e. destruct (p n) as [[St [Tt g]]|] eqn:e2.
   2: discriminate.
-  destruct chUniverse_eqP.
+  destruct choice_code_eqP.
   2:{ noconf ef. congruence. }
-  destruct chUniverse_eqP.
+  destruct choice_code_eqP.
   2:{ noconf ef. congruence. }
   discriminate.
 Qed.
@@ -119,17 +119,17 @@ Proof.
       destruct (p1 id) eqn:Hp1id.
       2: { inversion Hf. }
       destruct t as [S' [T' f']].
-      destruct chUniverse_eqP.
+      destruct choice_code_eqP.
       2:{ noconf ef. congruence. }
-      destruct chUniverse_eqP.
+      destruct choice_code_eqP.
       2:{ noconf ef. congruence. }
       noconf e. noconf e0.
       repeat f_equal. inversion Hf.
       rewrite -H0. reflexivity. }
     rewrite H in Hg.
-    destruct chUniverse_eqP.
+    destruct choice_code_eqP.
     2:{ noconf ef. congruence. }
-    destruct chUniverse_eqP.
+    destruct choice_code_eqP.
     2:{ noconf ef. congruence. }
     noconf e. noconf e0.
     inversion Hg.
@@ -153,9 +153,9 @@ Proof.
     destruct H as [f [H1 H2]].
     unfold lookup_op in e.
     rewrite H1 in e.
-    destruct chUniverse_eqP.
+    destruct choice_code_eqP.
     2:{ noconf ef. congruence. }
-    destruct chUniverse_eqP.
+    destruct choice_code_eqP.
     2:{ noconf ef. congruence. }
     discriminate.
   }
@@ -168,9 +168,9 @@ Proof.
     destruct H as [f' [H1 H2]].
     unfold lookup_op in el.
     rewrite H1 in el.
-    destruct chUniverse_eqP.
+    destruct choice_code_eqP.
     2:{ noconf ef. congruence. }
-    destruct chUniverse_eqP.
+    destruct choice_code_eqP.
     2:{ noconf ef. congruence. }
     discriminate.
   }
@@ -194,9 +194,9 @@ Proof.
     destruct H as [f [H1 H2]].
     unfold lookup_op in e.
     rewrite H1 in e.
-    destruct chUniverse_eqP.
+    destruct choice_code_eqP.
     2:{ noconf ef. congruence. }
-    destruct chUniverse_eqP.
+    destruct choice_code_eqP.
     2:{ noconf ef. congruence. }
     discriminate.
   }
@@ -223,9 +223,9 @@ Proof.
     destruct H as [f [H1 H2]].
     unfold lookup_op in e.
     rewrite H1 in e.
-    destruct chUniverse_eqP.
+    destruct choice_code_eqP.
     2:{ noconf ef. congruence. }
-    destruct chUniverse_eqP.
+    destruct choice_code_eqP.
     2:{ noconf ef. congruence. }
     discriminate.
   }
@@ -287,8 +287,8 @@ Proof.
   unfold lookup_op. unfold link.
   rewrite mapmE.
   destruct (p id) as [[S' [T' g]]|] eqn:e. 2: reflexivity.
-  simpl. destruct chUniverse_eqP. 2: reflexivity.
-  destruct chUniverse_eqP. 2: reflexivity.
+  simpl. destruct choice_code_eqP. 2: reflexivity.
+  destruct choice_code_eqP. 2: reflexivity.
   subst. cbn. reflexivity.
 Qed.
 
@@ -319,9 +319,9 @@ Proof.
     specialize (hp _ ho). cbn in hp. destruct hp as [f [ef hf]].
     cbn in e. destruct (p n) as [[St [Tt g]]|] eqn:e2.
     2: discriminate.
-    destruct chUniverse_eqP.
+    destruct choice_code_eqP.
     2:{ noconf ef. congruence. }
-    destruct chUniverse_eqP.
+    destruct choice_code_eqP.
     2:{ noconf ef. congruence. }
     discriminate.
   }
@@ -343,9 +343,9 @@ Proof.
   intros p id S T f e.
   unfold lookup_op.
   destruct (p id) as [[S' [T' g]]|] eqn:e1. 2: discriminate.
-  destruct chUniverse_eqP.
+  destruct choice_code_eqP.
   2:{ noconf e. contradiction. }
-  destruct chUniverse_eqP.
+  destruct choice_code_eqP.
   2:{ noconf e. contradiction. }
   subst.
   noconf e.

--- a/theories/Crypt/package/pkg_notation.v
+++ b/theories/Crypt/package/pkg_notation.v
@@ -100,7 +100,7 @@ From mathcomp Require Import ssrnat ssreflect ssrfun ssrbool ssrnum eqtype
 Set Warnings "notation-overridden,ambiguous-paths".
 From extructures Require Import ord fset fmap.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd RulesStateProb
-  chUniverse pkg_core_definition pkg_composition.
+  choice_code pkg_core_definition pkg_composition.
 
 
 #[local] Open Scope fset.

--- a/theories/Crypt/package/pkg_notation.v
+++ b/theories/Crypt/package/pkg_notation.v
@@ -100,7 +100,7 @@ From mathcomp Require Import ssrnat ssreflect ssrfun ssrbool ssrnum eqtype
 Set Warnings "notation-overridden,ambiguous-paths".
 From extructures Require Import ord fset fmap.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd RulesStateProb
-  choice_code pkg_core_definition pkg_composition.
+  choice_type pkg_core_definition pkg_composition.
 
 
 #[local] Open Scope fset.

--- a/theories/Crypt/package/pkg_rhl.v
+++ b/theories/Crypt/package/pkg_rhl.v
@@ -16,7 +16,7 @@ From extructures Require Import ord fset fmap.
 From Mon Require Import SPropBase.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd SubDistr Couplings
   RulesStateProb UniformStateProb UniformDistrLemmas StateTransfThetaDens
-  StateTransformingLaxMorph choice_code pkg_core_definition pkg_notation
+  StateTransformingLaxMorph choice_type pkg_core_definition pkg_notation
   pkg_tactics pkg_composition pkg_heap pkg_semantics pkg_lookup pkg_advantage
   pkg_invariants pkg_distr.
 Require Import Equations.Prop.DepElim.
@@ -313,7 +313,7 @@ Qed.
 (** Equivalence of packages in the program logic *)
 
 Definition eq_up_to_inv (E : Interface) (I : precond) (p₀ p₁ : raw_package) :=
-  ∀ (id : ident) (S T : choice_code) (x : S),
+  ∀ (id : ident) (S T : choice_type) (x : S),
     (id, (S, T)) \in E →
     ⊢ ⦃ λ '(s₀, s₁), I (s₀, s₁) ⦄
       get_op_default p₀ (id, (S, T)) x ≈ get_op_default p₁ (id, (S, T)) x
@@ -2330,7 +2330,7 @@ Proof.
 Qed.
 
 Theorem r_assertD :
-  ∀ {A₀ A₁ : choice_code} b₀ b₁ (pre : precond) (post : postcond A₀ A₁) k₀ k₁,
+  ∀ {A₀ A₁ : choice_type} b₀ b₁ (pre : precond) (post : postcond A₀ A₁) k₀ k₁,
     (∀ s, pre s → b₀ = b₁) →
     (∀ e₀ e₁, ⊢ ⦃ pre ⦄ k₀ e₀ ≈ k₁ e₁ ⦃ post ⦄) →
     ⊢ ⦃ pre ⦄ #assert b₀ as x ;; k₀ x ≈ #assert b₁ as x ;; k₁ x ⦃ post ⦄.
@@ -2347,7 +2347,7 @@ Qed.
 
 (* Simpler version for same_head *)
 Lemma r_assertD_same :
-  ∀ (A : choice_code) b (pre : precond) (post : postcond A A) k₀ k₁,
+  ∀ (A : choice_type) b (pre : precond) (post : postcond A A) k₀ k₁,
     (∀ e, ⊢ ⦃ pre ⦄ k₀ e ≈ k₁ e ⦃ post ⦄) →
     ⊢ ⦃ pre ⦄ #assert b as x ;; k₀ x ≈ #assert b as x ;; k₁ x ⦃ post ⦄.
 Proof.
@@ -2359,7 +2359,7 @@ Proof.
 Qed.
 
 Lemma r_cmd_fail :
-  ∀ A (B : choice_code) (c : command A) (pre : precond) (post : postcond B B),
+  ∀ A (B : choice_type) (c : command A) (pre : precond) (post : postcond B B),
     ⊢ ⦃ pre ⦄ fail ≈ c ;' fail ⦃ post ⦄.
 Proof.
   intros A B c pre post.
@@ -2385,7 +2385,7 @@ Proof.
 Qed.
 
 Lemma rswap_assertD_cmd_eq :
-  ∀ A (B : choice_code) b (c : command A) (r : _ → _ → raw_code B),
+  ∀ A (B : choice_type) b (c : command A) (r : _ → _ → raw_code B),
     ⊢ ⦃ λ '(h₀, h₁), h₀ = h₁ ⦄
       #assert b as e ;; x ← cmd c ;; r e x ≈
       x ← cmd c ;; #assert b as e ;; r e x
@@ -2399,7 +2399,7 @@ Qed.
 
 (* Symmetric of the above. *)
 Lemma rswap_cmd_assertD_eq :
-  ∀ A (B : choice_code) b (c : command A) (r : _ → _ → raw_code B),
+  ∀ A (B : choice_type) b (c : command A) (r : _ → _ → raw_code B),
     ⊢ ⦃ λ '(h₀, h₁), h₀ = h₁ ⦄
       x ← cmd c ;; #assert b as e ;; r e x ≈
       #assert b as e ;; x ← cmd c ;; r e x
@@ -2414,7 +2414,7 @@ Proof.
 Qed.
 
 Lemma rswap_assertD_assertD_eq :
-  ∀ (A : choice_code) b₀ b₁ (r : _ → _ → raw_code A),
+  ∀ (A : choice_type) b₀ b₁ (r : _ → _ → raw_code A),
     ⊢ ⦃ λ '(h₀, h₁), h₀ = h₁ ⦄
       #assert b₀ as e₀ ;; #assert b₁ as e₁ ;; r e₀ e₁ ≈
       #assert b₁ as e₁ ;; #assert b₀ as e₀ ;; r e₀ e₁
@@ -2430,7 +2430,7 @@ Qed.
 
 (* Unfortunately, this doesn't hold syntactically *)
 Lemma r_bind_assertD :
-  ∀ (A B : choice_code) b k1 (k2 : _ → raw_code B),
+  ∀ (A B : choice_type) b k1 (k2 : _ → raw_code B),
     ⊢ ⦃ λ '(h₀, h₁), h₀ = h₁ ⦄
       x ← (@assertD A b (λ z, k1 z)) ;; k2 x ≈
       @assertD B b (λ z, x ← k1 z ;; k2 x)
@@ -2457,7 +2457,7 @@ Proof.
 Qed.
 
 Lemma r_bind_assertD_sym :
-  ∀ (A B : choice_code) b k1 (k2 : _ → raw_code B),
+  ∀ (A B : choice_type) b k1 (k2 : _ → raw_code B),
     ⊢ ⦃ λ '(h₀, h₁), h₀ = h₁ ⦄
       @assertD B b (λ z, x ← k1 z ;; k2 x) ≈
       x ← (@assertD A b (λ z, k1 z)) ;; k2 x

--- a/theories/Crypt/package/pkg_rhl.v
+++ b/theories/Crypt/package/pkg_rhl.v
@@ -16,7 +16,7 @@ From extructures Require Import ord fset fmap.
 From Mon Require Import SPropBase.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd SubDistr Couplings
   RulesStateProb UniformStateProb UniformDistrLemmas StateTransfThetaDens
-  StateTransformingLaxMorph chUniverse pkg_core_definition pkg_notation
+  StateTransformingLaxMorph choice_code pkg_core_definition pkg_notation
   pkg_tactics pkg_composition pkg_heap pkg_semantics pkg_lookup pkg_advantage
   pkg_invariants pkg_distr.
 Require Import Equations.Prop.DepElim.
@@ -313,7 +313,7 @@ Qed.
 (** Equivalence of packages in the program logic *)
 
 Definition eq_up_to_inv (E : Interface) (I : precond) (p₀ p₁ : raw_package) :=
-  ∀ (id : ident) (S T : chUniverse) (x : S),
+  ∀ (id : ident) (S T : choice_code) (x : S),
     (id, (S, T)) \in E →
     ⊢ ⦃ λ '(s₀, s₁), I (s₀, s₁) ⦄
       get_op_default p₀ (id, (S, T)) x ≈ get_op_default p₁ (id, (S, T)) x
@@ -2330,7 +2330,7 @@ Proof.
 Qed.
 
 Theorem r_assertD :
-  ∀ {A₀ A₁ : chUniverse} b₀ b₁ (pre : precond) (post : postcond A₀ A₁) k₀ k₁,
+  ∀ {A₀ A₁ : choice_code} b₀ b₁ (pre : precond) (post : postcond A₀ A₁) k₀ k₁,
     (∀ s, pre s → b₀ = b₁) →
     (∀ e₀ e₁, ⊢ ⦃ pre ⦄ k₀ e₀ ≈ k₁ e₁ ⦃ post ⦄) →
     ⊢ ⦃ pre ⦄ #assert b₀ as x ;; k₀ x ≈ #assert b₁ as x ;; k₁ x ⦃ post ⦄.
@@ -2347,7 +2347,7 @@ Qed.
 
 (* Simpler version for same_head *)
 Lemma r_assertD_same :
-  ∀ (A : chUniverse) b (pre : precond) (post : postcond A A) k₀ k₁,
+  ∀ (A : choice_code) b (pre : precond) (post : postcond A A) k₀ k₁,
     (∀ e, ⊢ ⦃ pre ⦄ k₀ e ≈ k₁ e ⦃ post ⦄) →
     ⊢ ⦃ pre ⦄ #assert b as x ;; k₀ x ≈ #assert b as x ;; k₁ x ⦃ post ⦄.
 Proof.
@@ -2359,7 +2359,7 @@ Proof.
 Qed.
 
 Lemma r_cmd_fail :
-  ∀ A (B : chUniverse) (c : command A) (pre : precond) (post : postcond B B),
+  ∀ A (B : choice_code) (c : command A) (pre : precond) (post : postcond B B),
     ⊢ ⦃ pre ⦄ fail ≈ c ;' fail ⦃ post ⦄.
 Proof.
   intros A B c pre post.
@@ -2385,7 +2385,7 @@ Proof.
 Qed.
 
 Lemma rswap_assertD_cmd_eq :
-  ∀ A (B : chUniverse) b (c : command A) (r : _ → _ → raw_code B),
+  ∀ A (B : choice_code) b (c : command A) (r : _ → _ → raw_code B),
     ⊢ ⦃ λ '(h₀, h₁), h₀ = h₁ ⦄
       #assert b as e ;; x ← cmd c ;; r e x ≈
       x ← cmd c ;; #assert b as e ;; r e x
@@ -2399,7 +2399,7 @@ Qed.
 
 (* Symmetric of the above. *)
 Lemma rswap_cmd_assertD_eq :
-  ∀ A (B : chUniverse) b (c : command A) (r : _ → _ → raw_code B),
+  ∀ A (B : choice_code) b (c : command A) (r : _ → _ → raw_code B),
     ⊢ ⦃ λ '(h₀, h₁), h₀ = h₁ ⦄
       x ← cmd c ;; #assert b as e ;; r e x ≈
       #assert b as e ;; x ← cmd c ;; r e x
@@ -2414,7 +2414,7 @@ Proof.
 Qed.
 
 Lemma rswap_assertD_assertD_eq :
-  ∀ (A : chUniverse) b₀ b₁ (r : _ → _ → raw_code A),
+  ∀ (A : choice_code) b₀ b₁ (r : _ → _ → raw_code A),
     ⊢ ⦃ λ '(h₀, h₁), h₀ = h₁ ⦄
       #assert b₀ as e₀ ;; #assert b₁ as e₁ ;; r e₀ e₁ ≈
       #assert b₁ as e₁ ;; #assert b₀ as e₀ ;; r e₀ e₁
@@ -2430,7 +2430,7 @@ Qed.
 
 (* Unfortunately, this doesn't hold syntactically *)
 Lemma r_bind_assertD :
-  ∀ (A B : chUniverse) b k1 (k2 : _ → raw_code B),
+  ∀ (A B : choice_code) b k1 (k2 : _ → raw_code B),
     ⊢ ⦃ λ '(h₀, h₁), h₀ = h₁ ⦄
       x ← (@assertD A b (λ z, k1 z)) ;; k2 x ≈
       @assertD B b (λ z, x ← k1 z ;; k2 x)
@@ -2457,7 +2457,7 @@ Proof.
 Qed.
 
 Lemma r_bind_assertD_sym :
-  ∀ (A B : chUniverse) b k1 (k2 : _ → raw_code B),
+  ∀ (A B : choice_code) b k1 (k2 : _ → raw_code B),
     ⊢ ⦃ λ '(h₀, h₁), h₀ = h₁ ⦄
       @assertD B b (λ z, x ← k1 z ;; k2 x) ≈
       x ← (@assertD A b (λ z, k1 z)) ;; k2 x

--- a/theories/Crypt/package/pkg_semantics.v
+++ b/theories/Crypt/package/pkg_semantics.v
@@ -15,7 +15,7 @@ From extructures Require Import ord fset fmap.
 From Mon Require Import SPropBase.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd SubDistr Couplings
   RulesStateProb UniformStateProb UniformDistrLemmas StateTransfThetaDens
-  StateTransformingLaxMorph chUniverse pkg_core_definition pkg_notation
+  StateTransformingLaxMorph choice_code pkg_core_definition pkg_notation
   pkg_tactics pkg_composition pkg_heap.
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.
@@ -48,7 +48,7 @@ Arguments ropr {_ _ _} _ _.
 (** Interpretation of raw codes into the semantic model
 
   Note that we don't require any validity proof to do so,
-  instead we rely on the fact that types in the chUniverse are all
+  instead we rely on the fact that types in the choice_code are all
   inhabited.
 
 *)

--- a/theories/Crypt/package/pkg_semantics.v
+++ b/theories/Crypt/package/pkg_semantics.v
@@ -15,7 +15,7 @@ From extructures Require Import ord fset fmap.
 From Mon Require Import SPropBase.
 From Crypt Require Import Prelude Axioms ChoiceAsOrd SubDistr Couplings
   RulesStateProb UniformStateProb UniformDistrLemmas StateTransfThetaDens
-  StateTransformingLaxMorph choice_code pkg_core_definition pkg_notation
+  StateTransformingLaxMorph choice_type pkg_core_definition pkg_notation
   pkg_tactics pkg_composition pkg_heap.
 Require Import Equations.Prop.DepElim.
 From Equations Require Import Equations.
@@ -48,7 +48,7 @@ Arguments ropr {_ _ _} _ _.
 (** Interpretation of raw codes into the semantic model
 
   Note that we don't require any validity proof to do so,
-  instead we rely on the fact that types in the choice_code are all
+  instead we rely on the fact that types in the choice_type are all
   inhabited.
 
 *)

--- a/theories/Crypt/package/pkg_tactics.v
+++ b/theories/Crypt/package/pkg_tactics.v
@@ -32,7 +32,7 @@ From mathcomp Require Import ssreflect ssrbool ssrnat eqtype seq eqtype
 Set Warnings "notation-overridden,ambiguous-paths".
 From extructures Require Import ord fset fmap.
 From Crypt Require Import Prelude pkg_core_definition
-  pkg_composition pkg_notation chUniverse
+  pkg_composition pkg_notation choice_code
   RulesStateProb.
 From Coq Require Import Utf8 FunctionalExtensionality
   Setoids.Setoid Classes.Morphisms.
@@ -308,11 +308,11 @@ Proof.
   rewrite -fset0E in h. auto.
 Qed.
 
-Ltac chUniverse_eq_prove :=
+Ltac choice_code_eq_prove :=
   lazymatch goal with
-  | |- chProd _ _ = chProd _ _ => f_equal ; chUniverse_eq_prove
-  | |- chMap _ _ = chMap _ _ => f_equal ; chUniverse_eq_prove
-  | |- chOption _ = chOption _ => f_equal ; chUniverse_eq_prove
+  | |- chProd _ _ = chProd _ _ => f_equal ; choice_code_eq_prove
+  | |- chMap _ _ = chMap _ _ => f_equal ; choice_code_eq_prove
+  | |- chOption _ = chOption _ => f_equal ; choice_code_eq_prove
   | |- chFin _ = chFin _ => f_equal ; apply positive_ext ; reflexivity
   | |- _ = _ => reflexivity
   end.
@@ -323,8 +323,8 @@ Ltac chUniverse_eq_prove :=
     idtac
   | intro
   | rewrite imfset_fset ; rewrite notin_fset
-  | chUniverse_eq_prove
-  | chUniverse_eq_prove
+  | choice_code_eq_prove
+  | choice_code_eq_prove
   ]
   : typeclass_instances ssprove_valid_db.
 

--- a/theories/Crypt/package/pkg_tactics.v
+++ b/theories/Crypt/package/pkg_tactics.v
@@ -32,7 +32,7 @@ From mathcomp Require Import ssreflect ssrbool ssrnat eqtype seq eqtype
 Set Warnings "notation-overridden,ambiguous-paths".
 From extructures Require Import ord fset fmap.
 From Crypt Require Import Prelude pkg_core_definition
-  pkg_composition pkg_notation choice_code
+  pkg_composition pkg_notation choice_type
   RulesStateProb.
 From Coq Require Import Utf8 FunctionalExtensionality
   Setoids.Setoid Classes.Morphisms.
@@ -308,11 +308,11 @@ Proof.
   rewrite -fset0E in h. auto.
 Qed.
 
-Ltac choice_code_eq_prove :=
+Ltac choice_type_eq_prove :=
   lazymatch goal with
-  | |- chProd _ _ = chProd _ _ => f_equal ; choice_code_eq_prove
-  | |- chMap _ _ = chMap _ _ => f_equal ; choice_code_eq_prove
-  | |- chOption _ = chOption _ => f_equal ; choice_code_eq_prove
+  | |- chProd _ _ = chProd _ _ => f_equal ; choice_type_eq_prove
+  | |- chMap _ _ = chMap _ _ => f_equal ; choice_type_eq_prove
+  | |- chOption _ = chOption _ => f_equal ; choice_type_eq_prove
   | |- chFin _ = chFin _ => f_equal ; apply positive_ext ; reflexivity
   | |- _ = _ => reflexivity
   end.
@@ -323,8 +323,8 @@ Ltac choice_code_eq_prove :=
     idtac
   | intro
   | rewrite imfset_fset ; rewrite notin_fset
-  | choice_code_eq_prove
-  | choice_code_eq_prove
+  | choice_type_eq_prove
+  | choice_type_eq_prove
   ]
   : typeclass_instances ssprove_valid_db.
 

--- a/theories/Crypt/package/pkg_user_util.v
+++ b/theories/Crypt/package/pkg_user_util.v
@@ -24,7 +24,7 @@
     [ssprove_code_simpl].
 
   - [simplify_linking]
-    Will deal with residual [chUniverse_eqP] coming from linking.
+    Will deal with residual [choice_code_eqP] coming from linking.
 
 
   Tools for relation program logic
@@ -77,7 +77,7 @@ Set Warnings "notation-overridden,ambiguous-paths,notation-incompatible-format".
 From extructures Require Import ord fset fmap.
 From Crypt Require Import Axioms Prelude pkg_core_definition pkg_composition
   pkg_notation RulesStateProb pkg_advantage pkg_lookup pkg_semantics
-  pkg_heap pkg_invariants pkg_distr pkg_rhl pkg_tactics chUniverse.
+  pkg_heap pkg_invariants pkg_distr pkg_rhl pkg_tactics choice_code.
 From Coq Require Import Utf8 FunctionalExtensionality
   Setoids.Setoid Classes.Morphisms.
 
@@ -133,7 +133,7 @@ Ltac lookup_op_squeeze :=
   destruct lookup_op as [f|] eqn:e ; [
   | exfalso ;
     simpl in e ;
-    repeat (destruct chUniverse_eqP ; [| contradiction ]) ;
+    repeat (destruct choice_code_eqP ; [| contradiction ]) ;
     discriminate
   ] ;
   eapply lookup_op_spec in e ; simpl in e ;
@@ -149,14 +149,14 @@ Ltac lookup_op_squeeze :=
   ) ;
   noconf e.
 
-Ltac chUniverse_eqP_handle :=
+Ltac choice_code_eqP_handle :=
   let e := fresh "e" in
-  destruct chUniverse_eqP as [e|] ; [| contradiction ] ;
+  destruct choice_code_eqP as [e|] ; [| contradiction ] ;
   assert (e = erefl) by eapply uip ;
   subst e.
 
 Ltac simplify_linking :=
-  repeat chUniverse_eqP_handle ;
+  repeat choice_code_eqP_handle ;
   simpl.
 
 Ltac simplify_eq_rel m :=
@@ -302,7 +302,7 @@ Ltac cmd_bind_simpl :=
   repeat cmd_bind_simpl_once.
 
 (* No clear way of having cmd_assertD *)
-(* Definition cmd_assertD {A : chUniverse} (b : bool) : command A :=
+(* Definition cmd_assertD {A : choice_code} (b : bool) : command A :=
   (if b as b' return b = b' → raw_code A then k else λ _, fail) erefl. *)
 
 (* Right-biased application of rsame_head *)
@@ -568,7 +568,7 @@ Ltac ssprove_swap_seq_lhs l :=
   intros n ? ? h₀ h₁ ;
   invert_interface_in h₀ ;
   invert_interface_in h₁ ;
-  chUniverse_eq_prove
+  choice_code_eq_prove
   : typeclass_instances ssprove_valid_db.
 
 Lemma code_link_scheme :
@@ -606,7 +606,7 @@ Ltac ssprove_code_simpl_more_aux :=
     lazymatch c with
     | @bind _ (chElement ?B) (@assertD ?A ?b ?k1) ?k2 =>
       eapply r_transR ; [
-        (* How do I recover the other chUniverse otherwise? *)
+        (* How do I recover the other choice_code otherwise? *)
         eapply (r_bind_assertD_sym A B b k1 k2)
       | simpl
       ]

--- a/theories/Crypt/package/pkg_user_util.v
+++ b/theories/Crypt/package/pkg_user_util.v
@@ -24,7 +24,7 @@
     [ssprove_code_simpl].
 
   - [simplify_linking]
-    Will deal with residual [choice_code_eqP] coming from linking.
+    Will deal with residual [choice_type_eqP] coming from linking.
 
 
   Tools for relation program logic
@@ -77,7 +77,7 @@ Set Warnings "notation-overridden,ambiguous-paths,notation-incompatible-format".
 From extructures Require Import ord fset fmap.
 From Crypt Require Import Axioms Prelude pkg_core_definition pkg_composition
   pkg_notation RulesStateProb pkg_advantage pkg_lookup pkg_semantics
-  pkg_heap pkg_invariants pkg_distr pkg_rhl pkg_tactics choice_code.
+  pkg_heap pkg_invariants pkg_distr pkg_rhl pkg_tactics choice_type.
 From Coq Require Import Utf8 FunctionalExtensionality
   Setoids.Setoid Classes.Morphisms.
 
@@ -133,7 +133,7 @@ Ltac lookup_op_squeeze :=
   destruct lookup_op as [f|] eqn:e ; [
   | exfalso ;
     simpl in e ;
-    repeat (destruct choice_code_eqP ; [| contradiction ]) ;
+    repeat (destruct choice_type_eqP ; [| contradiction ]) ;
     discriminate
   ] ;
   eapply lookup_op_spec in e ; simpl in e ;
@@ -149,14 +149,14 @@ Ltac lookup_op_squeeze :=
   ) ;
   noconf e.
 
-Ltac choice_code_eqP_handle :=
+Ltac choice_type_eqP_handle :=
   let e := fresh "e" in
-  destruct choice_code_eqP as [e|] ; [| contradiction ] ;
+  destruct choice_type_eqP as [e|] ; [| contradiction ] ;
   assert (e = erefl) by eapply uip ;
   subst e.
 
 Ltac simplify_linking :=
-  repeat choice_code_eqP_handle ;
+  repeat choice_type_eqP_handle ;
   simpl.
 
 Ltac simplify_eq_rel m :=
@@ -302,7 +302,7 @@ Ltac cmd_bind_simpl :=
   repeat cmd_bind_simpl_once.
 
 (* No clear way of having cmd_assertD *)
-(* Definition cmd_assertD {A : choice_code} (b : bool) : command A :=
+(* Definition cmd_assertD {A : choice_type} (b : bool) : command A :=
   (if b as b' return b = b' → raw_code A then k else λ _, fail) erefl. *)
 
 (* Right-biased application of rsame_head *)
@@ -568,7 +568,7 @@ Ltac ssprove_swap_seq_lhs l :=
   intros n ? ? h₀ h₁ ;
   invert_interface_in h₀ ;
   invert_interface_in h₁ ;
-  choice_code_eq_prove
+  choice_type_eq_prove
   : typeclass_instances ssprove_valid_db.
 
 Lemma code_link_scheme :
@@ -606,7 +606,7 @@ Ltac ssprove_code_simpl_more_aux :=
     lazymatch c with
     | @bind _ (chElement ?B) (@assertD ?A ?b ?k1) ?k2 =>
       eapply r_transR ; [
-        (* How do I recover the other choice_code otherwise? *)
+        (* How do I recover the other choice_type otherwise? *)
         eapply (r_bind_assertD_sym A B b k1 k2)
       | simpl
       ]

--- a/theories/Crypt/rhl_semantics/free_monad/FreeProbProg.v
+++ b/theories/Crypt/rhl_semantics/free_monad/FreeProbProg.v
@@ -2,7 +2,7 @@ Set Warnings "-notation-overridden".
 From mathcomp Require Import all_ssreflect boolp.
 Set Warnings "notation-overridden".
 From Relational Require Import OrderEnrichedCategory OrderEnrichedRelativeMonadExamples.
-From Crypt Require Import ChoiceAsOrd choice_code.
+From Crypt Require Import ChoiceAsOrd choice_type.
 From Crypt Require Import SubDistr.
 
 
@@ -24,8 +24,8 @@ the arity predicate (ar : S -> choiceType) would map each operation to bool
 Indeed we expect the environment to either return true or false after
 a Bernouilli sampling operation has been issued to it.
 
-We take S = { X: choice_code & SDistr X }, that is, each subdistribution
-sampling from a choiceType present in choice_code (a small universe of choiceTypes)
+We take S = { X: choice_type & SDistr X }, that is, each subdistribution
+sampling from a choiceType present in choice_type (a small universe of choiceTypes)
 is considered as being part of our probabilistic signature (S,P)
 where P : S -> choiceType is the first projection.
 
@@ -124,7 +124,7 @@ End RelativeFreeMonad.
 Section Unary_free_prob_monad.
 
   (* the type of probabilistic operations*)
-  Definition P_OP  := { X : choice_code & SDistr X }.
+  Definition P_OP  := { X : choice_type & SDistr X }.
 
   (* the arities for operations in OPP*)
   Definition P_AR : P_OP -> choiceType :=

--- a/theories/Crypt/rhl_semantics/free_monad/FreeProbProg.v
+++ b/theories/Crypt/rhl_semantics/free_monad/FreeProbProg.v
@@ -2,7 +2,7 @@ Set Warnings "-notation-overridden".
 From mathcomp Require Import all_ssreflect boolp.
 Set Warnings "notation-overridden".
 From Relational Require Import OrderEnrichedCategory OrderEnrichedRelativeMonadExamples.
-From Crypt Require Import ChoiceAsOrd chUniverse.
+From Crypt Require Import ChoiceAsOrd choice_code.
 From Crypt Require Import SubDistr.
 
 
@@ -24,8 +24,8 @@ the arity predicate (ar : S -> choiceType) would map each operation to bool
 Indeed we expect the environment to either return true or false after
 a Bernouilli sampling operation has been issued to it.
 
-We take S = { X: chUniverse & SDistr X }, that is, each subdistribution
-sampling from a choiceType present in chUniverse (a small universe of choiceTypes)
+We take S = { X: choice_code & SDistr X }, that is, each subdistribution
+sampling from a choiceType present in choice_code (a small universe of choiceTypes)
 is considered as being part of our probabilistic signature (S,P)
 where P : S -> choiceType is the first projection.
 
@@ -33,7 +33,7 @@ where P : S -> choiceType is the first projection.
 NOTE regarding ancient design:
 
 Note that before we were specifying a probabilistic operation with
-an ITree like event type 
+an ITree like event type
 Inductive probE : Type -> Type :=
   |Bern : unit_interval R -> probE bool
   |Poisson : (λ : unit_interval R) → probE nat.
@@ -43,7 +43,7 @@ parameters of the constructors are supposed to represent the information
 we would like to pass when we issue an operation. For instance when
 sampling uniformly a boolean we need to provide a probability p : [O,1].
 We were using this last way of specifying sampling operations generically
-and we were translating this signature 
+and we were translating this signature
 internally into a collection of operations S and an
 arity predicate ar : S -> choiceType
 *)
@@ -124,8 +124,8 @@ End RelativeFreeMonad.
 Section Unary_free_prob_monad.
 
   (* the type of probabilistic operations*)
-  Definition P_OP  := { X : chUniverse & SDistr X }.
-  
+  Definition P_OP  := { X : choice_code & SDistr X }.
+
   (* the arities for operations in OPP*)
   Definition P_AR : P_OP -> choiceType :=
     fun op => chElement ( projT1 op ).

--- a/theories/Crypt/rhl_semantics/only_prob/Theta_dens.v
+++ b/theories/Crypt/rhl_semantics/only_prob/Theta_dens.v
@@ -3,7 +3,7 @@ From Relational Require Import OrderEnrichedCategory OrderEnrichedRelativeMonadE
 Set Warnings "-notation-overridden,-ambiguous-paths".
 From mathcomp Require Import all_ssreflect all_algebra reals distr realsum.
 Set Warnings "notation-overridden,ambiguous-paths".
-From Crypt Require Import ChoiceAsOrd Axioms RelativeMonadMorph_prod FreeProbProg SubDistr choice_code.
+From Crypt Require Import ChoiceAsOrd Axioms RelativeMonadMorph_prod FreeProbProg SubDistr choice_type.
 
 
 Import SPropNotations.
@@ -27,7 +27,7 @@ SDistr.
 
 (* Section test. *)
 (*   (*In this section we implement a probability handler, ie something of type *)
-(*   forall T : choice_code, probE T -> SDistr T*) *)
+(*   forall T : choice_type, probE T -> SDistr T*) *)
 (*   (*This kind of handler is exactly the data needed to define a universal map exiting *)
 (*   the free probablistic relative monad defined in FreeProbProg.v. Is abstracted over *)
 (*   in the subsequent sections. *) *)
@@ -42,14 +42,14 @@ SDistr.
 (*     |Bern : unit_interval R -> concrete_probE bool *)
 (*     |Poiss : unit_interval R -> concrete_probE nat. *)
 
-(*   Record my_choice_code : Type := mk_choice_code *)
+(*   Record my_choice_type : Type := mk_choice_type *)
 (*     { abs_chTy :> choiceType ; *)
 (*       unlock_absChTy : ((abs_chTy = bool_choiceType) + ( abs_chTy = nat_choiceType))%type *)
 (*     }. *)
 
-(*   Definition my_chElement : my_choice_code -> choiceType := fun relChTy => *)
+(*   Definition my_chElement : my_choice_type -> choiceType := fun relChTy => *)
 (*     match relChTy with *)
-(*     |mk_choice_code T unlock_T => *)
+(*     |mk_choice_type T unlock_T => *)
 (*     match unlock_T with *)
 (*     |inl unlock_bool => bool_choiceType *)
 (*     |inr unlock_nat => nat_choiceType *)

--- a/theories/Crypt/rhl_semantics/only_prob/Theta_dens.v
+++ b/theories/Crypt/rhl_semantics/only_prob/Theta_dens.v
@@ -3,7 +3,7 @@ From Relational Require Import OrderEnrichedCategory OrderEnrichedRelativeMonadE
 Set Warnings "-notation-overridden,-ambiguous-paths".
 From mathcomp Require Import all_ssreflect all_algebra reals distr realsum.
 Set Warnings "notation-overridden,ambiguous-paths".
-From Crypt Require Import ChoiceAsOrd Axioms RelativeMonadMorph_prod FreeProbProg SubDistr chUniverse.
+From Crypt Require Import ChoiceAsOrd Axioms RelativeMonadMorph_prod FreeProbProg SubDistr choice_code.
 
 
 Import SPropNotations.
@@ -27,7 +27,7 @@ SDistr.
 
 (* Section test. *)
 (*   (*In this section we implement a probability handler, ie something of type *)
-(*   forall T : chUniverse, probE T -> SDistr T*) *)
+(*   forall T : choice_code, probE T -> SDistr T*) *)
 (*   (*This kind of handler is exactly the data needed to define a universal map exiting *)
 (*   the free probablistic relative monad defined in FreeProbProg.v. Is abstracted over *)
 (*   in the subsequent sections. *) *)
@@ -42,14 +42,14 @@ SDistr.
 (*     |Bern : unit_interval R -> concrete_probE bool *)
 (*     |Poiss : unit_interval R -> concrete_probE nat. *)
 
-(*   Record my_chUniverse : Type := mk_chUniverse *)
+(*   Record my_choice_code : Type := mk_choice_code *)
 (*     { abs_chTy :> choiceType ; *)
 (*       unlock_absChTy : ((abs_chTy = bool_choiceType) + ( abs_chTy = nat_choiceType))%type *)
 (*     }. *)
 
-(*   Definition my_chElement : my_chUniverse -> choiceType := fun relChTy => *)
+(*   Definition my_chElement : my_choice_code -> choiceType := fun relChTy => *)
 (*     match relChTy with *)
-(*     |mk_chUniverse T unlock_T => *)
+(*     |mk_choice_code T unlock_T => *)
 (*     match unlock_T with *)
 (*     |inl unlock_bool => bool_choiceType *)
 (*     |inr unlock_nat => nat_choiceType *)

--- a/theories/Crypt/rhl_semantics/state_prob/StateTransfThetaDens.v
+++ b/theories/Crypt/rhl_semantics/state_prob/StateTransfThetaDens.v
@@ -36,8 +36,8 @@ End GetDomainAndCodomain.
 
 Section StT_unaryThetaDens.
   Context {probE : Type -> Type}. (*an interface for probabilistic events*)
-  Context {choice_code : Type}
-          {chElement : choice_code -> choiceType}.
+  Context {choice_type : Type}
+          {chElement : choice_type -> choiceType}.
   Context (prob_handler : forall (T:choiceType),
     probE T -> SDistr T).
 
@@ -122,8 +122,8 @@ End StT_unaryThetaDens.
 
 Section MakeTheDomainFree.
   Context {probE : Type -> Type}. (*an interface for probabilistic events*)
-  Context {choice_code : Type}
-          {chElement : choice_code -> choiceType}.
+  Context {choice_type : Type}
+          {chElement : choice_type -> choiceType}.
   Context {prob_handler : forall (T:choiceType),
     probE T -> SDistr T}.
 

--- a/theories/Crypt/rhl_semantics/state_prob/StateTransfThetaDens.v
+++ b/theories/Crypt/rhl_semantics/state_prob/StateTransfThetaDens.v
@@ -36,8 +36,8 @@ End GetDomainAndCodomain.
 
 Section StT_unaryThetaDens.
   Context {probE : Type -> Type}. (*an interface for probabilistic events*)
-  Context {chUniverse : Type}
-          {chElement : chUniverse -> choiceType}.
+  Context {choice_code : Type}
+          {chElement : choice_code -> choiceType}.
   Context (prob_handler : forall (T:choiceType),
     probE T -> SDistr T).
 
@@ -122,8 +122,8 @@ End StT_unaryThetaDens.
 
 Section MakeTheDomainFree.
   Context {probE : Type -> Type}. (*an interface for probabilistic events*)
-  Context {chUniverse : Type}
-          {chElement : chUniverse -> choiceType}.
+  Context {choice_code : Type}
+          {chElement : choice_code -> choiceType}.
   Context {prob_handler : forall (T:choiceType),
     probE T -> SDistr T}.
 

--- a/theories/Crypt/rhl_semantics/state_prob/StateTransformingLaxMorph.v
+++ b/theories/Crypt/rhl_semantics/state_prob/StateTransformingLaxMorph.v
@@ -5,7 +5,7 @@ From Mon Require Import SPropBase.
 Set Warnings "-notation-overridden,-ambiguous-paths".
 From mathcomp Require Import all_ssreflect (*boolp*).
 Set Warnings "notation-overridden,ambiguous-paths".
-From Crypt Require Import Axioms OrderEnrichedRelativeAdjunctions LaxFunctorsAndTransf LaxMorphismOfRelAdjunctions TransformingLaxMorph OrderEnrichedRelativeAdjunctionsExamples ThetaDex SubDistr Theta_exCP ChoiceAsOrd FreeProbProg UniversalFreeMap RelativeMonadMorph_prod LaxComp choice_code.
+From Crypt Require Import Axioms OrderEnrichedRelativeAdjunctions LaxFunctorsAndTransf LaxMorphismOfRelAdjunctions TransformingLaxMorph OrderEnrichedRelativeAdjunctionsExamples ThetaDex SubDistr Theta_exCP ChoiceAsOrd FreeProbProg UniversalFreeMap RelativeMonadMorph_prod LaxComp choice_type.
 (* From Crypt Require Import only_prob.Rules. *)
 
 Import SPropNotations.
@@ -219,7 +219,7 @@ Section UnaryInterpretState.
     retrFree_filled (F_choice_prod ⟨ unit_choiceType, S ⟩) (tt, new_s).
 
 
-  Definition probopStP {T : choice_code} (sd: SDistr T) : stT_Frp (chElement T).
+  Definition probopStP {T : choice_type} (sd: SDistr T) : stT_Frp (chElement T).
     move=> s. simpl.
     unshelve eapply ropr.
       unshelve econstructor. exact T. exact sd.

--- a/theories/Crypt/rhl_semantics/state_prob/StateTransformingLaxMorph.v
+++ b/theories/Crypt/rhl_semantics/state_prob/StateTransformingLaxMorph.v
@@ -5,7 +5,7 @@ From Mon Require Import SPropBase.
 Set Warnings "-notation-overridden,-ambiguous-paths".
 From mathcomp Require Import all_ssreflect (*boolp*).
 Set Warnings "notation-overridden,ambiguous-paths".
-From Crypt Require Import Axioms OrderEnrichedRelativeAdjunctions LaxFunctorsAndTransf LaxMorphismOfRelAdjunctions TransformingLaxMorph OrderEnrichedRelativeAdjunctionsExamples ThetaDex SubDistr Theta_exCP ChoiceAsOrd FreeProbProg UniversalFreeMap RelativeMonadMorph_prod LaxComp chUniverse.
+From Crypt Require Import Axioms OrderEnrichedRelativeAdjunctions LaxFunctorsAndTransf LaxMorphismOfRelAdjunctions TransformingLaxMorph OrderEnrichedRelativeAdjunctionsExamples ThetaDex SubDistr Theta_exCP ChoiceAsOrd FreeProbProg UniversalFreeMap RelativeMonadMorph_prod LaxComp choice_code.
 (* From Crypt Require Import only_prob.Rules. *)
 
 Import SPropNotations.
@@ -219,7 +219,7 @@ Section UnaryInterpretState.
     retrFree_filled (F_choice_prod ⟨ unit_choiceType, S ⟩) (tt, new_s).
 
 
-  Definition probopStP {T : chUniverse} (sd: SDistr T) : stT_Frp (chElement T).
+  Definition probopStP {T : choice_code} (sd: SDistr T) : stT_Frp (chElement T).
     move=> s. simpl.
     unshelve eapply ropr.
       unshelve econstructor. exact T. exact sd.

--- a/theories/Crypt/rules/RulesProb.v
+++ b/theories/Crypt/rules/RulesProb.v
@@ -94,7 +94,7 @@ Definition pure {X : ord_choiceType} (x : X) := ord_relmon_unit MFreePr _ x.
 
 Definition retF { A : choiceType } (a : A) := retrFree Ops Arit A a.
 
-(* Notation " A <$ c " := (@sample_from probE chUniverse chElement Hch A c) (at level 100). *)
+(* Notation " A <$ c " := (@sample_from probE choice_code chElement Hch A c) (at level 100). *)
 
 
 Definition M_d := (@RelativeMonadMorph_prod.Mprod _ _ _  MFreePr _ _ _ MFreePr ).

--- a/theories/Crypt/rules/RulesProb.v
+++ b/theories/Crypt/rules/RulesProb.v
@@ -94,7 +94,7 @@ Definition pure {X : ord_choiceType} (x : X) := ord_relmon_unit MFreePr _ x.
 
 Definition retF { A : choiceType } (a : A) := retrFree Ops Arit A a.
 
-(* Notation " A <$ c " := (@sample_from probE choice_code chElement Hch A c) (at level 100). *)
+(* Notation " A <$ c " := (@sample_from probE choice_type chElement Hch A c) (at level 100). *)
 
 
 Definition M_d := (@RelativeMonadMorph_prod.Mprod _ _ _  MFreePr _ _ _ MFreePr ).

--- a/theories/Crypt/rules/RulesStateProb.v
+++ b/theories/Crypt/rules/RulesStateProb.v
@@ -13,7 +13,7 @@ Set Warnings "notation-overridden,ambiguous-paths".
 
 From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings Theta_dens
   Theta_exCP LaxComp FreeProbProg RelativeMonadMorph_prod
-  StateTransformingLaxMorph choice_code.
+  StateTransformingLaxMorph choice_type.
 
 Import SPropNotations.
 Import Num.Theory.

--- a/theories/Crypt/rules/RulesStateProb.v
+++ b/theories/Crypt/rules/RulesStateProb.v
@@ -13,7 +13,7 @@ Set Warnings "notation-overridden,ambiguous-paths".
 
 From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings Theta_dens
   Theta_exCP LaxComp FreeProbProg RelativeMonadMorph_prod
-  StateTransformingLaxMorph chUniverse.
+  StateTransformingLaxMorph choice_code.
 
 Import SPropNotations.
 Import Num.Theory.

--- a/theories/Crypt/rules/UniformDistr.v
+++ b/theories/Crypt/rules/UniformDistr.v
@@ -33,7 +33,7 @@ From Crypt Require Import
      FreeProbProg
      RulesProb
      UniformDistrLemmas
-     choice_code
+     choice_type
      Prelude.
 
 Import SPropNotations.

--- a/theories/Crypt/rules/UniformDistr.v
+++ b/theories/Crypt/rules/UniformDistr.v
@@ -33,7 +33,7 @@ From Crypt Require Import
      FreeProbProg
      RulesProb
      UniformDistrLemmas
-     chUniverse
+     choice_code
      Prelude.
 
 Import SPropNotations.

--- a/theories/Crypt/rules/UniformStateProb.v
+++ b/theories/Crypt/rules/UniformStateProb.v
@@ -10,7 +10,7 @@ Set Warnings "notation-overridden,ambiguous-paths".
 
 From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings Theta_dens
   Theta_exCP LaxComp FreeProbProg UniformDistrLemmas
-  Prelude chUniverse StateTransformingLaxMorph RulesStateProb.
+  Prelude choice_code StateTransformingLaxMorph RulesStateProb.
 
 Import SPropNotations.
 Import Num.Theory.

--- a/theories/Crypt/rules/UniformStateProb.v
+++ b/theories/Crypt/rules/UniformStateProb.v
@@ -10,7 +10,7 @@ Set Warnings "notation-overridden,ambiguous-paths".
 
 From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings Theta_dens
   Theta_exCP LaxComp FreeProbProg UniformDistrLemmas
-  Prelude choice_code StateTransformingLaxMorph RulesStateProb.
+  Prelude choice_type StateTransformingLaxMorph RulesStateProb.
 
 Import SPropNotations.
 Import Num.Theory.


### PR DESCRIPTION
The name was wrong before: `A : chUniverse` seems to suggests that `A` is a choice universe when it is a type, or a choice  code.

I would rather not merge it without feedback.