### PR TITLE
Remove need for prime order in ElGamal

### DIFF
--- a/theories/Crypt/examples/ElGamal.v
+++ b/theories/Crypt/examples/ElGamal.v
@@ -45,7 +45,7 @@ Module Type ElGamalParam.
   Definition ζ : {set gT} := [set : gT].
   Parameter g :  gT.
   Parameter g_gen : ζ = <[g]>.
-  Parameter prime_order : prime #[g].
+  Parameter order_gt1 : (1 < #[g])%N.
 
 End ElGamalParam.
 
@@ -295,8 +295,6 @@ Qed.
 Lemma bijective_expgn :
   bijective (λ (a : 'Z_q), g ^+ a).
 Proof.
-  assert (hq : (1 < q)%N).
-  { eapply prime_gt1. unfold q. apply prime_order. }
   unshelve eexists (λ x, (proj1_sig (@cyclePmin gT g x _) %% q)%:R).
   - rewrite -g_gen. unfold ζ. apply in_setT.
   - simpl. intros a.
@@ -308,18 +306,22 @@ Proof.
     destruct cyclePmin as [n hn e]. simpl.
     move: e => /eqP e. rewrite eq_expg_mod_order in e.
     move: e => /eqP e.
-    rewrite !modn_small in e. 2: auto.
+    rewrite -e.
+    (* case_eq (q == 1)%N.
+    1:{
+      fold q in *. set (q' := q) in *. clearbody q'.
+      move /eqP => ?. subst. rewrite modn1.
+      clear h n e hn.
+      destruct a as [a h]. unfold Zp_trunc in *. simpl in *.
+      (* So in the case where q = 1, we have 'Z_1 = {0, 1} but a mod 1 = 0. *)
+    } *)
+    rewrite modn_small.
     2:{
-      eapply leq_trans. 1: eapply ltn_ord. fold q.
-      unfold Zp_trunc.
-      erewrite <- Lt.S_pred. 2:{ eapply Lt.lt_pred. apply /leP. eauto. }
-      apply /leP.
-      rewrite PeanoNat.Nat.succ_pred_pos.
-      2:{ move: hq => /leP hq. auto with arith. }
+      fold q. eapply leq_trans. 1: eapply ltn_ord.
+      rewrite Zp_cast.
+      2: apply order_gt1.
       auto.
     }
-    subst.
-    rewrite modn_small. 2: auto.
     apply natr_Zp.
   - simpl. intro x.
     match goal with
@@ -329,7 +331,7 @@ Proof.
     clearbody h. simpl in h.
     destruct cyclePmin as [n hn e]. simpl. subst.
     rewrite modn_small. 2: auto.
-    f_equal. rewrite val_Zp_nat. 2: auto.
+    f_equal. rewrite val_Zp_nat. 2: apply order_gt1.
     apply modn_small. auto.
 Qed.
 
@@ -485,7 +487,7 @@ Module EGP_Z3 <: ElGamalParam.
     unfold ζ, g. apply Zp_cycle.
   Qed.
 
-  Lemma prime_order : prime #[g].
+  Lemma order_gt1 : (1 < #[g])%N.
   Proof.
     unfold g.
     rewrite order_Zp1.


### PR DESCRIPTION
During our call today we realised that we did not need the prime condition for ElGamal. I guess it is needed for hardness, but we do not formalise it.

We do need the order to be at least two however because of a discrepancy between `'Z_1` which is `{ 0, 1 }` and the fact that `a mod 1 = 0` (we have to show that every element of `'Z_1` is `0`).
It could also be that I'm doing the proof wrong and that we actually don't *need* this condition. Please point it out to me if obvious.