### PR TITLE
Added examples from Som1Lse/joy-of-ssprove

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -89,5 +89,15 @@ theories/Crypt/examples/RandomOracle.v
 theories/Crypt/examples/SigmaProtocol.v
 theories/Crypt/examples/Schnorr.v
 
+# Examples from https://github.com/Som1Lse/joy-of-ssprove
+theories/Crypt/examples/MACCCA.v
+theories/Crypt/examples/PRFMAC.v
+theories/Crypt/examples/PRFPRG.v
+theories/Crypt/examples/PRPCCA.v
+theories/Crypt/examples/SecretSharing.v
+theories/Crypt/examples/ShamirSecretSharing.v
+theories/Crypt/examples/StretchPRG.v
+theories/Crypt/examples/SymmRatchet.v
+
 # Printing the axioms of all results from the paper
 theories/Crypt/Main.v

--- a/theories/Crypt/examples/MACCCA.v
+++ b/theories/Crypt/examples/MACCCA.v
@@ -1,0 +1,489 @@
+(**
+  This formalises Claim 10.10 from "The Joy of Cryptography" (p. 194).
+  It is fairly straight forward, significantly more so than PRPCCA.v, but it
+  relies on two, somewhat high-level, cryptographic primitives.
+
+  It shows an alternate way to gain CCA security, by augmenting a CPA-secure
+  encryption scheme with a MAC.
+
+  The advantage is at most a sum of the MAC and CPA epsilons, which are
+  negligible by assumption, hence the scheme is secure.
+*)
+
+From Relational Require Import OrderEnrichedCategory GenericRulesSimple.
+
+Set Warnings "-notation-overridden,-ambiguous-paths".
+From mathcomp Require Import all_ssreflect all_algebra reals distr realsum
+  ssrnat ssreflect ssrfun ssrbool ssrnum eqtype choice seq.
+Set Warnings "notation-overridden,ambiguous-paths".
+
+From Mon Require Import SPropBase.
+From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
+  UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb
+  pkg_core_definition choice_type pkg_composition pkg_rhl Package Prelude.
+
+From extructures Require Import ord fset fmap.
+
+Import SPropNotations.
+
+Import PackageNotation.
+
+From Equations Require Import Equations.
+Require Equations.Prop.DepElim.
+
+Set Equations With UIP.
+
+Set Bullet Behavior "Strict Subproofs".
+Set Default Goal Selector "!".
+Set Primitive Projections.
+
+Import Num.Def.
+Import Num.Theory.
+Import Order.POrderTheory.
+
+Section MACCCA_example.
+
+(**
+  We can't use sets directly in [choice_type] so instead we use a map to units.
+  We can then use [domm] to get the domain, which is a set.
+*)
+Definition chSet t := chMap t 'unit.
+
+Notation " 'set t " := (chSet t) (in custom pack_type at level 2).
+Notation " 'set t " := (chSet t) (at level 2): package_scope.
+
+Definition tt := Datatypes.tt.
+
+Variable (n: nat).
+
+Definition Word_N: nat := 2^n.
+Definition Word: choice_type := chFin (mkpos Word_N).
+
+Context (mac: Word -> Word -> Word).
+Context (enc: Word -> Word -> Word).
+Context (dec: Word -> Word -> Word).
+
+Notation " 'word " := (Word) (in custom pack_type at level 2).
+Notation " 'word " := (Word) (at level 2): package_scope.
+
+Definition km_loc: Location := ('option 'word ; 0).
+Definition T_loc: Location := ('set ('word × 'word) ; 1).
+Definition ek_loc: Location := ('option 'word ; 2).
+Definition S_loc: Location := ('set ('word × 'word) ; 3).
+Definition gettag: nat := 4.
+Definition checktag: nat := 5.
+Definition eavesdrop: nat := 6.
+Definition decrypt: nat := 7.
+
+Definition mkpair {Lt Lf E}
+  (t: package Lt [interface] E) (f: package Lf [interface] E):
+  loc_GamePair E := fun b => if b then {locpackage t} else {locpackage f}.
+
+Definition TAG_locs_tt := fset [:: km_loc].
+Definition TAG_locs_ff := fset [:: km_loc; T_loc].
+
+Definition kgen (l: Location): raw_code 'word :=
+  k_init ← get ('option 'word ; projT2 l) ;;
+  match k_init with
+  | None =>
+      k <$ uniform Word_N ;;
+      #put ('option 'word ; projT2 l) := Some k ;;
+      ret k
+  | Some k => ret k
+  end.
+
+Lemma kgen_valid {L I} (l: nat):
+  ('option 'word ; l) \in L ->
+  ValidCode L I (kgen ('option 'word ; l)).
+Proof.
+  move=> H.
+  apply: valid_getr => [// | [k|]].
+  1: by apply: valid_ret.
+  apply: valid_sampler => k.
+  apply: valid_putr => //.
+  by apply: valid_ret => //.
+Qed.
+
+Hint Extern 1 (ValidCode ?L ?I (kgen ?l)) =>
+  eapply kgen_valid ;
+  auto_in_fset
+  : typeclass_instances ssprove_valid_db.
+
+Definition TAG_pkg_tt:
+  package TAG_locs_tt
+    [interface]
+    [interface
+      #val #[gettag]: 'word → 'word ;
+      #val #[checktag]: 'word × 'word → 'bool ] :=
+  [package
+    #def #[gettag] (m: 'word): 'word {
+      k ← kgen km_loc ;;
+      ret (mac k m)
+    } ;
+    #def #[checktag] ('(m, t): 'word × 'word): 'bool {
+      k ← kgen km_loc ;;
+      ret (t == mac k m)
+    }
+  ].
+
+Definition TAG_pkg_ff:
+  package TAG_locs_ff
+    [interface]
+    [interface
+      #val #[gettag]: 'word → 'word ;
+      #val #[checktag]: 'word × 'word → 'bool ] :=
+  [package
+    #def #[gettag] (m: 'word): 'word {
+      T ← get T_loc ;;
+      k ← kgen km_loc ;;
+      let t := mac k m in
+      #put T_loc := setm T (m, t) tt ;;
+      ret t
+    } ;
+    #def #[checktag] ('(m, t): 'word × 'word): 'bool {
+      T ← get T_loc ;;
+      ret ((m, t) \in domm T)
+    }
+  ].
+
+Definition TAG := mkpair TAG_pkg_tt TAG_pkg_ff.
+
+Definition CPA_EVAL_locs := fset [:: ek_loc].
+
+Definition CPA_EVAL_pkg_tt:
+  package CPA_EVAL_locs [interface]
+    [interface #val #[eavesdrop]: 'word × 'word → 'word ] :=
+  [package
+    #def #[eavesdrop] ('(ml, mr): 'word × 'word): 'word {
+      k ← kgen ek_loc ;;
+      ret (enc k ml)
+    }
+  ].
+
+Definition CPA_EVAL_pkg_ff:
+  package CPA_EVAL_locs [interface]
+    [interface #val #[eavesdrop]: 'word × 'word → 'word ] :=
+  [package
+    #def #[eavesdrop] ('(ml, mr): 'word × 'word): 'word {
+      k ← kgen ek_loc ;;
+      ret (enc k mr)
+    }
+  ].
+
+Definition CPA_EVAL := mkpair CPA_EVAL_pkg_tt CPA_EVAL_pkg_ff.
+
+Definition CCA_EVAL_locs := fset [:: km_loc; ek_loc; S_loc].
+
+Definition CCA_EVAL_pkg_tt:
+  package CCA_EVAL_locs [interface]
+    [interface
+      #val #[eavesdrop]: 'word × 'word → 'word × 'word ;
+      #val #[decrypt]: 'word × 'word → 'option 'word ] :=
+  [package
+    #def #[eavesdrop] ('(ml, mr): 'word × 'word): 'word × 'word {
+      S ← get S_loc ;;
+      ke ← kgen ek_loc ;;
+      km ← kgen km_loc ;;
+      let c := enc ke ml in
+      let t := mac km c in
+      #put S_loc := setm S (c, t) tt ;;
+      ret (c, t)
+    } ;
+    #def #[decrypt] ('(c, t): 'word × 'word): 'option 'word {
+      S ← get S_loc ;;
+      if ((c, t) \in domm S) then ret None else
+      km ← kgen km_loc ;;
+      if (t != mac km c) then ret None else
+      ke ← kgen ek_loc ;;
+      ret (Some (dec ke c))
+    }
+  ].
+
+Definition CCA_EVAL_pkg_ff:
+  package CCA_EVAL_locs [interface]
+    [interface
+      #val #[eavesdrop]: 'word × 'word → 'word × 'word ;
+      #val #[decrypt]: 'word × 'word → 'option 'word ] :=
+  [package
+    #def #[eavesdrop] ('(ml, mr): 'word × 'word): 'word × 'word {
+      S ← get S_loc ;;
+      ke ← kgen ek_loc ;;
+      km ← kgen km_loc ;;
+      let c := enc ke mr in
+      let t := mac km c in
+      #put S_loc := setm S (c, t) tt ;;
+      ret (c, t)
+    } ;
+    #def #[decrypt] ('(c, t): 'word × 'word): 'option 'word {
+      S ← get S_loc ;;
+      if ((c, t) \in domm S) then ret None else
+      km ← kgen km_loc ;;
+      if (t != mac km c) then ret None else
+      ke ← kgen ek_loc ;;
+      ret (Some (dec ke c))
+    }
+  ].
+
+Definition CCA_EVAL := mkpair CCA_EVAL_pkg_tt CCA_EVAL_pkg_ff.
+
+Definition CCA_EVAL_TAG_locs := fset [:: ek_loc; S_loc].
+
+Definition CCA_EVAL_TAG_pkg_tt:
+  package CCA_EVAL_TAG_locs
+    [interface
+      #val #[gettag]: 'word → 'word ;
+      #val #[checktag]: 'word × 'word → 'bool ]
+    [interface
+      #val #[eavesdrop]: 'word × 'word → 'word × 'word ;
+      #val #[decrypt]: 'word × 'word → 'option 'word ] :=
+  [package
+    #def #[eavesdrop] ('(ml, mr): 'word × 'word): 'word × 'word {
+      #import {sig #[gettag]: 'word → 'word } as gettag ;;
+      S ← get S_loc ;;
+      ke ← kgen ek_loc ;;
+      let c := enc ke ml in
+      t ← gettag c ;;
+      #put S_loc := setm S (c, t) tt ;;
+      ret (c, t)
+    } ;
+    #def #[decrypt] ('(c, t): 'word × 'word): 'option 'word {
+      #import {sig #[checktag]: 'word × 'word → 'bool } as checktag ;;
+      S ← get S_loc ;;
+      if ((c, t) \in domm S) then ret None else
+      r ← checktag (c, t) ;;
+      if (~~ r) then ret None else
+      ke ← kgen ek_loc ;;
+      ret (Some (dec ke c))
+    }
+  ].
+
+Definition CCA_EVAL_TAG_pkg_ff:
+  package CCA_EVAL_TAG_locs
+    [interface
+      #val #[gettag]: 'word → 'word ;
+      #val #[checktag]: 'word × 'word → 'bool ]
+    [interface
+      #val #[eavesdrop]: 'word × 'word → 'word × 'word ;
+      #val #[decrypt]: 'word × 'word → 'option 'word ] :=
+  [package
+    #def #[eavesdrop] ('(ml, mr): 'word × 'word): 'word × 'word {
+      #import {sig #[gettag]: 'word → 'word } as gettag ;;
+      S ← get S_loc ;;
+      ke ← kgen ek_loc ;;
+      let c := enc ke mr in
+      t ← gettag c ;;
+      #put S_loc := setm S (c, t) tt ;;
+      ret (c, t)
+    } ;
+    #def #[decrypt] ('(c, t): 'word × 'word): 'option 'word {
+      #import {sig #[checktag]: 'word × 'word → 'bool } as checktag ;;
+      S ← get S_loc ;;
+      if ((c, t) \in domm S) then ret None else
+      r ← checktag (c, t) ;;
+      if (~~ r) then ret None else
+      ke ← kgen ek_loc ;;
+      ret (Some (dec ke c))
+    }
+  ].
+
+Definition CCA_EVAL_HYB_locs := fset [:: km_loc; T_loc; S_loc].
+
+Definition CCA_EVAL_HYB_pkg:
+  package CCA_EVAL_HYB_locs
+    [interface #val #[eavesdrop]: 'word × 'word → 'word ]
+    [interface
+      #val #[eavesdrop]: 'word × 'word → 'word × 'word ;
+      #val #[decrypt]: 'word × 'word → 'option 'word ] :=
+  [package
+    #def #[eavesdrop] ('(ml, mr): 'word × 'word): 'word × 'word {
+      #import {sig #[eavesdrop]: 'word × 'word → 'word } as eavesdrop ;;
+      S ← get S_loc ;;
+      c ← eavesdrop (ml, mr) ;;
+      T ← get T_loc ;;
+      km ← kgen km_loc ;;
+      let t := mac km c in
+      #put T_loc := setm T (c, t) tt ;;
+      #put S_loc := setm S (c, t) tt ;;
+      ret (c, t)
+    } ;
+    #def #[decrypt] ('(c, t): 'word × 'word): 'option 'word {
+      ret None
+    }
+  ].
+
+Lemma CCA_EVAL_equiv_true:
+  CCA_EVAL true ≈₀ CCA_EVAL_TAG_pkg_tt ∘ TAG true.
+Proof.
+  apply: eq_rel_perf_ind_eq.
+  simplify_eq_rel m.
+  all: apply rpost_weaken_rule with eq;
+    last by move=> [? ?] [? ?] [].
+  all: simplify_linking.
+  all: ssprove_code_simpl.
+  all: ssprove_code_simpl.
+  all: by apply: rreflexivity_rule.
+Qed.
+
+Lemma CCA_EVAL_HYB_equiv_true:
+  CCA_EVAL_TAG_pkg_tt ∘ TAG false ≈₀ CCA_EVAL_HYB_pkg ∘ CPA_EVAL true.
+Proof.
+  apply eq_rel_perf_ind with (
+    (fun '(h0, h1) => h0 = h1) ⋊
+    couple_lhs S_loc T_loc
+      (fun S T => S = T)
+  ).
+  1: {
+    ssprove_invariant=> //=.
+    all: by rewrite /CCA_EVAL_TAG_locs /TAG_locs_ff !fset_cons !in_fsetU !in_fset1 eq_refl Bool.orb_true_r.
+  }
+  simplify_eq_rel m.
+  all: simplify_linking.
+  all: ssprove_code_simpl.
+  all: ssprove_code_simpl.
+  - case: m => [ml mr].
+    apply: r_get_vs_get_remember => S.
+    ssprove_sync=> [|[ke|]];
+      first by move=> ? ? ->.
+    2: ssprove_sync=> ke;
+      ssprove_sync;
+      first by move=> ? ? ->.
+    all: apply: r_get_vs_get_remember => T.
+    all: ssprove_sync=> [|[km|]];
+      first by move=> ? ? ->.
+    2,4: ssprove_sync=> km;
+      ssprove_sync;
+      first by move=> ? ? ->.
+    all: apply: (r_rem_couple_lhs S_loc T_loc) => Hinv.
+    all: apply: r_put_vs_put.
+    all: apply: r_put_vs_put.
+    all: ssprove_restore_mem;
+      last by apply: r_ret.
+    all: ssprove_invariant.
+    all: by rewrite Hinv.
+  - case: m => [c t].
+    apply: r_get_remember_lhs => S.
+    destruct ((c, t) \in domm S) eqn:Heq.
+    all: rewrite Heq.
+    1: by apply: r_ret => ? ? [].
+    apply: r_get_remember_lhs => T.
+    apply: (r_rem_couple_lhs S_loc T_loc) => Hinv.
+    rewrite -Hinv Heq /=.
+    by apply: r_ret => ? ? [] [].
+Qed.
+
+Lemma CCA_EVAL_HYB_equiv_false:
+  CCA_EVAL_HYB_pkg ∘ CPA_EVAL false ≈₀ CCA_EVAL_TAG_pkg_ff ∘ TAG false.
+Proof.
+  apply eq_rel_perf_ind with (
+    (fun '(h0, h1) => h0 = h1) ⋊
+    couple_rhs S_loc T_loc
+      (fun S T => S = T)
+  ).
+  1: {
+    ssprove_invariant=> //=.
+    all: by rewrite /CCA_EVAL_TAG_locs /TAG_locs_ff !fset_cons !in_fsetU !in_fset1 eq_refl !Bool.orb_true_r.
+  }
+  simplify_eq_rel m.
+  all: simplify_linking.
+  all: ssprove_code_simpl.
+  all: ssprove_code_simpl.
+  - case: m => [ml mr].
+    apply: r_get_vs_get_remember => S.
+    ssprove_sync=> [|[ke|]];
+      first by move=> ? ? ->.
+    2: ssprove_sync=> ke;
+      ssprove_sync;
+      first by move=> ? ? ->.
+    all: apply: r_get_vs_get_remember => T.
+    all: ssprove_sync=> [|[km|]];
+      first by move=> ? ? ->.
+    2,4: ssprove_sync=> km;
+      ssprove_sync;
+      first by move=> ? ? ->.
+    all: apply: (r_rem_couple_rhs S_loc T_loc) => Hinv.
+    all: apply: r_put_vs_put.
+    all: apply: r_put_vs_put.
+    all: ssprove_restore_mem;
+      last by apply: r_ret.
+    all: ssprove_invariant.
+    all: by rewrite Hinv.
+  - case: m => [c t].
+    apply: r_get_remember_rhs => S.
+    destruct ((c, t) \in domm S) eqn:Heq.
+    all: rewrite Heq.
+    1: by apply: r_ret => ? ? [].
+    apply: r_get_remember_rhs => T.
+    apply: (r_rem_couple_rhs S_loc T_loc) => Hinv.
+    rewrite -Hinv Heq /=.
+    by apply: r_ret => ? ? [] [].
+Qed.
+
+Lemma CCA_EVAL_equiv_false:
+  CCA_EVAL_TAG_pkg_ff ∘ TAG true ≈₀ CCA_EVAL false.
+Proof.
+  apply: eq_rel_perf_ind_eq.
+  simplify_eq_rel m.
+  all: apply rpost_weaken_rule with eq;
+    last by move=> [? ?] [? ?] [].
+  all: simplify_linking.
+  all: ssprove_code_simpl.
+  all: ssprove_code_simpl.
+  all: by apply: rreflexivity_rule.
+Qed.
+
+Local Open Scope ring_scope.
+
+(**
+  The advantage an adversary can gain over the MAC, i.e. the chance by
+  which an adversary can construct a forge a MAC.
+  Negligible by assumption.
+*)
+Definition mac_epsilon := Advantage TAG.
+
+(**
+  The advantage an adversary can gain over the CPA-secure encryption, i.e. the
+  chance by which an adversary can distinguish which message a ciphertext
+  belongs to.
+  Negligible by assumption.
+*)
+Definition cpa_epsilon := Advantage CPA_EVAL.
+
+Theorem security_based_on_mac LA A:
+  ValidPackage LA
+    [interface
+      #val #[eavesdrop]: 'word × 'word → 'word × 'word ;
+      #val #[decrypt]: 'word × 'word → 'option 'word ]
+    A_export A ->
+  fdisjoint LA (
+    TAG_locs_tt :|: TAG_locs_ff :|: CPA_EVAL_locs :|:
+    CCA_EVAL_locs :|: CCA_EVAL_TAG_locs :|: CCA_EVAL_HYB_locs
+    ) ->
+  Advantage CCA_EVAL A <=
+  mac_epsilon (A ∘ CCA_EVAL_TAG_pkg_tt) +
+  cpa_epsilon (A ∘ CCA_EVAL_HYB_pkg) +
+  mac_epsilon (A ∘ CCA_EVAL_TAG_pkg_ff).
+Proof.
+  move=> vA H.
+  rewrite Advantage_E Advantage_sym.
+  ssprove triangle (CCA_EVAL true) [::
+    CCA_EVAL_TAG_pkg_tt ∘ TAG true ;
+    CCA_EVAL_TAG_pkg_tt ∘ TAG false ;
+    CCA_EVAL_HYB_pkg ∘ CPA_EVAL true ;
+    CCA_EVAL_HYB_pkg ∘ CPA_EVAL false ;
+    CCA_EVAL_TAG_pkg_ff ∘ TAG false ;
+    CCA_EVAL_TAG_pkg_ff ∘ TAG true
+  ] (CCA_EVAL false) A as ineq.
+  apply: le_trans.
+  1: by apply: ineq.
+  rewrite !fdisjointUr in H.
+  move: H => /andP [/andP [/andP [/andP [/andP [H1 H2] H3] H4] H5] H6].
+  move: {ineq H1 H2 H3 H4 H5 H6} (H1, H2, H3, H4, H5, H6) => H.
+  rewrite CCA_EVAL_equiv_true ?fdisjointUr ?H // GRing.add0r.
+  rewrite CCA_EVAL_HYB_equiv_true ?fdisjointUr ?H // GRing.addr0.
+  rewrite CCA_EVAL_HYB_equiv_false ?fdisjointUr ?H // GRing.addr0.
+  rewrite CCA_EVAL_equiv_false ?fdisjointUr ?H // GRing.addr0.
+  rewrite /mac_epsilon /cpa_epsilon !Advantage_E -!Advantage_link.
+  by rewrite (Advantage_sym (TAG true)) (Advantage_sym (CPA_EVAL true)).
+Qed.
+
+End MACCCA_example.

--- a/theories/Crypt/examples/PRFMAC.v
+++ b/theories/Crypt/examples/PRFMAC.v
@@ -1,0 +1,496 @@
+(**
+  This formalises Claim 10.4 from "The Joy of Cryptography" (p. 188).
+  Most of it is fairly straight forward, the longest part being
+  [TAG_GUESS_equiv_3].
+
+  It would also be nice to formalise Claim 10.3 (p. 186), but its argument
+  depends on the adversary only having polynomial time, and how to formulate
+  that is unclear.
+
+  The final statement ([security_based_on_prf]) is similar to that of PRF.v,
+  stating that the advantage is bounded by a [prf_epsilon] and a
+  [statistical_gap]. It would be particularly nice to simply state that it is
+  negligible in [n].
+*)
+
+From Relational Require Import OrderEnrichedCategory GenericRulesSimple.
+
+Set Warnings "-notation-overridden,-ambiguous-paths".
+From mathcomp Require Import all_ssreflect all_algebra reals distr realsum
+  ssrnat ssreflect ssrfun ssrbool ssrnum eqtype choice seq.
+Set Warnings "notation-overridden,ambiguous-paths".
+
+From Mon Require Import SPropBase.
+From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
+  UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb
+  pkg_core_definition choice_type pkg_composition pkg_rhl Package Prelude.
+
+From extructures Require Import ord fset fmap.
+
+Import SPropNotations.
+
+Import PackageNotation.
+
+From Equations Require Import Equations.
+Require Equations.Prop.DepElim.
+
+Set Equations With UIP.
+
+Set Bullet Behavior "Strict Subproofs".
+Set Default Goal Selector "!".
+Set Primitive Projections.
+
+Import Num.Def.
+Import Num.Theory.
+Import Order.POrderTheory.
+
+(**
+  We can't use sets directly in [choice_type] so instead we use a map to units.
+  We can then use [domm] to get the domain, which is a set.
+*)
+Definition chSet t := chMap t 'unit.
+
+Notation " 'set t " := (chSet t) (in custom pack_type at level 2).
+Notation " 'set t " := (chSet t) (at level 2): package_scope.
+
+Definition tt := Datatypes.tt.
+
+Section PRFMAC_example.
+
+Variable (n: nat).
+
+Definition Word_N: nat := 2^n.
+Definition Word: choice_type := chFin (mkpos Word_N).
+
+Notation " 'word " := (Word) (in custom pack_type at level 2).
+Notation " 'word " := (Word) (at level 2): package_scope.
+
+#[local] Open Scope package_scope.
+
+Definition k_loc: Location := ('option 'word ; 0).
+Definition T_loc: Location := (chMap 'word 'word ; 1).
+Definition S_loc: Location := ('set ('word × 'word) ; 2).
+Definition lookup: nat := 3.
+Definition encrypt: nat := 4.
+Definition gettag: nat := 5.
+Definition checktag: nat := 6.
+Definition guess: nat := 7.
+
+Definition mkpair {Lt Lf E}
+  (t: package Lt [interface] E) (f: package Lf [interface] E):
+  loc_GamePair E := fun b => if b then {locpackage t} else {locpackage f}.
+
+Context (PRF: Word -> Word -> Word).
+
+Definition EVAL_locs_tt := fset [:: k_loc].
+Definition EVAL_locs_ff := fset [:: T_loc].
+
+Definition kgen: raw_code 'word :=
+  k_init ← get k_loc ;;
+  match k_init with
+  | None =>
+      k <$ uniform Word_N ;;
+      #put k_loc := Some k ;;
+      ret k
+  | Some k => ret k
+  end.
+
+Lemma kgen_valid {L I}:
+  k_loc \in L ->
+  ValidCode L I kgen.
+Proof.
+  move=> H.
+  apply: valid_getr => [// | [k|]].
+  1: by apply: valid_ret.
+  apply: valid_sampler => k.
+  apply: valid_putr => //.
+  by apply: valid_ret => //.
+Qed.
+
+Hint Extern 1 (ValidCode ?L ?I kgen) =>
+  eapply kgen_valid ;
+  auto_in_fset
+  : typeclass_instances ssprove_valid_db.
+
+Definition EVAL_pkg_tt:
+  package EVAL_locs_tt
+    [interface]
+    [interface #val #[lookup]: 'word → 'word ] :=
+  [package
+    #def #[lookup] (m: 'word): 'word {
+      k ← kgen ;;
+      ret (PRF k m)
+    }
+  ].
+
+Definition EVAL_pkg_ff:
+  package EVAL_locs_ff
+    [interface]
+    [interface #val #[lookup]: 'word → 'word ] :=
+  [package
+    #def #[lookup] (m: 'word): 'word {
+      T ← get T_loc ;;
+      match getm T m with
+      | None =>
+          r <$ uniform Word_N ;;
+          #put T_loc := setm T m r ;;
+          ret r
+      | Some r => ret r
+      end
+    }
+  ].
+
+Definition EVAL := mkpair EVAL_pkg_tt EVAL_pkg_ff.
+
+Definition GUESS_locs := fset [:: T_loc].
+
+Definition GUESS_pkg_tt:
+  package GUESS_locs
+    [interface]
+    [interface
+      #val #[lookup]: 'word → 'word ;
+      #val #[guess]: 'word × 'word → 'bool ] :=
+  [package
+    #def #[lookup] (m: 'word): 'word {
+      T ← get T_loc ;;
+      match getm T m with
+      | None =>
+          t <$ uniform Word_N ;;
+          #put T_loc := setm T m t ;;
+          ret t
+      | Some t => ret t
+      end
+    } ;
+    #def #[guess] ('(m, t): 'word × 'word): 'bool {
+      T ← get T_loc ;;
+      r ← match getm T m with
+      | None =>
+          r <$ uniform Word_N ;;
+          #put T_loc := setm T m r ;;
+          ret r
+      | Some r => ret r
+      end ;;
+      ret (t == r)
+    }
+  ].
+
+Definition GUESS_pkg_ff:
+  package GUESS_locs
+    [interface]
+    [interface
+      #val #[lookup]: 'word → 'word ;
+      #val #[guess]: 'word × 'word → 'bool ] :=
+  [package
+    #def #[lookup] (m: 'word): 'word {
+      T ← get T_loc ;;
+      match getm T m with
+      | None =>
+          t <$ uniform Word_N ;;
+          #put T_loc := setm T m t ;;
+          ret t
+      | Some t => ret t
+      end
+    } ;
+    #def #[guess] ('(m, t): 'word × 'word): 'bool {
+      T ← get T_loc ;;
+      ret (Some t == getm T m)
+    }
+  ].
+
+Definition GUESS := mkpair GUESS_pkg_tt GUESS_pkg_ff.
+
+Definition TAG_locs_tt := fset [:: k_loc].
+Definition TAG_locs_ff := fset [:: k_loc; S_loc].
+
+Definition TAG_pkg_tt:
+  package TAG_locs_tt
+    [interface]
+    [interface
+      #val #[gettag]: 'word → 'word ;
+      #val #[checktag]: 'word × 'word → 'bool ] :=
+  [package
+    #def #[gettag] (m: 'word): 'word {
+      k ← kgen ;;
+      ret (PRF k m)
+    } ;
+    #def #[checktag] ('(m, t): 'word × 'word): 'bool {
+      k ← kgen ;;
+      ret (t == PRF k m)
+    }
+  ].
+
+Definition TAG_pkg_ff:
+  package TAG_locs_ff
+    [interface]
+    [interface
+      #val #[gettag]: 'word → 'word ;
+      #val #[checktag]: 'word × 'word → 'bool ] :=
+  [package
+    #def #[gettag] (m: 'word): 'word {
+      S ← get S_loc ;;
+      k ← kgen ;;
+      let t := PRF k m in
+      #put S_loc := setm S (m, t) tt ;;
+      ret t
+    } ;
+    #def #[checktag] ('(m, t): 'word × 'word): 'bool {
+      S ← get S_loc ;;
+      ret ((m, t) \in domm S)
+    }
+  ].
+
+Definition TAG := mkpair TAG_pkg_tt TAG_pkg_ff.
+
+Definition TAG_EVAL_locs_ff := fset [:: S_loc].
+
+Definition TAG_EVAL_pkg_tt:
+  package fset0
+    [interface #val #[lookup]: 'word → 'word ]
+    [interface
+      #val #[gettag]: 'word → 'word ;
+      #val #[checktag]: 'word × 'word → 'bool ] :=
+  [package
+    #def #[gettag] (m: 'word): 'word {
+      #import {sig #[lookup]: 'word → 'word } as lookup ;;
+      t ← lookup m ;;
+      ret t
+    } ;
+    #def #[checktag] ('(m, t): 'word × 'word): 'bool {
+      #import {sig #[lookup]: 'word → 'word } as lookup ;;
+      r ← lookup m ;;
+      ret (t == r)
+    }
+  ].
+
+Definition TAG_EVAL_pkg_ff:
+  package TAG_EVAL_locs_ff
+    [interface #val #[lookup]: 'word → 'word]
+    [interface
+      #val #[gettag]: 'word → 'word ;
+      #val #[checktag]: 'word × 'word → 'bool ] :=
+  [package
+    #def #[gettag] (m: 'word): 'word {
+      #import {sig #[lookup]: 'word → 'word } as lookup ;;
+      S ← get S_loc ;;
+      t ← lookup m ;;
+      #put S_loc := setm S (m, t) tt ;;
+      ret t
+    } ;
+    #def #[checktag] ('(m, t): 'word × 'word): 'bool {
+      S ← get S_loc ;;
+      ret ((m, t) \in domm S)
+    }
+  ].
+
+Definition TAG_GUESS_locs := fset [:: S_loc ].
+
+Definition TAG_GUESS_pkg:
+  package TAG_GUESS_locs
+    [interface
+      #val #[lookup]: 'word → 'word ;
+      #val #[guess]: 'word × 'word → 'bool ]
+    [interface
+      #val #[gettag]: 'word → 'word ;
+      #val #[checktag]: 'word × 'word → 'bool ] :=
+  [package
+    #def #[gettag] (m: 'word): 'word {
+      #import {sig #[lookup]: 'word → 'word } as lookup ;;
+      S ← get S_loc ;;
+      t ← lookup m ;;
+      #put S_loc := setm S (m, t) tt ;;
+      ret t
+    } ;
+    #def #[checktag] ('(m, t): 'word × 'word): 'bool {
+      #import {sig #[guess]: 'word × 'word → 'bool } as guess ;;
+      r ← guess (m, t) ;;
+      ret r
+    }
+  ].
+
+Lemma TAG_equiv_true:
+  TAG true ≈₀ TAG_EVAL_pkg_tt ∘ EVAL true.
+Proof.
+  apply: eq_rel_perf_ind_eq.
+  simplify_eq_rel m.
+  all: apply rpost_weaken_rule with eq;
+    last by move=> [? ?] [? ?] [].
+  2: case: m => [m t].
+  all: simplify_linking.
+  all: simplify_linking.
+  all: ssprove_sync_eq.
+  all: case => [k|].
+  all: by apply: rreflexivity_rule.
+Qed.
+
+Lemma TAG_EVAL_equiv_true:
+  TAG_EVAL_pkg_tt ∘ EVAL false ≈₀ TAG_GUESS_pkg ∘ GUESS true.
+Proof.
+  apply eq_rel_perf_ind_ignore with (fset [:: S_loc]).
+  1: {
+    apply: fsubset_trans.
+    - by apply fsubsetUl.
+    - by apply fsubsetUr.
+  }
+  simplify_eq_rel m.
+  2: case: m => [m t].
+  all: simplify_linking.
+  all: simplify_linking.
+  all: ssprove_code_simpl.
+  all: ssprove_code_simpl_more.
+  2: {
+    apply: (@r_reflexivity_alt _ (fset1 T_loc)).
+    all: by ssprove_invariant.
+  }
+  1: apply: r_get_remember_rhs => S.
+  ssprove_sync=> T.
+  case (getm T _) => [t|].
+  2: ssprove_sync=> t.
+  2: ssprove_sync.
+  all: apply: r_put_rhs.
+  all: ssprove_restore_mem;
+    last by apply: r_ret.
+  all: by ssprove_invariant.
+Qed.
+
+(**
+  The first function ([gettag]) is exactly the same in both packages.
+  It turns out, however, to be pretty complicated since we need to prove the
+  invariant holds.
+*)
+Lemma TAG_EVAL_equiv_false:
+  TAG_GUESS_pkg ∘ GUESS false ≈₀ TAG_EVAL_pkg_ff ∘ EVAL false.
+Proof.
+  apply eq_rel_perf_ind with (
+    (fun '(h0, h1) => h0 = h1) ⋊
+    couple_rhs T_loc S_loc
+      (fun T S => forall m t,
+        ((m, t) \in domm S) = (Some t == getm T m))
+  ).
+  1: {
+    ssprove_invariant=> /=.
+    1,2: by rewrite /GUESS_locs /TAG_GUESS_locs !fset_cons !in_fsetU !in_fset1 eq_refl ?Bool.orb_true_r.
+    move=> m t.
+    by rewrite domm0 in_fset0 get_empty_heap emptymE.
+  }
+  simplify_eq_rel m.
+  2: case: m => [m t].
+  all: simplify_linking.
+  all: simplify_linking.
+  - apply: r_get_vs_get_remember => S.
+    apply: r_get_vs_get_remember => T.
+    destruct (getm T m) as [t|] eqn:Heqt.
+    all: rewrite Heqt /=.
+    + apply: r_put_vs_put.
+      ssprove_restore_mem;
+        last by apply: r_ret.
+      ssprove_invariant=> s0 s1 [[[[Hinv _] H1] _] H2] m' t'.
+      rewrite get_set_heap_eq get_set_heap_neq // domm_set in_fsetU in_fset1.
+      case: (eq_dec (m', t') (m, t)) => Heq.
+      * case: Heq => [-> ->].
+        by rewrite H2 Heqt /= !eq_refl.
+      * move /eqP /negPf in Heq.
+        by rewrite Heq -H1 Hinv.
+    + ssprove_sync=> k.
+      apply: (r_rem_couple_rhs T_loc S_loc) => Hinv.
+      apply: r_put_vs_put.
+      apply: r_put_vs_put.
+      ssprove_restore_mem;
+        last by apply: r_ret.
+      ssprove_invariant=> m' k'.
+      rewrite domm_set in_fsetU in_fset1 setmE.
+      case: (eq_dec (m', k') (m, k)) => Heq.
+      1: {
+        case: Heq => [-> ->].
+        by rewrite !eq_refl /= eq_refl.
+      }
+      move /eqP /negPf in Heq.
+      rewrite Heq /=.
+      rewrite xpair_eqE in Heq.
+      case: (eq_dec m' m) => Heqm.
+      * rewrite Heqm eq_refl /= in Heq*.
+        by rewrite Heq Hinv Heqt.
+      * move /eqP /negPf in Heqm.
+        by rewrite Heqm Hinv.
+  - ssprove_code_simpl.
+    ssprove_code_simpl_more.
+    apply: r_get_remember_lhs => T.
+    apply: r_get_remember_rhs => S.
+    apply: (r_rem_couple_rhs T_loc S_loc) => [|Hinv].
+    1: by apply: (Remembers_rhs_from_tracked_lhs _).
+    rewrite Hinv.
+    ssprove_forget_all.
+    by apply: r_ret.
+Qed.
+
+Lemma TAG_equiv_false:
+  TAG_EVAL_pkg_ff ∘ EVAL true ≈₀ TAG false.
+Proof.
+  apply: eq_rel_perf_ind_eq.
+  simplify_eq_rel m.
+  all: apply rpost_weaken_rule with eq;
+    last by move=> [? ?] [? ?] [].
+  2: case: m => [m t].
+  all: simplify_linking.
+  all: ssprove_sync_eq=> S.
+  1: ssprove_sync_eq.
+  1: case => [k|].
+  all: by apply: rreflexivity_rule.
+Qed.
+
+Local Open Scope ring_scope.
+
+(**
+  The advantage an adversary can gain over the PRF, i.e. the chance by
+  which an adversary can distinguish the PRF from a truly random function.
+  Negligible by assumption.
+*)
+Definition prf_epsilon := Advantage EVAL.
+
+(**
+  The advantage an adversary can gain in the [GUESS] game.
+  This is negligible, but not yet provable in SSProve.
+*)
+Definition statistical_gap :=
+  AdvantageE (TAG_GUESS_pkg ∘ GUESS true) (TAG_GUESS_pkg ∘ GUESS false).
+
+Theorem security_based_on_prf LA A:
+  ValidPackage LA
+    [interface
+      #val #[gettag]: 'word → 'word ;
+      #val #[checktag]: 'word × 'word → 'bool ]
+    A_export A ->
+  fdisjoint LA (
+    EVAL_locs_tt :|: EVAL_locs_ff :|: GUESS_locs :|:
+    TAG_locs_tt :|: TAG_locs_ff :|:
+    TAG_EVAL_locs_ff :|: TAG_GUESS_locs
+  ) ->
+  Advantage TAG A <=
+  prf_epsilon (A ∘ TAG_EVAL_pkg_tt) +
+  statistical_gap A +
+  prf_epsilon (A ∘ TAG_EVAL_pkg_ff).
+Proof.
+  move=> vA H.
+  rewrite Advantage_E Advantage_sym.
+  ssprove triangle (TAG true) [::
+    TAG_EVAL_pkg_tt ∘ EVAL true   ;
+    TAG_EVAL_pkg_tt ∘ EVAL false  ;
+    TAG_GUESS_pkg ∘ GUESS true  ;
+    TAG_GUESS_pkg ∘ GUESS false ;
+    TAG_EVAL_pkg_ff ∘ EVAL false  ;
+    TAG_EVAL_pkg_ff ∘ EVAL true
+  ] (TAG false) A
+  as ineq.
+  apply: le_trans.
+  1: by apply: ineq.
+  rewrite !fdisjointUr in H.
+  move: H => /andP [/andP [/andP [/andP [/andP [/andP [H1 H2] H3] H4] H5] H6] H7].
+  move: {ineq H1 H2 H3 H4 H5 H6 H7} (H1, H2, H3, H4, H5, H6, H7, fdisjoints0) => H.
+  rewrite TAG_equiv_true ?fdisjointUr ?H // GRing.add0r.
+  rewrite TAG_EVAL_equiv_true ?fdisjointUr ?H // GRing.addr0.
+  rewrite TAG_EVAL_equiv_false ?fdisjointUr ?H // GRing.addr0.
+  rewrite TAG_equiv_false ?fdisjointUr ?H // GRing.addr0.
+  rewrite Advantage_sym.
+  by rewrite /prf_epsilon /statistical_gap !Advantage_E !Advantage_link.
+Qed.
+
+End PRFMAC_example.

--- a/theories/Crypt/examples/PRFPRG.v
+++ b/theories/Crypt/examples/PRFPRG.v
@@ -1,0 +1,434 @@
+(**
+  This formalises Claim 6.3 from "The Joy of Cryptography" (p. 111).
+  It shows how to work with variable length proofs.
+
+  It is fairly complete. One thing that is missing is the final step, which is
+  proving the last hybrid is perfectly indistinguishable from [GEN false],
+  which, to my knowledge, cannot (yet) be formalised in SSProve, so instead we
+  make it a hypothesis of the final statement [security_based_on_prf].
+*)
+
+From Relational Require Import OrderEnrichedCategory GenericRulesSimple.
+
+Set Warnings "-notation-overridden,-ambiguous-paths".
+From mathcomp Require Import all_ssreflect all_algebra reals distr realsum
+  ssrnat ssreflect ssrfun ssrbool ssrnum eqtype choice seq.
+Set Warnings "notation-overridden,ambiguous-paths".
+
+From Mon Require Import SPropBase.
+From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
+  UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb
+  pkg_core_definition choice_type pkg_composition pkg_rhl Package Prelude.
+
+From extructures Require Import ord fset fmap.
+
+Import SPropNotations.
+
+Import PackageNotation.
+
+From Equations Require Import Equations.
+Require Equations.Prop.DepElim.
+
+Set Equations With UIP.
+
+Set Bullet Behavior "Strict Subproofs".
+Set Default Goal Selector "!".
+Set Primitive Projections.
+
+Import Num.Def.
+Import Num.Theory.
+Import Order.POrderTheory.
+
+Section PRFGEN_example.
+
+Variable (n: nat).
+
+Context(Hpos: 0 < n).
+
+Definition Word_N: nat := 2^n.
+Definition Word: choice_type := 'fin Word_N.
+
+#[program]
+Definition zero: Word := @Ordinal _ 0 _.
+Next Obligation.
+  by apply: PositiveExp2.
+Qed.
+
+#[program]
+Definition one: Word := @Ordinal _ 1 _.
+Next Obligation.
+  rewrite /Word_N.
+  move: Hpos.
+  case: n => [// | n'] _.
+  by rewrite expnS leq_pmulr // PositiveExp2.
+Qed.
+
+Notation " 'word " := (Word) (in custom pack_type at level 2).
+Notation " 'word " := (Word) (at level 2): package_scope.
+
+Context (PRF: Word -> Word -> Word).
+
+Definition k_loc: Location := ('option 'word ; 0).
+Definition T_loc: Location := (chMap 'word 'word ; 1).
+Definition count_loc: Location := ('nat ; 2).
+Definition query: nat := 3.
+Definition lookup: nat := 4.
+
+Definition mkpair {Lt Lf E}
+  (t: package Lt [interface] E) (f: package Lf [interface] E):
+  loc_GamePair E := fun b => if b then {locpackage t} else {locpackage f}.
+
+Definition EVAL_locs_tt := fset [:: k_loc].
+Definition EVAL_locs_ff := fset [:: T_loc].
+
+Definition kgen: raw_code 'word :=
+  k_init ← get k_loc ;;
+  match k_init with
+  | None =>
+      k <$ uniform Word_N ;;
+      #put k_loc := Some k ;;
+      ret k
+  | Some k => ret k
+  end.
+
+Lemma kgen_valid {L I}:
+  k_loc \in L ->
+  ValidCode L I kgen.
+Proof.
+  move=> H.
+  apply: valid_getr => [// | [k|]].
+  1: by apply: valid_ret.
+  apply: valid_sampler => k.
+  apply: valid_putr => //.
+  by apply: valid_ret => //.
+Qed.
+
+Hint Extern 1 (ValidCode ?L ?I kgen) =>
+  eapply kgen_valid ;
+  auto_in_fset
+  : typeclass_instances ssprove_valid_db.
+
+Definition EVAL_pkg_tt:
+  package EVAL_locs_tt
+    [interface]
+    [interface #val #[lookup]: 'word → 'word ] :=
+  [package
+    #def #[lookup] (m: 'word): 'word {
+      k ← kgen ;;
+      ret (PRF k m)
+    }
+  ].
+
+Definition EVAL_pkg_ff:
+  package EVAL_locs_ff
+    [interface]
+    [interface #val #[lookup]: 'word → 'word ] :=
+  [package
+    #def #[lookup] (m: 'word): 'word {
+      T ← get T_loc ;;
+      match getm T m with
+      | None =>
+          r <$ uniform Word_N ;;
+          #put T_loc := setm T m r ;;
+          ret r
+      | Some r => ret r
+      end
+    }
+  ].
+
+Definition EVAL := mkpair EVAL_pkg_tt EVAL_pkg_ff.
+
+Definition GEN_pkg_tt:
+  package fset0 [interface]
+    [interface #val #[query]: 'unit → 'word × 'word ] :=
+  [package
+    #def #[query] (_: 'unit): 'word × 'word {
+      s <$ uniform Word_N ;;
+      ret (PRF s zero, PRF s one)
+    }
+  ].
+
+Definition GEN_pkg_ff:
+  package fset0 [interface]
+    [interface #val #[query]: 'unit → 'word × 'word ] :=
+  [package
+    #def #[query] (_: 'unit): 'word × 'word {
+      x <$ uniform Word_N ;;
+      y <$ uniform Word_N ;;
+      ret (x, y)
+    }
+  ].
+
+Definition GEN := mkpair GEN_pkg_tt GEN_pkg_ff.
+
+Definition GEN_HYB_locs := fset [:: count_loc ].
+
+(**
+  Defining the hybrid proofs is surprisingly simple: We can just take [i] as a
+  parameter, and we can use it in the package.
+
+  We diverge slightly from the book: The first hybrid is [GEN_HYB_pkg 0] rather
+  than [GEN_HYB_pkg 1]. This makes the proofs simpler, since all choices of [i]
+  are valid.
+*)
+Definition GEN_HYB_pkg i:
+  package GEN_HYB_locs
+    [interface]
+    [interface #val #[query]: 'unit → 'word × 'word ] :=
+  [package
+    #def #[query] (_: 'unit): 'word × 'word {
+      count ← get count_loc ;;
+      #put count_loc := count.+1 ;;
+      if count < i then
+        x <$ uniform Word_N ;;
+        y <$ uniform Word_N ;;
+        ret (x, y)
+      else
+        s <$ uniform Word_N ;;
+        ret (PRF s zero, PRF s one)
+    }
+  ].
+
+Definition GEN_HYB_EVAL_pkg i:
+  package GEN_HYB_locs
+    [interface #val #[lookup]: 'word → 'word ]
+    [interface #val #[query]: 'unit → 'word × 'word ] :=
+  [package
+    #def #[query] (_: 'unit): 'word × 'word {
+      #import {sig #[lookup]: 'word → 'word } as lookup ;;
+      count ← get count_loc ;;
+      #put count_loc := count.+1 ;;
+      if count < i then
+        x <$ uniform Word_N ;;
+        y <$ uniform Word_N ;;
+        ret (x, y)
+      else if count == i then
+        x ← lookup zero ;;
+        y ← lookup one ;;
+        ret (x, y)
+      else
+        s <$ uniform Word_N ;;
+        ret (PRF s zero, PRF s one)
+    }
+  ].
+
+Lemma GEN_equiv_true:
+  GEN true ≈₀ GEN_HYB_pkg 0.
+Proof.
+  apply eq_rel_perf_ind_ignore with (fset [:: count_loc]).
+  1: by rewrite -fset1E /GEN_HYB_locs fsub1set !fset_cons !in_fsetU !in_fset1 eq_refl !Bool.orb_true_r.
+  simplify_eq_rel m.
+  apply: r_get_remember_rhs => count.
+  apply: r_put_rhs.
+  ssprove_sync=> s.
+  ssprove_restore_mem;
+    last by apply: r_ret.
+  by ssprove_invariant.
+Qed.
+
+(**
+  The proofs are fairly simple. The main trick is to realise that [k] is
+  uninitialised when [count <= i].
+*)
+Lemma GEN_GEN_HYB_equiv i:
+  GEN_HYB_pkg i ≈₀ GEN_HYB_EVAL_pkg i ∘ EVAL true.
+Proof.
+  apply eq_rel_perf_ind with (
+    (heap_ignore (fset1 k_loc)) ⋊
+    couple_rhs count_loc k_loc
+      (fun count k => count <= i -> k = None)
+    ).
+  1: {
+    ssprove_invariant=> //=.
+    1: rewrite fsub1set.
+    all: by rewrite /GEN_HYB_locs /EVAL_locs_tt !fset_cons !in_fsetU !in_fset1 eq_refl !Bool.orb_true_r.
+  }
+  simplify_eq_rel m.
+  ssprove_code_simpl.
+  apply: r_get_vs_get_remember => count.
+  case: (eq_dec count i) => Heq.
+  - rewrite Heq eq_refl ltnn /=.
+    ssprove_swap_rhs 0.
+    apply: r_get_remember_rhs => k.
+    apply: (r_rem_couple_rhs count_loc k_loc) => Hinv.
+    rewrite Hinv //.
+    apply: r_put_vs_put.
+    ssprove_sync=> s.
+    apply: r_put_rhs.
+    apply: r_get_remind_rhs.
+    1: {
+      apply: is_remembering_rhs => s0 s1 [h [_ ->]] /=.
+      by rewrite get_set_heap_eq.
+    }
+    ssprove_restore_mem;
+      last by apply: r_ret.
+    ssprove_invariant.
+    2: by rewrite -subnE subSnn.
+    move {Hinv k Heq} => s0 s1 [[[Hinv _] _] _] loc H.
+    rewrite (get_set_heap_neq _ k_loc) -?in_fset1 //.
+    case: (eq_dec loc count_loc)=> Heq.
+    + by rewrite Heq !get_set_heap_eq.
+    + move /eqP in Heq.
+      by rewrite !get_set_heap_neq // Hinv.
+  - move /eqP /negPf in Heq.
+    rewrite Heq /=.
+    destruct (count < i) eqn:Hlt.
+    all: apply: r_put_vs_put.
+    all: ssprove_sync=> x.
+    1: ssprove_sync=> y.
+    all: ssprove_restore_mem;
+      last by apply: r_ret.
+    all: ssprove_invariant.
+    all: move=> s0 s1 [[Hinv _] H] /=.
+    all: rewrite /couple_rhs get_set_heap_eq get_set_heap_neq //.
+    all: move /eqP in Hlt.
+    + rewrite Hinv // H -subnE eqnE.
+      by rewrite subn_eq0 ltnW // -subn_eq0 Hlt.
+    + move /eqP /negPf in Hlt.
+      by rewrite -subnE eqnE Hlt.
+Qed.
+
+(**
+  This proof is very similar to the previous proof, except it is [T] that is
+  uninitialised when [count <= i].
+*)
+Lemma GEN_GEN_HYB_EVAL_equiv i:
+  GEN_HYB_EVAL_pkg i ∘ EVAL false ≈₀ GEN_HYB_pkg i.+1.
+Proof.
+  apply eq_rel_perf_ind with (
+    (heap_ignore (fset1 T_loc)) ⋊
+    couple_lhs count_loc T_loc
+      (fun count T => count <= i -> T = emptym)
+    ).
+  1: {
+    ssprove_invariant => //=.
+    1: rewrite fsub1set.
+    all: by rewrite /GEN_HYB_locs /EVAL_locs_ff !fset_cons !in_fsetU !in_fset1 eq_refl !Bool.orb_true_r.
+  }
+  simplify_eq_rel m.
+  ssprove_code_simpl.
+  apply: r_get_vs_get_remember => count.
+  case: (eq_dec count i) => Heq.
+  - rewrite Heq eq_refl ltnn ltnSn /=.
+    ssprove_swap_lhs 0.
+    apply: r_get_remember_lhs => T.
+    apply: (r_rem_couple_lhs count_loc T_loc) => Hinv.
+    rewrite Hinv //=.
+    apply: r_put_vs_put.
+    ssprove_sync=> x.
+    apply: r_put_lhs.
+    apply: r_get_remind_lhs.
+    1: {
+      apply: is_remembering_lhs => s0 s1 [h [_ ->]] /=.
+      by rewrite get_set_heap_eq.
+    }
+    rewrite setmE /=.
+    ssprove_sync=> y.
+    apply: r_put_lhs.
+    ssprove_restore_mem;
+      last by apply: r_ret.
+    ssprove_invariant.
+    2: by rewrite -subnE subSnn.
+    move {Hinv T Heq} => s0 s1 [[[Hinv A] B] C] loc H /=.
+    rewrite !(get_set_heap_neq _ T_loc) -?in_fset1 //.
+    case: (eq_dec loc count_loc)=> Heq.
+    + by rewrite Heq !get_set_heap_eq.
+    + move /eqP in Heq.
+      by rewrite !get_set_heap_neq // Hinv.
+  - move /eqP /negPf in Heq.
+    rewrite Heq /=.
+    destruct (count < i) eqn:Hlt.
+    all: apply: r_put_vs_put.
+    1: rewrite ltnW //.
+    2: rewrite ltnS leq_eqVlt Heq Hlt /=.
+    all: ssprove_sync => x.
+    1: ssprove_sync => y.
+    all: ssprove_restore_mem;
+      last by apply: r_ret.
+    all: ssprove_invariant.
+    all: move=> s0 s1 [[Hinv H] _] /=.
+    all: rewrite /couple_lhs get_set_heap_eq get_set_heap_neq //.
+    all: move /eqP in Hlt.
+    + rewrite Hinv // H -subnE eqnE.
+      by rewrite subn_eq0 ltnW // -subn_eq0 Hlt.
+    + move /eqP /negPf in Hlt.
+      by rewrite -subnE eqnE Hlt.
+Qed.
+
+Local Open Scope ring_scope.
+
+(**
+  The advantage an adversary can gain over the PRF, i.e. the chance by
+  which an adversary can distinguish the PRF from a truly random function.
+  Negligible by assumption.
+*)
+Definition prf_epsilon := Advantage EVAL.
+
+(**
+  First we prove a bound on the hybrid packages. Since [q] can be any number
+  the bound is a sum of [prf_epsilon], and the proof is by induction.
+*)
+Theorem hyb_security_based_on_prf LA A q:
+  ValidPackage LA
+    [interface #val #[query]: 'unit → 'word × 'word ]
+    A_export A ->
+  fdisjoint LA (
+    EVAL_locs_tt :|: EVAL_locs_ff :|: GEN_HYB_locs
+  ) ->
+  AdvantageE (GEN_HYB_pkg 0) (GEN_HYB_pkg q) A <=
+  \sum_(i < q) prf_epsilon (A ∘ GEN_HYB_EVAL_pkg i).
+Proof.
+  move=> vA H.
+  elim: q => [|q IHq].
+  1: by rewrite big_ord0 /AdvantageE GRing.subrr normr0.
+  ssprove triangle (GEN_HYB_pkg 0) [::
+    pack (GEN_HYB_pkg q) ;
+    GEN_HYB_EVAL_pkg q ∘ EVAL true ;
+    GEN_HYB_EVAL_pkg q ∘ EVAL false
+  ] (GEN_HYB_pkg q.+1) A
+  as ineq.
+  apply: le_trans.
+  1: by apply: ineq.
+  rewrite !fdisjointUr in H.
+  move: H => /andP [/andP [H1 H2] H3].
+  move: {ineq H1 H2 H3} (H1, H2, H3) => H.
+  rewrite GEN_GEN_HYB_equiv ?fdisjointUr ?H // GRing.addr0.
+  rewrite GEN_GEN_HYB_EVAL_equiv ?fdisjointUr ?H // GRing.addr0.
+  rewrite big_ord_recr ler_add //.
+  by rewrite /prf_epsilon Advantage_E Advantage_link Advantage_sym.
+Qed.
+
+(**
+  The final statement requires a proof that [A ∘ GEN_HYB_pkg q] and [A ∘ GEN false]
+  are perfectly indistinguishable. The [q] for which this holds depends on the
+  adversary (and might not exist for some adversaries). We sidestep this issue
+  by making it a hypothesis.
+*)
+Theorem security_based_on_prf LA A q:
+  ValidPackage LA
+    [interface #val #[query]: 'unit → 'word × 'word ]
+    A_export A ->
+  fdisjoint LA (
+    EVAL_locs_tt :|: EVAL_locs_ff :|: GEN_HYB_locs
+  ) ->
+  AdvantageE (GEN_HYB_pkg q) (GEN false) A = 0 ->
+  Advantage GEN A <= \sum_(i < q) prf_epsilon (A ∘ GEN_HYB_EVAL_pkg i).
+Proof.
+  move=> vA H GEN_equiv_false.
+  rewrite Advantage_E Advantage_sym.
+  ssprove triangle (GEN true) [::
+    pack (GEN_HYB_pkg 0) ;
+    pack (GEN_HYB_pkg q)
+  ] (GEN false) A
+  as ineq.
+  apply: le_trans.
+  1: by apply: ineq.
+  rewrite !fdisjointUr in H.
+  move: H => /andP [/andP [H1 H2] H3].
+  move: {ineq H1 H2 H3} (H1, H2, H3, fdisjoints0) => H.
+  rewrite GEN_equiv_true ?fdisjointUr ?H // GRing.add0r.
+  rewrite GEN_equiv_false GRing.addr0.
+  by rewrite hyb_security_based_on_prf // !fdisjointUr !H.
+Qed.
+
+End PRFGEN_example.

--- a/theories/Crypt/examples/PRPCCA.v
+++ b/theories/Crypt/examples/PRPCCA.v
@@ -1,0 +1,1213 @@
+(**
+  This formalises Claim 9.4 from "The Joy of Cryptography" (p. 172). It is a
+  CCA-secure scheme based on a Strong Pseudo-Random Permutation (SPRP). It is
+  significantly more complicated than MACCCA.v, but relies only on one,
+  somewhat low-level, cryptographic primitive.
+
+  It shows how to do sampling without replacement in SSProve. It follows the
+  proof from the book rather closely, with only a minor diversion (see
+  [CTXT_HYB_pkg_2]), and most of the proofs are relatively easy to follow.
+
+  As with PRFMAC.v it shows the advantage is at most the sum of the
+  [prp_epsilon] and a [statistical_gap]. The first is negligible by assumption,
+  the latter requires additional analysis to prove, which is not yet supported
+  by SSProve.
+*)
+
+From Relational Require Import OrderEnrichedCategory GenericRulesSimple.
+
+Set Warnings "-notation-overridden,-ambiguous-paths".
+From mathcomp Require Import all_ssreflect all_algebra reals distr realsum
+  ssrnat ssreflect ssrfun ssrbool ssrnum eqtype choice seq.
+Set Warnings "notation-overridden,ambiguous-paths".
+
+From Mon Require Import SPropBase.
+From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
+  UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb
+  pkg_core_definition choice_type pkg_composition pkg_rhl Package Prelude.
+
+From extructures Require Import ord fset fmap.
+
+Import SPropNotations.
+
+Import PackageNotation.
+
+From Equations Require Import Equations.
+Require Equations.Prop.DepElim.
+
+Set Equations With UIP.
+
+Set Bullet Behavior "Strict Subproofs".
+Set Default Goal Selector "!".
+Set Primitive Projections.
+
+Import Num.Def.
+Import Num.Theory.
+Import Order.POrderTheory.
+
+Section PRPCCA_example.
+
+(**
+  We can't use sets directly in [choice_type] so instead we use a map to units.
+  We can then use [domm] to get the domain, which is a set.
+*)
+Definition chSet t := chMap t 'unit.
+
+Notation " 'set t " := (chSet t) (in custom pack_type at level 2).
+Notation " 'set t " := (chSet t) (at level 2): package_scope.
+
+Definition tt := Datatypes.tt.
+
+Definition fset_to_chset {T: ordType} (s: {fset T}): {fmap T -> 'unit} :=
+  mkfmap [seq (i, tt) | i <- s].
+
+Lemma domm_fset_to_chset {T}:
+  cancel (@fset_to_chset T) (@domm T 'unit).
+Proof.
+  move=> [m Hm] /=.
+  apply: fsval_eq.
+  have H: (fst \o pair^~ tt =1 id) => //.
+  by rewrite /fset_to_chset val_domm mkfmapK /unzip1 -map_comp (eq_map (H T)) map_id.
+Qed.
+
+(**
+  A core part of the proof is sampling without replacement. This is implemented
+  by keeping track of a set of sampled items, and then sampling from the
+  complement of that set.
+
+  [compl] computes the complement of a set of integers modulo [n].
+*)
+Definition compl {n} (r: {fset 'I_n}): {fset 'I_n} :=
+  fset (ord_enum n) :\: r.
+
+Lemma in_compl {n} (a: 'I_n) (s: {fset 'I_n}):
+  (a \in compl s) = (a \notin s).
+Proof.
+  by rewrite in_fsetD in_fset mem_ord_enum Bool.andb_true_r.
+Qed.
+
+(**
+  We cannot sample directly from a set in SSProve, so instead we sample an
+  integer less than the size of the set, and then pick the corresponding
+  element.
+*)
+Definition sample_subset {n} `{Positive n} {r: seq 'I_n} (k: 'I_(size r)): 'fin n :=
+  nth (chCanonical ('fin n)) r (nat_of_ord k).
+
+Lemma sample_subset_in {n} `{Positive n} {r: seq 'I_n} (k: 'I_(size r)):
+  sample_subset k \in r.
+Proof.
+  by apply: mem_nth.
+Qed.
+
+(**
+  This implements sampling without replacement, by sampling from the complement
+  of [r].
+
+  The input to [uniform] must be positive, and since [r] changes at runtime that
+  won't necessarily be the case. We handle this with an [#assert], which means
+  if [r'] is empty (i.e., we've sampled the entire set) the program will crash,
+  which is the only reasonable way to handle the case. (In fact, [#assert] is
+  implemented as sampling from an empty distribution.)
+*)
+Definition samp_no_repl {n} `{Positive n} {L} (r: {fset ('fin n)}): code L [interface] ('fin n) :=
+  {code
+    let r' := compl r in
+    #assert (0 < size r') as H ;;
+    i <$ @uniform _ H ;;
+    ret (sample_subset i)
+  }.
+
+Variable (n l: nat).
+
+Definition Word_N: nat := 2^n.
+Definition Word: choice_type := 'fin Word_N.
+
+Definition Key_N: nat := 2^l.
+Definition Key: choice_type := 'fin Key_N.
+
+(**
+  Ciphertexts are technically a [Word * Key] pair, but since we want to be able
+  to sample random ciphertexts, we define them as [n+l]-bit integers.
+*)
+Definition Ciph_N: nat := 2^(n + l).
+Definition Ciph: choice_type := 'fin Ciph_N.
+
+(**
+  We can then define functions to convert between the two.
+*)
+#[program]
+Definition ciph_to_pair (c: Ciph): Word * Key :=
+  (@Ordinal _ (c %% Word_N) _, @Ordinal _ (c %/ Word_N) _).
+Next Obligation.
+  by rewrite ltn_mod PositiveExp2.
+Qed.
+Next Obligation.
+  by rewrite ltn_divLR ?PositiveExp2 // -expnD addnC.
+Qed.
+
+#[program]
+Definition mkciph (m: Word) (r: Key): Ciph :=
+  @Ordinal _ (r * Word_N + m) _.
+Next Obligation.
+  apply: (@leq_trans (r * Word_N + Word_N)).
+  - by rewrite ltn_add2l.
+  - by rewrite /Ciph_N expnD addnC -mulSn mulnC leq_pmul2l ?PositiveExp2.
+Qed.
+
+Lemma mkciph_ciph_to_pair (c: Ciph):
+  mkciph (ciph_to_pair c).1 (ciph_to_pair c).2 = c.
+Proof.
+  apply: ord_inj.
+  case: c => [c Hc] /=.
+  by rewrite -divn_eq.
+Qed.
+
+Lemma ciph_to_pair_mkciph (m: Word) (r: Key):
+  ciph_to_pair (mkciph m r) = (m, r).
+Proof.
+  rewrite /mkciph /ciph_to_pair /=.
+  f_equal.
+  all: apply: ord_inj => /=.
+  - by rewrite modnMDl modn_small.
+  - by rewrite divnMDl ?PositiveExp2 ?divn_small ?addn0.
+Qed.
+
+Lemma mkciph_eq (m m': Word) (r r': Key):
+  (mkciph m r == mkciph m' r') = (m == m') && (r == r').
+Proof.
+  case: (eq_dec ((m == m') && (r == r')) true).
+  1: {
+    move=> /andP [/eqP -> /eqP ->].
+    by rewrite !eq_refl.
+  }
+  move /eqP.
+  rewrite eqb_id => /nandP [/negPf Hneq|/negPf Hneq].
+  all: rewrite Hneq ?Bool.andb_false_r /=.
+  all: move /eqP in Hneq.
+  all: apply /eqP => contra.
+  all: apply (f_equal ciph_to_pair) in contra.
+  all: rewrite !ciph_to_pair_mkciph in contra.
+  all: by case: contra.
+Qed.
+
+Context (PRP:  Key -> Ciph -> Ciph).
+Context (PRP': Key -> Ciph -> Ciph).
+
+Notation " 'word " := (Word) (in custom pack_type at level 2).
+Notation " 'word " := (Word) (at level 2): package_scope.
+
+Notation " 'key " := (Key) (in custom pack_type at level 2).
+Notation " 'key " := (Key) (at level 2): package_scope.
+
+Notation " 'ciph " := (Ciph) (in custom pack_type at level 2).
+Notation " 'ciph " := (Ciph) (at level 2): package_scope.
+
+Definition k_loc: Location := ('option 'key ; 0).
+Definition T_loc: Location := (chMap 'ciph 'ciph ; 1).
+Definition Tinv_loc: Location := (chMap 'ciph 'ciph ; 2).
+Definition Tinv'_loc: Location := (chMap 'ciph 'ciph ; 3).
+Definition S_loc: Location := ('set 'ciph ; 4).
+Definition R_loc: Location := ('set 'key ; 5).
+Definition samp: nat := 6.
+Definition ctxt: nat := 7.
+Definition decrypt: nat := 8.
+Definition lookup: nat := 9.
+Definition invlookup: nat := 10.
+
+Definition mkpair {Lt Lf E}
+  (t: package Lt [interface] E) (f: package Lf [interface] E):
+  loc_GamePair E := fun b => if b then {locpackage t} else {locpackage f}.
+
+(**
+  The [SAMP] packages define sampling with ([true]), and without ([false])
+  replacement.
+*)
+Definition SAMP_pkg_tt (p: nat) `{Positive p}:
+  package fset0 [interface]
+    [interface
+      #val #[samp]: 'set ('fin p) → ('fin p) ] :=
+  [package
+    #def #[samp] (S: 'set ('fin p)): ('fin p) {
+      s <$ uniform p ;;
+      ret s
+    }
+  ].
+
+Definition SAMP_pkg_ff (p: nat) `{Positive p}:
+  package fset0 [interface]
+    [interface
+      #val #[samp]: 'set ('fin p) → ('fin p) ] :=
+  [package
+    #def #[samp] (S: 'set ('fin p)): ('fin p) {
+      s ← samp_no_repl (domm S) ;;
+      ret s
+    }
+  ].
+
+Definition SAMP (p: nat) `{Positive p} :=
+  mkpair (SAMP_pkg_tt p) (SAMP_pkg_ff p).
+
+Definition kgen: raw_code 'key :=
+  k_init ← get k_loc ;;
+  match k_init with
+  | None =>
+      k <$ uniform Key_N ;;
+      #put k_loc := Some k ;;
+      ret k
+  | Some k => ret k
+  end.
+
+Lemma kgen_valid {L I}:
+  k_loc \in L ->
+  ValidCode L I kgen.
+Proof.
+  move=> H.
+  apply: valid_getr => [// | [k|]].
+  1: by apply: valid_ret.
+  apply: valid_sampler => k.
+  apply: valid_putr => //.
+  by apply: valid_ret => //.
+Qed.
+
+Hint Extern 1 (ValidCode ?L ?I kgen) =>
+  eapply kgen_valid ;
+  auto_in_fset
+  : typeclass_instances ssprove_valid_db.
+
+Definition EVAL_locs_tt := (fset [:: k_loc]).
+Definition EVAL_locs_ff := (fset [:: T_loc; Tinv_loc]).
+
+(**
+  Next, we define the packages for the SPRP, [EVAL]. They follow the definitions
+  from the book exactly.
+
+  They are computationally indistinguishable by assumption.
+*)
+Definition EVAL_pkg_tt:
+  package EVAL_locs_tt
+    [interface]
+    [interface
+      #val #[lookup]: 'ciph → 'ciph ;
+      #val #[invlookup]: 'ciph → 'ciph ] :=
+  [package
+    #def #[lookup] (x: 'ciph): 'ciph {
+      k ← kgen ;;
+      ret (PRP k x)
+    } ;
+    #def #[invlookup] (y: 'ciph): 'ciph {
+      k ← kgen ;;
+      ret (PRP' k y)
+    }
+  ].
+
+Definition EVAL_pkg_ff:
+  package EVAL_locs_ff
+    [interface]
+    [interface
+      #val #[lookup]: 'ciph → 'ciph ;
+      #val #[invlookup]: 'ciph → 'ciph ] :=
+  [package
+    #def #[lookup] (x: 'ciph): 'ciph {
+      T ← get T_loc ;;
+      match getm T x with
+      | None =>
+          y ← samp_no_repl (codomm T) ;;
+          Tinv ← get Tinv_loc ;;
+          #put T_loc := setm T x y ;;
+          #put Tinv_loc := setm Tinv y x ;;
+          ret y
+      | Some y => ret y
+      end
+    } ;
+    #def #[invlookup] (y: 'ciph): 'ciph {
+      Tinv ← get Tinv_loc ;;
+      match getm Tinv y with
+      | None =>
+          x ← samp_no_repl (codomm Tinv) ;;
+          T ← get T_loc ;;
+          #put T_loc := setm T x y ;;
+          #put Tinv_loc := setm Tinv y x ;;
+          ret x
+      | Some x => ret x
+      end
+    }
+  ].
+
+Definition EVAL_SAMP_pkg:
+  package EVAL_locs_ff
+    [interface
+      #val #[samp]: 'set 'ciph → 'ciph ]
+    [interface
+      #val #[lookup]: 'ciph → 'ciph ;
+      #val #[invlookup]: 'ciph → 'ciph ] :=
+  [package
+    #def #[lookup] (x: 'ciph): 'ciph {
+      T ← get T_loc ;;
+      match getm T x with
+      | None =>
+          #import {sig #[samp]: 'set 'ciph → 'ciph } as samp ;;
+          y ← samp (fset_to_chset (codomm T)) ;;
+          Tinv ← get Tinv_loc ;;
+          #put T_loc := setm T x y ;;
+          #put Tinv_loc := setm Tinv y x ;;
+          ret y
+      | Some y => ret y
+      end
+    } ;
+    #def #[invlookup] (y: 'ciph): 'ciph {
+      Tinv ← get Tinv_loc ;;
+      match getm Tinv y with
+      | None =>
+          #import {sig #[samp]: 'set 'ciph → 'ciph } as samp ;;
+          x ← samp (fset_to_chset (codomm Tinv)) ;;
+          T ← get T_loc ;;
+          #put T_loc := setm T x y ;;
+          #put Tinv_loc := setm Tinv y x ;;
+          ret x
+      | Some x => ret x
+      end
+    }
+  ].
+
+Definition EVAL := mkpair EVAL_pkg_tt EVAL_pkg_ff.
+
+Definition CTXT_locs := (fset [:: k_loc; S_loc]).
+
+(**
+  We now get to the main definitions of the proof. We are trying to prove the
+  [CTXT] packages are computationally indistinguishable.
+*)
+Definition CTXT_pkg_tt:
+  package CTXT_locs
+    [interface]
+    [interface
+      #val #[ctxt]: 'word → 'ciph ;
+      #val #[decrypt]: 'ciph → 'word ] :=
+  [package
+    #def #[ctxt] (m: 'word): 'ciph {
+      r <$ uniform Key_N ;;
+      k ← kgen ;;
+      let c := PRP k (mkciph m r) in
+      S ← get S_loc ;;
+      #put S_loc := setm S c tt ;;
+      ret c
+    } ;
+    #def #[decrypt] (c: 'ciph): 'word {
+      S ← get S_loc ;;
+      #assert (c \notin domm S) ;;
+      k ← kgen ;;
+      ret (ciph_to_pair (PRP' k c)).1
+    }
+  ].
+
+Definition CTXT_pkg_ff:
+  package CTXT_locs
+    [interface]
+    [interface
+      #val #[ctxt]: 'word → 'ciph ;
+      #val #[decrypt]: 'ciph → 'word ] :=
+  [package
+    #def #[ctxt] (m: 'word): 'ciph {
+      c <$ uniform Ciph_N ;;
+      S ← get S_loc ;;
+      #put S_loc := setm S c tt ;;
+      ret c
+    } ;
+    #def #[decrypt] (c: 'ciph): 'word {
+      S ← get S_loc ;;
+      #assert (c \notin domm S) ;;
+      k ← kgen ;;
+      ret (ciph_to_pair (PRP' k c)).1
+    }
+  ].
+
+Definition CTXT := mkpair CTXT_pkg_tt CTXT_pkg_ff.
+
+Definition CTXT_EVAL_locs := (fset [:: S_loc]).
+
+Definition CTXT_EVAL_pkg_tt:
+  package CTXT_EVAL_locs
+    [interface
+      #val #[lookup]: 'ciph → 'ciph ;
+      #val #[invlookup]: 'ciph → 'ciph ]
+    [interface
+      #val #[ctxt]: 'word → 'ciph ;
+      #val #[decrypt]: 'ciph → 'word ] :=
+  [package
+    #def #[ctxt] (m: 'word): 'ciph {
+      #import {sig #[lookup]: 'ciph → 'ciph } as lookup ;;
+      r <$ uniform Key_N ;;
+      c ← lookup (mkciph m r) ;;
+      S ← get S_loc ;;
+      #put S_loc := setm S c tt ;;
+      ret c
+    } ;
+    #def #[decrypt] (c: 'ciph): 'word {
+      #import {sig #[invlookup]: 'ciph → 'ciph } as invlookup ;;
+      S ← get S_loc ;;
+      #assert (c \notin domm S) ;;
+      mr ← invlookup c ;;
+      let (m, r) := ciph_to_pair mr in
+      ret m
+    }
+  ].
+
+Definition CTXT_EVAL_SAMP_locs := (fset [:: S_loc; R_loc]).
+
+Definition CTXT_EVAL_SAMP_pkg:
+  package CTXT_EVAL_SAMP_locs
+    [interface
+      #val #[samp]: 'set 'key → 'key ;
+      #val #[lookup]: 'ciph → 'ciph ;
+      #val #[invlookup]: 'ciph → 'ciph ]
+    [interface
+      #val #[ctxt]: 'word → 'ciph ;
+      #val #[decrypt]: 'ciph → 'word ] :=
+  [package
+    #def #[ctxt] (m: 'word): 'ciph {
+      #import {sig #[samp]: 'set 'key → 'key } as samp ;;
+      #import {sig #[lookup]: 'ciph → 'ciph } as lookup ;;
+      R ← get R_loc ;;
+      r ← samp R ;;
+      c ← lookup (mkciph m r) ;;
+      S ← get S_loc ;;
+      #put S_loc := setm S c tt ;;
+      #put R_loc := setm R r tt ;;
+      ret c
+    } ;
+    #def #[decrypt] (c: 'ciph): 'word {
+      #import {sig #[invlookup]: 'ciph → 'ciph } as invlookup ;;
+      R ← get R_loc ;;
+      S ← get S_loc ;;
+      #assert (c \notin domm S) ;;
+      mr ← invlookup c ;;
+      let (m, r) := ciph_to_pair mr in
+      #put R_loc := setm R r tt ;;
+      ret m
+    }
+  ].
+
+(**
+  This package is interesting. It is a parallel composition ([par]) of [EVAL]
+  and [SAMP Key_N], i.e. it provides both sampling of keys and a strong
+  pseudo-random permutation of ciphertext.
+
+  [b] controls whether they use sampling with, or without replacement, but there
+  is a catch: They are reversed! If keys are sampled with replacement then the
+  ciphertext sampling is without replacement and vice-versa. This is
+  unintuitive, but it matches the use of Lemma 4.12 from the proof in the book
+  (p. 174).
+*)
+Definition EVAL_SAMP (b: bool):
+  package EVAL_locs_ff [interface]
+    [interface
+      #val #[samp]: 'set 'key → 'key ;
+      #val #[lookup]: 'ciph → 'ciph ;
+      #val #[invlookup]: 'ciph → 'ciph ].
+Proof.
+  apply (mkpackage (par (EVAL_SAMP_pkg ∘ SAMP Ciph_N b) (SAMP Key_N (~~ b)))).
+  ssprove_valid => //=.
+  all: case: b.
+  1-2: by fdisjoint_auto.
+  1-2: by apply: fsubsetxx.
+  1-2: by apply: fsub0set.
+  1-2: by rewrite fsetU0 fsubsetxx.
+  1-2: by rewrite /Game_import -fset0E fsetU0 fsubsetxx.
+  1-2: by rewrite fset_cons fsetUC fset1E fsubsetxx.
+Defined.
+
+Definition CTXT_HYB_locs_1 := (fset [:: S_loc; R_loc; T_loc; Tinv_loc]).
+
+Definition CTXT_HYB_pkg_1:
+  package CTXT_HYB_locs_1
+    [interface
+      #val #[samp]: 'set 'key → 'key ]
+    [interface
+      #val #[ctxt]: 'word → 'ciph ;
+      #val #[decrypt]: 'ciph → 'word ] :=
+  [package
+    #def #[ctxt] (m: 'word): 'ciph {
+      #import {sig #[samp]: 'set 'key → 'key } as samp ;;
+      R ← get R_loc ;;
+      r ← samp R ;;
+      let mr := mkciph m r in
+      T ← get T_loc ;;
+      c <$ uniform Ciph_N ;;
+      Tinv ← get Tinv_loc ;;
+      S ← get S_loc ;;
+      #put T_loc := setm T mr c ;;
+      #put Tinv_loc := setm Tinv c mr ;;
+      #put S_loc := setm S c tt ;;
+      #put R_loc := setm R r tt ;;
+      ret c
+    } ;
+    #def #[decrypt] (c: 'ciph): 'word {
+      R ← get R_loc ;;
+      S ← get S_loc ;;
+      #assert (c \notin domm S) ;;
+      Tinv ← get Tinv_loc ;;
+      mr ← match getm Tinv c with
+      | None =>
+          mr <$ uniform Ciph_N ;;
+          T ← get T_loc ;;
+          #put T_loc := setm T mr c ;;
+          #put Tinv_loc := setm Tinv c mr ;;
+          ret mr
+      | Some mr => ret mr
+      end ;;
+      let (m, r) := ciph_to_pair mr in
+      #put R_loc := setm R r tt ;;
+      ret m
+    }
+  ].
+
+Definition CTXT_HYB_locs_2 := (fset [:: S_loc; T_loc; Tinv_loc; Tinv'_loc]).
+
+(**
+  This is where the proof diverges from the book. The proof in the book removes
+  the writes to [T] and [Tinv] from the [ctxt] function because [T] is never
+  read, and [Tinv] is only read when [c] _isn't_ in [S], and we add it to [S]
+  right after. The second argument, while sound, isn't directly expressible in
+  SSProve, so we have to spread this into a few steps:
+   - We add a new variable [Tinv'] which is the same as [Tinv] except for the
+     write in [ctxt]. I.e., it is equivalent to the one from the book after the
+     removal of the write.
+   - We replace [getm Tinv c] with [getm Tinv' c] in the [match] inside
+     [decrypt]. This is valid since we only reach that point if [c] isn't [S],
+     and in that case they have the same value.
+   - Now, we can remove the write to [Tinv] in [ctxt], as well as remove [T]
+     entirely.
+   - Then we can go back to using [Tinv] inside the [match]. [Tinv] and [Tinv']
+     are exactly equal at this point.
+   - Finally, we can get rid of [Tinv'] completely.
+*)
+Definition CTXT_HYB_pkg_2:
+  package CTXT_HYB_locs_2
+    [interface]
+    [interface
+      #val #[ctxt]: 'word → 'ciph ;
+      #val #[decrypt]: 'ciph → 'word ] :=
+  [package
+    #def #[ctxt] (m: 'word): 'ciph {
+      r <$ uniform Key_N ;;
+      let mr := mkciph m r in
+      T ← get T_loc ;;
+      c <$ uniform Ciph_N ;;
+      Tinv ← get Tinv_loc ;;
+      S ← get S_loc ;;
+      #put T_loc := setm T mr c ;;
+      #put Tinv_loc := setm Tinv c mr ;;
+      #put S_loc := setm S c tt ;;
+      ret c
+    } ;
+    #def #[decrypt] (c: 'ciph): 'word {
+      S ← get S_loc ;;
+      #assert (c \notin domm S) ;;
+      Tinv ← get Tinv_loc ;;
+      Tinv' ← get Tinv'_loc ;;
+      mr ← match getm Tinv c with
+      | None =>
+          mr <$ uniform Ciph_N ;;
+          T ← get T_loc ;;
+          #put T_loc := setm T mr c ;;
+          #put Tinv_loc := setm Tinv c mr ;;
+          #put Tinv'_loc := setm Tinv' c mr ;;
+          ret mr
+      | Some mr => ret mr
+      end ;;
+      let (m, r) := ciph_to_pair mr in
+      ret m
+    }
+  ].
+
+Definition CTXT_HYB_pkg_3:
+  package CTXT_HYB_locs_2
+    [interface]
+    [interface
+      #val #[ctxt]: 'word → 'ciph ;
+      #val #[decrypt]: 'ciph → 'word ] :=
+  [package
+    #def #[ctxt] (m: 'word): 'ciph {
+      r <$ uniform Key_N ;;
+      let mr := mkciph m r in
+      T ← get T_loc ;;
+      c <$ uniform Ciph_N ;;
+      Tinv ← get Tinv_loc ;;
+      S ← get S_loc ;;
+      #put T_loc := setm T mr c ;;
+      #put Tinv_loc := setm Tinv c mr ;;
+      #put S_loc := setm S c tt ;;
+      ret c
+    } ;
+    #def #[decrypt] (c: 'ciph): 'word {
+      S ← get S_loc ;;
+      #assert (c \notin domm S) ;;
+      Tinv ← get Tinv_loc ;;
+      Tinv' ← get Tinv'_loc ;;
+      mr ← match getm Tinv' c with
+      | None =>
+          mr <$ uniform Ciph_N ;;
+          T ← get T_loc ;;
+          #put T_loc := setm T mr c ;;
+          #put Tinv_loc := setm Tinv c mr ;;
+          #put Tinv'_loc := setm Tinv' c mr ;;
+          ret mr
+      | Some mr => ret mr
+      end ;;
+      let (m, r) := ciph_to_pair mr in
+      ret m
+    }
+  ].
+
+Definition CTXT_HYB_pkg_4:
+  package CTXT_HYB_locs_2
+    [interface]
+    [interface
+      #val #[ctxt]: 'word → 'ciph ;
+      #val #[decrypt]: 'ciph → 'word ] :=
+  [package
+    #def #[ctxt] (m: 'word): 'ciph {
+      r <$ uniform Key_N ;;
+      let mr := mkciph m r in
+      c <$ uniform Ciph_N ;;
+      S ← get S_loc ;;
+      #put S_loc := setm S c tt ;;
+      ret c
+    } ;
+    #def #[decrypt] (c: 'ciph): 'word {
+      S ← get S_loc ;;
+      #assert (c \notin domm S) ;;
+      Tinv ← get Tinv_loc ;;
+      Tinv' ← get Tinv'_loc ;;
+      mr ← match getm Tinv' c with
+      | None =>
+          mr <$ uniform Ciph_N ;;
+          T ← get T_loc ;;
+          #put T_loc := setm T mr c ;;
+          #put Tinv_loc := setm Tinv c mr ;;
+          #put Tinv'_loc := setm Tinv' c mr ;;
+          ret mr
+      | Some mr => ret mr
+      end ;;
+      let (m, r) := ciph_to_pair mr in
+      ret m
+    }
+  ].
+
+Definition CTXT_HYB_pkg_5:
+  package CTXT_HYB_locs_2
+    [interface]
+    [interface
+      #val #[ctxt]: 'word → 'ciph ;
+      #val #[decrypt]: 'ciph → 'word ] :=
+  [package
+    #def #[ctxt] (m: 'word): 'ciph {
+      r <$ uniform Key_N ;;
+      let mr := mkciph m r in
+      c <$ uniform Ciph_N ;;
+      S ← get S_loc ;;
+      #put S_loc := setm S c tt ;;
+      ret c
+    } ;
+    #def #[decrypt] (c: 'ciph): 'word {
+      S ← get S_loc ;;
+      #assert (c \notin domm S) ;;
+      Tinv ← get Tinv_loc ;;
+      Tinv' ← get Tinv'_loc ;;
+      mr ← match getm Tinv c with
+      | None =>
+          mr <$ uniform Ciph_N ;;
+          T ← get T_loc ;;
+          #put T_loc := setm T mr c ;;
+          #put Tinv_loc := setm Tinv c mr ;;
+          #put Tinv'_loc := setm Tinv' c mr ;;
+          ret mr
+      | Some mr => ret mr
+      end ;;
+      let (m, r) := ciph_to_pair mr in
+      ret m
+    }
+  ].
+
+Definition CTXT_EVAL_pkg_ff:
+  package CTXT_EVAL_locs
+    [interface
+      #val #[lookup]: 'ciph → 'ciph ;
+      #val #[invlookup]: 'ciph → 'ciph ]
+    [interface
+      #val #[ctxt]: 'word → 'ciph ;
+      #val #[decrypt]: 'ciph → 'word ] :=
+  [package
+    #def #[ctxt] (m: 'word): 'ciph {
+      c <$ uniform Ciph_N ;;
+      S ← get S_loc ;;
+      #put S_loc := setm S c tt ;;
+      ret c
+    } ;
+    #def #[decrypt] (c: 'ciph): 'word {
+      #import {sig #[invlookup]: 'ciph → 'ciph } as invlookup ;;
+      S ← get S_loc ;;
+      #assert (c \notin domm S) ;;
+      mr ← invlookup c ;;
+      let (m, r) := ciph_to_pair mr in
+      ret m
+    }
+  ].
+
+(**
+  The rest is the equivalence proofs and the final security statement. They are
+  all fairly straight forward, although they can get a bit long.
+*)
+Lemma CTXT_equiv_true:
+  CTXT true ≈₀ CTXT_EVAL_pkg_tt ∘ EVAL true.
+Proof.
+  apply: eq_rel_perf_ind_eq.
+  simplify_eq_rel m.
+  all: apply rpost_weaken_rule with eq;
+    last by move=> [? ?] [? ?] [].
+  all: simplify_linking.
+  all: ssprove_code_simpl.
+  all: by apply: rreflexivity_rule.
+Qed.
+
+Lemma CTXT_EVAL_equiv_true:
+  CTXT_EVAL_pkg_tt ∘ EVAL false ≈₀ CTXT_EVAL_SAMP_pkg ∘ EVAL_SAMP false.
+Proof.
+  apply eq_rel_perf_ind_ignore with (fset [:: R_loc]).
+  1: by rewrite -fset1E /CTXT_EVAL_SAMP_locs fsub1set !fset_cons !in_fsetU !in_fset1 eq_refl !Bool.orb_true_r.
+  simplify_eq_rel m.
+  all: simplify_linking.
+  all: ssprove_code_simpl.
+  all: rewrite cast_fun_K.
+  all: ssprove_code_simpl.
+  all: ssprove_code_simpl_more.
+  all: apply: r_get_remember_rhs => R.
+  - ssprove_sync=> r.
+    ssprove_sync=> T.
+    case: (getm T (mkciph m r)) => [c|].
+    + ssprove_sync=> S.
+      ssprove_sync.
+      shelve.
+    + ssprove_code_simpl_more.
+      rewrite domm_fset_to_chset.
+      ssprove_sync=> H1.
+      ssprove_sync=> c.
+      ssprove_sync=> Tinv.
+      ssprove_swap_seq_lhs [:: 1; 0].
+      ssprove_swap_seq_rhs [:: 1; 0].
+      ssprove_sync=> S.
+      do 3 ssprove_sync.
+      shelve.
+  - ssprove_sync=> S.
+    ssprove_sync=> H1.
+    ssprove_sync=> Tinv.
+    case: (getm Tinv m) => [c|].
+    + shelve.
+    + ssprove_code_simpl_more.
+      rewrite domm_fset_to_chset.
+      ssprove_sync=> H2.
+      ssprove_sync=> c.
+      ssprove_sync=> T.
+      do 2 ssprove_sync.
+      shelve.
+    Unshelve.
+    all: apply: r_put_rhs.
+    all: ssprove_restore_mem;
+      last by apply: r_ret.
+    all: by ssprove_invariant.
+Qed.
+
+Lemma CTXT_HYB_equiv_1:
+  CTXT_EVAL_SAMP_pkg ∘ EVAL_SAMP true ≈₀ CTXT_HYB_pkg_1 ∘ SAMP Key_N false.
+Proof.
+  apply eq_rel_perf_ind with (
+    (fun '(h0, h1) => h0 = h1) ⋊
+    couple_rhs T_loc R_loc
+      (fun T R => forall m r,
+        r \notin domm R -> getm T (mkciph m r) = None)
+  ).
+  1: {
+    ssprove_invariant=> //.
+    all: by rewrite /CTXT_HYB_locs_1 !fset_cons !in_fsetU !in_fset1 eq_refl !Bool.orb_true_r.
+  }
+  simplify_eq_rel m.
+  all: ssprove_code_simpl.
+  1: rewrite cast_fun_K.
+  all: ssprove_code_simpl.
+  all: apply: r_get_vs_get_remember => R.
+  all: ssprove_code_simpl_more.
+  - ssprove_sync=> H1.
+    ssprove_sync=> r.
+    apply: r_get_vs_get_remember => T.
+    apply: (r_rem_couple_rhs T_loc R_loc) => Hinv.
+    rewrite Hinv -?in_compl ?sample_subset_in //.
+    ssprove_sync=> c.
+    ssprove_sync=> [|Tinv];
+      first by move=> ? ? ->.
+    ssprove_swap_seq_lhs [:: 1; 0].
+    ssprove_sync=> [|S];
+      first by move=> ? ? ->.
+    do 4 apply: r_put_vs_put.
+    all: ssprove_restore_mem;
+      last by apply: r_ret.
+    ssprove_invariant=> m' r'.
+    rewrite domm_set in_fsetU => /norP [H H'].
+    rewrite setmE mkciph_eq.
+    rewrite in_fset1 in H.
+    move: H => /negPf ->.
+    by rewrite Bool.andb_false_r Hinv.
+  - ssprove_sync=> [|S];
+      first by move=> ? ? ->.
+    ssprove_sync=> H1.
+    ssprove_sync=> [|Tinv];
+      first by move=> ? ? ->.
+    case: (getm Tinv m) => [c|].
+    + apply: r_put_vs_put.
+      all: ssprove_restore_mem;
+        last by apply: r_ret.
+      ssprove_invariant=> s0 s1 [[/= Hinv <-] <-] m' r'.
+      rewrite get_set_heap_eq domm_set in_fsetU => /norP [H H'].
+      rewrite get_set_heap_neq.
+      2: by apply /eqP.
+      by rewrite Hinv.
+    + ssprove_sync=> c.
+      apply: r_get_vs_get_remember => T.
+      apply: (r_rem_couple_rhs T_loc R_loc) => Hinv.
+      do 3 apply: r_put_vs_put.
+      all: ssprove_restore_mem;
+        last by apply: r_ret.
+      ssprove_invariant=> m' r'.
+      rewrite domm_set in_fsetU => /norP [H H'].
+      rewrite setmE -(mkciph_ciph_to_pair c) mkciph_eq.
+      rewrite in_fset1 in H.
+      move /negPf in H.
+      by rewrite H Bool.andb_false_r Hinv.
+Qed.
+
+Lemma CTXT_HYB_equiv_2:
+  CTXT_HYB_pkg_1 ∘ SAMP Key_N true ≈₀ CTXT_HYB_pkg_2.
+Proof.
+  apply eq_rel_perf_ind_ignore with (R_loc |: fset1 Tinv'_loc).
+  1: by rewrite fsubU1set /CTXT_HYB_locs_1 /CTXT_HYB_locs_2 fsub1set !fset_cons !in_fsetU !in_fset1 !eq_refl !Bool.orb_true_r.
+  simplify_eq_rel m.
+  all: ssprove_code_simpl.
+  all: ssprove_code_simpl_more.
+  all: apply: r_get_remember_lhs => R.
+  - ssprove_sync=> r.
+    ssprove_sync=> [|T];
+      first by rewrite in_fsetU !in_fset1; apply /norP; split; apply /eqP.
+    ssprove_sync=> c.
+    ssprove_sync=> [|Tinv];
+    first by rewrite in_fsetU !in_fset1; apply /norP; split; apply /eqP.
+    ssprove_sync=> [|S];
+      first by rewrite in_fsetU !in_fset1; apply /norP; split; apply /eqP.
+    do 3 ssprove_sync.
+    shelve.
+  - ssprove_sync=> [|S];
+      first by rewrite in_fsetU !in_fset1; apply /norP; split; apply /eqP.
+    ssprove_sync=> H1.
+    ssprove_sync=> [|Tinv];
+      first by rewrite in_fsetU !in_fset1; apply /norP; split; apply /eqP.
+    apply: r_get_remember_rhs => Tinv'.
+    case: (getm Tinv m) => [c|].
+    1: shelve.
+    ssprove_sync=> c.
+    ssprove_sync=> [|T];
+      first by rewrite in_fsetU !in_fset1; apply /norP; split; apply /eqP.
+    do 2 ssprove_sync.
+    apply: r_put_rhs.
+    shelve.
+  Unshelve.
+  all: apply: r_put_lhs.
+  all: ssprove_restore_mem;
+    last by apply: r_ret.
+  all: by ssprove_invariant.
+Qed.
+
+Lemma CTXT_HYB_equiv_3:
+  CTXT_HYB_pkg_2 ≈₀ CTXT_HYB_pkg_3.
+Proof.
+  apply eq_rel_perf_ind with (
+    (fun '(h0, h1) => h0 = h1) ⋊
+    triple_rhs S_loc Tinv_loc Tinv'_loc
+      (fun S Tinv Tinv' => forall c,
+        c \notin domm S -> getm Tinv c = getm Tinv' c)
+  ).
+  1: {
+    ssprove_invariant=> //.
+    all: by rewrite /CTXT_HYB_locs_2 !fset_cons !in_fsetU !in_fset1 eq_refl !Bool.orb_true_r.
+  }
+  simplify_eq_rel m.
+  all: ssprove_code_simpl.
+  all: ssprove_code_simpl_more.
+  - ssprove_sync=> r.
+    ssprove_sync=> [|T];
+      first by move=> [? ?] [? ?] ->.
+    ssprove_sync=> c.
+    apply: r_get_vs_get_remember => Tinv.
+    apply: r_get_vs_get_remember => S.
+    ssprove_sync;
+      first by move=> [? ?] [? ?] ->.
+    apply: r_put_vs_put.
+    apply: r_put_vs_put.
+    ssprove_restore_mem;
+      last by apply: r_ret.
+    ssprove_invariant=> s0 s1 [[[[Hinv _] <-] _] <-] c'.
+    specialize (Hinv c').
+    rewrite get_set_heap_eq domm_set in_fsetU => /norP [H H'].
+    rewrite get_set_heap_neq.
+    2: by apply /eqP.
+    rewrite get_set_heap_eq !get_set_heap_neq.
+    2,3: by apply /eqP.
+    rewrite in_fset1 in H.
+    move /negPf in H.
+    by rewrite setmE H Hinv.
+  - apply: r_get_vs_get_remember => S.
+    ssprove_sync=> H1.
+    apply: r_get_vs_get_remember => Tinv.
+    apply: r_get_vs_get_remember => Tinv'.
+    apply: (r_rem_triple_rhs S_loc Tinv_loc Tinv'_loc) => Hinv.
+    rewrite Hinv //.
+    case: (Tinv' m) => [c|].
+    1: {
+      ssprove_forget_all.
+      by apply: r_ret.
+    }
+    ssprove_sync=> c.
+    ssprove_sync=> [|T];
+      first by move=> ? ? ->.
+    ssprove_sync;
+      first by move=> ? ? ->.
+    apply: r_put_vs_put.
+    apply: r_put_vs_put.
+    ssprove_restore_mem;
+      last by apply: r_ret.
+    apply: preserve_update_mem_conj.
+    1: by ssprove_invariant.
+    move=> s0 s1 [[[[[[/= A B] Heq] C] D] E] F] c'.
+    rewrite 3?get_set_heap_neq.
+    2-4: by apply /eqP.
+    rewrite !get_set_heap_eq !setmE Heq.
+    case: (c' == m) => //.
+    by apply: Hinv.
+Qed.
+
+Lemma CTXT_HYB_equiv_4:
+  CTXT_HYB_pkg_3 ≈₀ CTXT_HYB_pkg_4.
+Proof.
+  apply eq_rel_perf_ind_ignore with (T_loc |: fset1 Tinv_loc).
+  1: by rewrite fsubU1set /CTXT_HYB_locs_2 fsub1set !fset_cons !in_fsetU !in_fset1 !eq_refl !Bool.orb_true_r.
+  simplify_eq_rel m.
+  all: ssprove_code_simpl.
+  all: ssprove_code_simpl_more.
+  - ssprove_sync=> r.
+    apply: r_get_remember_lhs => T.
+    ssprove_sync=> c.
+    apply: r_get_remember_lhs => Tinv.
+    ssprove_sync=> [|S];
+      first by rewrite in_fsetU !in_fset1; apply /norP; split; apply /eqP.
+    do 2 apply: r_put_lhs.
+    shelve.
+  - ssprove_sync=> [|S];
+      first by rewrite in_fsetU !in_fset1; apply /norP; split; apply /eqP.
+    ssprove_sync=> H1.
+    apply: r_get_remember_lhs => Tinv_l.
+    apply: r_get_remember_rhs => Tinv_r.
+    ssprove_sync=> [|Tinv'];
+      first by rewrite in_fsetU !in_fset1; apply /norP; split; apply /eqP.
+    case: (getm Tinv' m) => [c|].
+    + ssprove_forget_all.
+      by apply: r_ret.
+    + ssprove_sync=> c.
+      apply: r_get_remember_lhs => Tl.
+      apply: r_get_remember_rhs => Tr.
+      apply: r_put_lhs.
+      apply: r_put_rhs.
+      apply: r_put_vs_put.
+      shelve.
+    Unshelve.
+    all: ssprove_restore_mem;
+      first by ssprove_invariant.
+    all: ssprove_sync.
+    all: by apply: r_ret.
+Qed.
+
+Lemma CTXT_HYB_equiv_5:
+  CTXT_HYB_pkg_4 ≈₀ CTXT_HYB_pkg_5.
+Proof.
+  apply eq_rel_perf_ind with (
+    (fun '(h0, h1) => h0 = h1) ⋊
+    couple_rhs Tinv_loc Tinv'_loc eq
+  ).
+  1: {
+    ssprove_invariant=> //.
+    all: by rewrite /CTXT_HYB_locs_2 !fset_cons !in_fsetU !in_fset1 eq_refl !Bool.orb_true_r.
+  }
+  simplify_eq_rel m.
+  - apply: (@r_reflexivity_alt _ (S_loc |: fset1 R_loc)) => [loc H|loc v H].
+    all: ssprove_invariant;
+      first by move=> ? ? ->.
+    all: rewrite in_fsetU !in_fset1 in H.
+    all: apply /eqP.
+    all: by move: H => /orP [/eqP|/eqP] ->.
+  - ssprove_code_simpl.
+    ssprove_code_simpl_more.
+    ssprove_sync=> [|S];
+      first by move=> ? ? ->.
+    ssprove_sync=> H1.
+    apply: r_get_vs_get_remember => Tinv.
+    apply: r_get_vs_get_remember => Tinv'.
+    apply: (r_rem_couple_rhs Tinv_loc Tinv'_loc) => ->.
+    case: (getm Tinv' m) => [c|].
+    + ssprove_forget_all.
+      by apply: r_ret.
+    + ssprove_sync=> c.
+      ssprove_sync=> [|T];
+        first by move=> ? ? ->.
+      ssprove_sync;
+        first by move=> ? ? ->.
+      do 2 apply: r_put_vs_put.
+      ssprove_restore_mem;
+        last by apply: r_ret.
+      by ssprove_invariant.
+Qed.
+
+Lemma CTXT_HYB_equiv_6:
+  CTXT_HYB_pkg_5 ≈₀ CTXT_EVAL_pkg_ff ∘ EVAL_SAMP_pkg ∘ SAMP Ciph_N true.
+Proof.
+  apply eq_rel_perf_ind_ignore with (fset [:: Tinv'_loc]).
+  1: by rewrite -fset1E /CTXT_HYB_locs_2 /EVAL_locs_ff fsub1set !fset_cons !in_fsetU !in_fset1 !eq_refl !Bool.orb_true_r /=.
+  simplify_eq_rel m.
+  all: ssprove_code_simpl.
+  all: ssprove_code_simpl.
+  all: ssprove_code_simpl_more.
+  - apply: r_dead_sample_L.
+    apply: (@r_reflexivity_alt _ (fset1 S_loc)) => [loc H|loc v H].
+    all: ssprove_invariant.
+    rewrite in_fset1 in H.
+    move /eqP in H.
+    rewrite H -fset1E in_fset1.
+    by apply /eqP.
+  - ssprove_sync=> S.
+    ssprove_sync=> H1.
+    ssprove_sync=> Tinv.
+    apply: r_get_remember_lhs => Tinv'.
+    case: (Tinv m) => [c|] /=.
+    1: {
+      ssprove_forget_all.
+      by apply: r_ret.
+    }
+    ssprove_sync=> c.
+    ssprove_sync=> T.
+    do 2 ssprove_sync.
+    apply: r_put_lhs.
+    ssprove_restore_mem;
+      last by apply: r_ret.
+    by ssprove_invariant.
+Qed.
+
+Lemma CTXT_EVAL_equiv_false:
+  CTXT_EVAL_pkg_ff ∘ EVAL_SAMP_pkg ∘ SAMP Ciph_N false ≈₀ CTXT_EVAL_pkg_ff ∘ EVAL false.
+Proof.
+  apply: eq_rel_perf_ind_eq.
+  simplify_eq_rel m.
+  all: apply rpost_weaken_rule with eq;
+    last by move=> [? ?] [? ?] [].
+  2: ssprove_code_simpl.
+  2: rewrite cast_fun_K.
+  2: ssprove_code_simpl.
+  2: ssprove_code_simpl_more.
+  2: ssprove_sync_eq=> S.
+  2: ssprove_sync_eq=> H1.
+  2: ssprove_sync_eq=> Tinv.
+  2: rewrite domm_fset_to_chset.
+  all: by apply: rreflexivity_rule.
+Qed.
+
+Lemma CTXT_equiv_false:
+  CTXT_EVAL_pkg_ff ∘ EVAL true ≈₀ CTXT false.
+Proof.
+  apply: eq_rel_perf_ind_eq.
+  simplify_eq_rel m.
+  all: apply rpost_weaken_rule with eq;
+    last by move=> [? ?] [? ?] [].
+  2: ssprove_code_simpl.
+  2: ssprove_code_simpl.
+  2: ssprove_code_simpl_more.
+  all: by apply: rreflexivity_rule.
+Qed.
+
+Local Open Scope ring_scope.
+
+(**
+  The advantage an adversary can gain over the PRP, i.e. the chance by
+  which an adversary can distinguish the PRP from a truly random function.
+  Negligible by assumption.
+*)
+Definition prp_epsilon := Advantage EVAL.
+
+(**
+  The advantage an adversary can gain in the [SAMP] games.
+  This is negligible, but not yet provable in SSProve.
+*)
+Definition statistical_gap A :=
+  Advantage EVAL_SAMP (A ∘ CTXT_EVAL_SAMP_pkg) +
+  Advantage (SAMP Key_N) (A ∘ CTXT_HYB_pkg_1) +
+  Advantage (SAMP Ciph_N) (A ∘ CTXT_EVAL_pkg_ff ∘ EVAL_SAMP_pkg).
+
+Theorem security_based_on_prp LA A:
+  ValidPackage LA
+    [interface
+      #val #[ctxt]: 'word → 'ciph ;
+      #val #[decrypt]: 'ciph → 'word ]
+    A_export A ->
+  fdisjoint LA (
+    EVAL_locs_tt :|: EVAL_locs_ff :|: CTXT_locs :|:
+    CTXT_EVAL_locs :|: CTXT_EVAL_SAMP_locs :|:
+    CTXT_HYB_locs_1 :|: CTXT_HYB_locs_2
+    ) ->
+  Advantage CTXT A <=
+  prp_epsilon (A ∘ CTXT_EVAL_pkg_tt) +
+  statistical_gap A +
+  prp_epsilon (A ∘ CTXT_EVAL_pkg_ff).
+Proof.
+  move=> vA H.
+  rewrite Advantage_E Advantage_sym.
+  ssprove triangle (CTXT true) [::
+    CTXT_EVAL_pkg_tt ∘ EVAL true ;
+    CTXT_EVAL_pkg_tt ∘ EVAL false ;
+    CTXT_EVAL_SAMP_pkg ∘ EVAL_SAMP false ;
+    CTXT_EVAL_SAMP_pkg ∘ EVAL_SAMP true ;
+    CTXT_HYB_pkg_1 ∘ SAMP Key_N false ;
+    CTXT_HYB_pkg_1 ∘ SAMP Key_N true ;
+    pack CTXT_HYB_pkg_2 ;
+    pack CTXT_HYB_pkg_3 ;
+    pack CTXT_HYB_pkg_4 ;
+    pack CTXT_HYB_pkg_5 ;
+    CTXT_EVAL_pkg_ff ∘ EVAL_SAMP_pkg ∘ SAMP Ciph_N true ;
+    CTXT_EVAL_pkg_ff ∘ EVAL_SAMP_pkg ∘ SAMP Ciph_N false ;
+    CTXT_EVAL_pkg_ff ∘ EVAL false ;
+    CTXT_EVAL_pkg_ff ∘ EVAL true
+  ] (CTXT false) A as ineq.
+  apply: le_trans.
+  1: by apply: ineq.
+  rewrite !fdisjointUr in H.
+  move: H => /andP [/andP [/andP [/andP [/andP [/andP [H1 H2] H3] H4] H5] H6] H7].
+  move: {ineq H1 H2 H3 H4 H5 H6 H7} (H1, H2, H3, H4, H5, H6, H7, fdisjoints0) => H.
+  rewrite CTXT_equiv_true ?fdisjointUr ?H // GRing.add0r.
+  rewrite CTXT_EVAL_equiv_true ?fdisjointUr ?H // GRing.addr0.
+  rewrite CTXT_HYB_equiv_1 ?fdisjointUr ?H // GRing.addr0.
+  rewrite CTXT_HYB_equiv_2 ?fdisjointUr ?H // GRing.addr0.
+  rewrite CTXT_HYB_equiv_3 ?fdisjointUr ?H // GRing.addr0.
+  rewrite CTXT_HYB_equiv_4 ?fdisjointUr ?H // GRing.addr0.
+  rewrite CTXT_HYB_equiv_5 ?fdisjointUr ?H // GRing.addr0.
+  rewrite CTXT_HYB_equiv_6 ?fdisjointUr ?H // GRing.addr0.
+  rewrite CTXT_EVAL_equiv_false ?fdisjointUr ?H // GRing.addr0.
+  rewrite CTXT_equiv_false ?fdisjointUr ?H // GRing.addr0.
+  rewrite /prp_epsilon /statistical_gap !Advantage_E !GRing.addrA.
+  rewrite -!Advantage_link !link_assoc.
+  by rewrite (Advantage_sym (EVAL true)) (Advantage_sym (SAMP Ciph_N true)).
+Qed.
+
+End PRPCCA_example.

--- a/theories/Crypt/examples/SecretSharing.v
+++ b/theories/Crypt/examples/SecretSharing.v
@@ -1,0 +1,232 @@
+(**
+  This formalises Theorem 3.6 from "The Joy of Cryptography" (p. 51).
+  It is a simple 2-out-of-2 secret-sharing scheme with perfect security,
+  based on XOR.
+
+  It is fairly simple to understand. The hardest part is probably the definition
+  of [plus] (XOR), which is not really necessary to understand the proof.
+
+  The final statement ([unconditional_secrecy]) is equivalent to that of the
+  books: The scheme achieves perfect secerery with up to two shares
+  (non-inclusive).
+*)
+
+From Relational Require Import OrderEnrichedCategory GenericRulesSimple.
+
+Set Warnings "-notation-overridden,-ambiguous-paths".
+From mathcomp Require Import all_ssreflect all_algebra reals distr realsum
+  ssrnat ssreflect ssrfun ssrbool ssrnum eqtype choice seq.
+Set Warnings "notation-overridden,ambiguous-paths".
+
+From Mon Require Import SPropBase.
+From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
+  UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb
+  pkg_core_definition choice_type pkg_composition pkg_rhl Package Prelude.
+
+From extructures Require Import ord fset fmap.
+
+Import SPropNotations.
+
+Import PackageNotation.
+
+From Equations Require Import Equations.
+Require Equations.Prop.DepElim.
+
+Set Equations With UIP.
+
+Set Bullet Behavior "Strict Subproofs".
+Set Default Goal Selector "!".
+Set Primitive Projections.
+
+Import Num.Def.
+Import Num.Theory.
+Import Order.POrderTheory.
+
+Section SecretSharing_example.
+
+Variable (n: nat).
+
+Definition Word_N: nat := 2^n.
+Definition Word: choice_type := chFin (mkpos Word_N).
+
+(**
+  The first bit is a formalisation of [plus] (XOR).
+  It is similar to the definitions in OTP.v and PRF.v, but it has been split
+  into lemmas to hopefully be easier to read.
+  It is still somewhat unwieldy though.
+*)
+
+(**
+  Lemmas for the [plus] obligation.
+*)
+Lemma pow2_inj m:
+  (2 ^ m)%N = BinNat.N.to_nat (BinNat.N.pow (BinNums.Npos (BinNums.xO 1%AC)) (BinNat.N.of_nat m)).
+Proof.
+  elim: m => [// | m IHm].
+  rewrite expnSr Nnat.Nat2N.inj_succ BinNat.N.pow_succ_r' Nnat.N2Nat.inj_mul PeanoNat.Nat.mul_comm.
+  by apply: f_equal2.
+Qed.
+
+Lemma log2_lt_pow2 w m:
+  (w.+1 < 2^m)%N ->
+  BinNat.N.lt (BinNat.N.log2 (BinNat.N.of_nat w.+1)) (BinNat.N.of_nat m).
+Proof.
+  move=> H.
+  rewrite -BinNat.N.log2_lt_pow2.
+  - rewrite /BinNat.N.lt Nnat.N2Nat.inj_compare PeanoNat.Nat.compare_lt_iff -pow2_inj Nnat.Nat2N.id.
+    by apply /ltP.
+  - rewrite Nnat.Nat2N.inj_succ.
+    by apply: BinNat.N.lt_0_succ.
+Qed.
+
+#[program] Definition plus (w k: Word): Word :=
+  @Ordinal _ (BinNat.N.to_nat (BinNat.N.lxor
+    (BinNat.N.of_nat (nat_of_ord w))
+    (BinNat.N.of_nat (nat_of_ord k)))) _.
+Next Obligation.
+  move: w k => [[|w] Hw] [[|k] Hk].
+  1-3: by rewrite /= ?Pnat.SuccNat2Pos.id_succ.
+  move: (log2_lt_pow2 _ _ Hw) => H1.
+  move: (log2_lt_pow2 _ _ Hk) => H2.
+  move: (BinNat.N.max_lub_lt _ _ _ H1 H2) => Hm.
+  case: (BinNat.N.eq_dec (BinNat.N.lxor (BinNat.N.of_nat w.+1) (BinNat.N.of_nat k.+1)) BinNat.N0) => H0.
+  1: by rewrite H0 expn_gt0.
+  move: (BinNat.N.log2_lxor (BinNat.N.of_nat w.+1) (BinNat.N.of_nat k.+1)) => Hbound.
+  move: (BinNat.N.le_lt_trans _ _ _ Hbound Hm).
+  rewrite -BinNat.N.log2_lt_pow2.
+  2: by apply BinNat.N.neq_0_lt_0.
+  rewrite /BinNat.N.lt Nnat.N2Nat.inj_compare PeanoNat.Nat.compare_lt_iff -pow2_inj.
+  by move /ltP.
+Qed.
+
+Notation "m ⊕ k" := (plus m k) (at level 70).
+
+(**
+  Some lemmas for [plus] itself.
+*)
+Lemma plus_comm m k:
+  (m ⊕ k) = (k ⊕ m).
+Proof.
+  apply: ord_inj.
+  case: m => m ? /=.
+  by rewrite BinNat.N.lxor_comm.
+Qed.
+
+Lemma plus_assoc m l k:
+  ((m ⊕ l) ⊕ k) = (m ⊕ (l ⊕ k)).
+Proof.
+  apply: ord_inj.
+  case: m => m ? /=.
+  rewrite !Nnat.N2Nat.id.
+  by rewrite BinNat.N.lxor_assoc.
+Qed.
+
+Lemma plus_involutive m k:
+  (m ⊕ k) ⊕ k = m.
+Proof.
+  rewrite plus_assoc.
+  apply: ord_inj.
+  case: m => m ? /=.
+  rewrite Nnat.N2Nat.id.
+  rewrite BinNat.N.lxor_nilpotent.
+  rewrite BinNat.N.lxor_0_r.
+  by rewrite Nnat.Nat2N.id.
+Qed.
+
+#[local] Open Scope package_scope.
+
+Notation " 'word " := (Word) (in custom pack_type at level 2).
+Notation " 'word " := (Word) (at level 2): package_scope.
+
+(**
+  We can't use sequences directly in [choice_type] so instead we use a map from
+  natural numbers to the type.
+*)
+Definition chSeq t := chMap 'nat t.
+
+Notation " 'seq t " := (chSeq t) (in custom pack_type at level 2).
+Notation " 'seq t " := (chSeq t) (at level 2): package_scope.
+
+(**
+  We can't use sets directly in [choice_type] so instead we use a map to units.
+  We can then use [domm] to get the domain, which is a set.
+*)
+Definition chSet t := chMap t 'unit.
+
+Notation " 'set t " := (chSet t) (in custom pack_type at level 2).
+Notation " 'set t " := (chSet t) (at level 2): package_scope.
+
+Definition shares: nat := 0.
+
+Definition SHARE_pkg_tt:
+  package fset0 [interface]
+    [interface #val #[shares]: ('word × 'word) × 'set 'nat → 'seq 'word ] :=
+  [package
+    #def #[shares] ('(ml, mr, U): ('word × 'word) × 'set 'nat): 'seq 'word {
+      if size (domm U) >= 2 then ret emptym
+      else
+      s0 <$ uniform (2^n) ;;
+      let s1 := s0 ⊕ ml in
+      let sh := [fmap (0, s0) ; (1, s1)] in
+      ret (fmap_of_seq (pmap sh (domm U)))
+    }
+  ].
+
+Definition SHARE_pkg_ff:
+  package fset0 [interface]
+    [interface #val #[shares]: ('word × 'word) × 'set 'nat → 'seq 'word ] :=
+  [package
+    #def #[shares] ('(ml, mr, U): ('word × 'word) × 'set 'nat): 'seq 'word {
+      if size (domm U) >= 2 then ret emptym
+      else
+      s0 <$ uniform (2^n) ;;
+      let s1 := s0 ⊕ mr in
+      let sh := [fmap (0, s0) ; (1, s1)] in
+      ret (fmap_of_seq (pmap sh (domm U)))
+    }
+  ].
+
+Definition mkpair {Lt Lf E}
+  (t: package Lt [interface] E) (f: package Lf [interface] E):
+  loc_GamePair E := fun b => if b then {locpackage t} else {locpackage f}.
+
+Definition SHARE := mkpair SHARE_pkg_tt SHARE_pkg_ff.
+
+Lemma SHARE_equiv:
+  SHARE true ≈₀ SHARE false.
+Proof.
+  apply: eq_rel_perf_ind_eq.
+  simplify_eq_rel m.
+  apply rpost_weaken_rule with eq;
+    last by move=> [? ?] [? ?] [].
+  case m => [[ml mr] U].
+  case: (_ (domm U)) => {U} [|a U] /=.
+  1: by apply: rreflexivity_rule.
+  case: U => [|b U] /=.
+  2: by apply: rreflexivity_rule.
+  case: a => [|[|a]] /=.
+  1,3: by apply: rreflexivity_rule.
+  apply: r_uniform_bij => [|s0].
+  1: {
+    exists (fun x => x ⊕ (ml ⊕ mr)) => x.
+    all: by apply: plus_involutive.
+  }
+  rewrite plus_assoc plus_involutive.
+  by apply: rreflexivity_rule.
+Qed.
+
+(**
+  This corresponds to Theorem 3.6 from "The Joy of Cryptography".
+*)
+Theorem unconditional_secrecy LA A:
+  ValidPackage LA
+    [interface #val #[shares]: ('word × 'word) × 'set 'nat → 'seq 'word ]
+    A_export A ->
+  Advantage SHARE A = 0%R.
+Proof.
+  move=> vA.
+  rewrite Advantage_E Advantage_sym.
+  by rewrite SHARE_equiv ?fdisjoints0.
+Qed.
+
+End SecretSharing_example.

--- a/theories/Crypt/examples/ShamirSecretSharing.v
+++ b/theories/Crypt/examples/ShamirSecretSharing.v
@@ -1,0 +1,1052 @@
+(**
+  This formalises Theorem 3.13 from "The Joy of Cryptography" (p. 60).
+  It formalises Shamir's Secret Sharing scheme and proves that it has perfect
+  security. It is a t-out-of-n secret sharing scheme over the field ['F_p].
+
+  We also formalise Theorem 3.8 and 3.9 from the book
+  We skip Lemma 3.12, since the bijection technique used in this proof doesn't
+  benefit from the extra steps. (Note, earlier commits did include it, so if you
+  are interested, feel free to check out the commit history.)
+
+  By far most of the proof is spent on proving various properties of polynomials
+  that are used to define and prove security of a bijection. After this the
+  remaining part of the proof is just using that bijection to prove the scheme
+  is secure.
+
+  This differs a bit from the proof in "The Joy of Cryptography" since this is
+  based on a bijection whereas it is based on statistical analysis. This
+  arguably harder to prove, but it is the method that is directly supported by
+  SSProve, and it is also easier verify that you got it right.
+
+  The final statement ([unconditional_secrecy]) is equivalent to that of the
+  books: The scheme achieves perfect secrecy, for any [t], [n] and any prime
+  [p].
+*)
+
+From Relational Require Import OrderEnrichedCategory GenericRulesSimple.
+
+Set Warnings "-notation-overridden,-ambiguous-paths".
+From mathcomp Require Import all_ssreflect all_algebra reals distr realsum
+  ssrnat ssreflect ssrfun ssrbool ssrnum eqtype choice seq.
+Set Warnings "notation-overridden,ambiguous-paths".
+
+From Mon Require Import SPropBase.
+From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
+  UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb
+  pkg_core_definition choice_type pkg_composition pkg_rhl Package Prelude.
+
+From extructures Require Import ord fset fmap.
+
+Import SPropNotations.
+
+Import PackageNotation.
+
+From Equations Require Import Equations.
+Require Equations.Prop.DepElim.
+
+Set Equations With UIP.
+
+Set Bullet Behavior "Strict Subproofs".
+Set Default Goal Selector "!".
+Set Primitive Projections.
+
+Import Num.Def.
+Import Num.Theory.
+Import Order.POrderTheory.
+
+Local Open Scope ring_scope.
+
+(**
+  First step is to define Lagrange interpolation.
+  This is implemented in the [lagrange_poly] function, which is split up into
+  several helper functions.
+*)
+Definition lagrange_basis {R: unitRingType} (s: seq R) (x: R): {poly R} :=
+  \prod_(c <- s) ((x-c)^-1 *: Poly [:: -c ; 1]).
+
+Fixpoint subseqs_rec {T} l m r: seq (T * seq T) :=
+  match r with
+  | [::] => [:: (m, l)]
+  | a :: r' => (m, l ++ r) :: subseqs_rec (l ++ [:: m]) a r'
+  end.
+
+Definition subseqs {T} (s: seq T): seq (T * seq T) :=
+  match s with
+  | [::] => [::]
+  | m :: r => subseqs_rec [::] m r
+  end.
+
+Definition lagrange_poly_part {R: unitRingType} (j: R * R * seq (R * R)): {poly R} :=
+  j.1.2 *: lagrange_basis (unzip1 j.2) j.1.1.
+
+Definition lagrange_poly {R: unitRingType} (pts: seq (R * R)): {poly R} :=
+  \sum_(j <- subseqs pts) lagrange_poly_part j.
+
+(**
+  Then we prove some fundamental properties of Lagrange Interpolation.
+  Specifically:
+  - [size_lagrange_poly]: The size of a Lagrange polynomial is [<= size pts].
+  - [lagrange_poly_correct]: Evaluating a Lagrange polynomial at a point gives the corresponding y value.
+  - [lagrange_poly_unique]: There is exactly one polynomial with size [<= size pts], that satisfies [lagrange_poly_correct].
+
+  These together formalise Theorem 3.8 and 3.9 from the book
+*)
+
+Lemma lagrange_basis_0 {R: comUnitRingType} (x1 x: R) (s: seq R):
+  x \in s ->
+  (lagrange_basis s x1).[x] = 0.
+Proof.
+  rewrite /lagrange_basis.
+  elim: s => [// | a s IHs].
+  rewrite in_cons big_cons hornerM hornerZ !horner_cons hornerC GRing.mul0r GRing.add0r GRing.mul1r.
+  destruct (x == a) eqn:Heq.
+  - move /eqP in Heq.
+    by rewrite Heq GRing.subrr GRing.mulr0 GRing.mul0r.
+  - move=> H.
+    by rewrite IHs // GRing.mulr0.
+Qed.
+
+Lemma lagrange_basis_1 {R: fieldType} (x: R) (s: seq R):
+  (x \notin s) = ((lagrange_basis s x).[x] == 1).
+Proof.
+  rewrite /lagrange_basis.
+  elim: s => [|a s IHs].
+  1: by rewrite big_nil hornerC eq_refl.
+  rewrite in_cons big_cons hornerM hornerZ !horner_cons hornerC GRing.mul0r GRing.add0r GRing.mul1r.
+  destruct (x == a) eqn:Heq.
+  - move /eqP in Heq.
+    by rewrite Heq GRing.subrr GRing.mulr0 GRing.mul0r eq_sym GRing.oner_eq0.
+  - apply negbT in Heq.
+    rewrite -GRing.subr_eq0 in Heq.
+    by rewrite GRing.mulVf // GRing.mul1r IHs.
+Qed.
+
+Lemma size_lagrange_basis {R: fieldType} (x: R) (s: seq R):
+  (size (lagrange_basis s x) <= S (size s))%N.
+Proof.
+  rewrite /lagrange_basis.
+  elim: s => [|a s IHs].
+  1: by rewrite big_nil size_poly1.
+  rewrite big_cons.
+  destruct (x == a) eqn:Heq.
+  1: {
+    move /eqP in Heq.
+    by rewrite Heq GRing.subrr GRing.invr0 -mul_polyC polyC0 !GRing.mul0r size_poly0.
+  }
+  apply negbT in Heq.
+  apply: leq_trans.
+  1: by apply: size_mul_leq.
+  rewrite size_scale.
+  - by rewrite (@PolyK R 0) // GRing.oner_neq0.
+  - by rewrite GRing.invr_neq0 // GRing.subr_eq0.
+Qed.
+
+Lemma lagrange_poly_part_0 {R: fieldType} (x: R) l m r:
+  uniq (unzip1 (l ++ (m :: r))) ->
+  x \in unzip1 l ->
+  (\sum_(j <- subseqs_rec l m r) lagrange_poly_part j).[x] = 0.
+Proof.
+  elim: r l m => [|m' r IHr] l [x0 y0] Huniq Hin.
+  1: by rewrite big_seq1 hornerZ lagrange_basis_0 ?GRing.mulr0.
+  rewrite /= big_cons hornerD hornerZ.
+  rewrite lagrange_basis_0 ?IHr ?GRing.mulr0 ?GRing.add0r //.
+  1: by rewrite -catA cat_cons.
+  all: by rewrite /unzip1 map_cat -/unzip1 mem_cat Hin.
+Qed.
+
+Lemma uniq_unzip1_in {S T: eqType} (a: S * T) (s: seq (S * T)):
+  uniq (unzip1 (a :: s)) ->
+  a.1 \notin unzip1 s.
+Proof.
+  by rewrite /unzip1 map_cons cons_uniq -/unzip1 => /andP [].
+Qed.
+
+Lemma lagrange_poly_part_correct {R: fieldType} (x y: R) l m r:
+  uniq (unzip1 (l ++ (m :: r))) ->
+  (x, y) \in m :: r ->
+  (\sum_(j <- subseqs_rec l m r) lagrange_poly_part j).[x] = y.
+Proof.
+  elim: r l m => [|m' r IHr] l [x0 y0] Huniq Hin.
+  1: {
+    rewrite big_seq1 hornerZ.
+    rewrite mem_seq1 in Hin.
+    move /eqP in Hin.
+    case: Hin => -> ->.
+    rewrite /unzip1 map_cat uniq_catC -/unzip1 /= in Huniq.
+    move: Huniq => /andP [Hnotin Huniq].
+    rewrite lagrange_basis_1 in Hnotin.
+    move /eqP in Hnotin.
+    by rewrite Hnotin GRing.mulr1.
+  }
+  rewrite /= big_cons hornerD hornerZ.
+  rewrite in_cons in Hin.
+  move: Hin => /orP [/eqP Heq|Hin].
+  1: {
+    case: Heq => -> ->.
+    rewrite lagrange_poly_part_0 ?GRing.addr0 //.
+    2: by rewrite -catA cat_cons.
+    2: by rewrite /unzip1 map_cat mem_cat Bool.orb_comm mem_seq1 eq_refl.
+    rewrite /unzip1 map_cat uniq_catC -map_cat cat_cons -/unzip1 in Huniq.
+    apply (uniq_unzip1_in (x0, y0)) in Huniq.
+    rewrite /unzip1 map_cat mem_cat Bool.orb_comm -mem_cat -map_cat -/unzip1 in Huniq.
+    rewrite lagrange_basis_1 /= in Huniq.
+    move /eqP in Huniq.
+    by rewrite Huniq GRing.mulr1.
+  }
+  rewrite IHr //.
+  2: by rewrite -catA cat_cons.
+  rewrite lagrange_basis_0 ?GRing.mulr0 ?GRing.add0r //.
+  apply (map_f fst) in Hin.
+  by rewrite /unzip1 map_cat mem_cat Bool.orb_comm Hin.
+Qed.
+
+Lemma size_lagrange_poly_part {R: fieldType} l (m: R * R) r:
+  (size (\sum_(j <- subseqs_rec l m r) lagrange_poly_part j)%R <= size (l ++ m :: r))%N.
+Proof.
+  generalize dependent m.
+  generalize dependent l.
+  elim: r => /= [|m' r IHr] l m.
+  1: {
+    rewrite big_seq1 size_cat addn1.
+    apply: leq_trans.
+    1: by apply: size_scale_leq.
+    apply: leq_trans.
+    - by apply: size_lagrange_basis.
+    - by rewrite /unzip1 size_map ltnSn.
+  }
+  rewrite big_cons.
+  apply: leq_trans.
+  1: by apply: size_add.
+  rewrite geq_max.
+  apply /andP.
+  split.
+  - rewrite /lagrange_poly_part /=.
+    apply: leq_trans.
+    1: by apply: size_scale_leq.
+    replace (size (l ++ [:: m, m' & r])) with (size (unzip1 (l ++ [:: m' & r]))).+1.
+    1: by apply: size_lagrange_basis.
+    by rewrite /unzip1 size_map !size_cat -addnS.
+  - replace (size (l ++ [:: m, m' & r])) with (size ((l ++ [:: m]) ++ m' :: r)).
+    1: by apply: IHr.
+    by rewrite !size_cat addn1 !addnS.
+Qed.
+
+Lemma size_lagrange_poly {R: fieldType} (pts: seq (R * R)):
+  (size (lagrange_poly pts) <= size pts)%N.
+Proof.
+  case: pts => [|m r].
+  - by rewrite /lagrange_poly big_nil size_poly0.
+  - by apply: (size_lagrange_poly_part [::]).
+Qed.
+
+Lemma lagrange_poly_correct {R: fieldType} (x y: R) pts:
+  uniq (unzip1 (pts)) ->
+  (x, y) \in pts ->
+  (lagrange_poly pts).[x] = y.
+Proof.
+  case: pts => [// | m r] Huniq Hin.
+  by apply: lagrange_poly_part_correct.
+Qed.
+
+Lemma lagrange_poly_unique {R: fieldType} (pts: seq (R * R)) (q: {poly R}):
+  uniq (unzip1 pts) ->
+  (size q <= size pts)%N ->
+  (forall x y, (x, y) \in pts -> q.[x] = y) ->
+  q = lagrange_poly pts.
+Proof.
+  move=> Huniq Hsize1 Hpred.
+  assert (size (q - lagrange_poly pts)%R <= size pts)%N as Hsize.
+  1: {
+    move: (size_lagrange_poly pts) => Hsize2.
+    apply: leq_trans.
+    1: apply: size_add.
+    by rewrite geq_max size_opp Hsize1 Hsize2.
+  }
+  apply /eqP.
+  rewrite -GRing.subr_eq0 -size_poly_eq0.
+  rewrite size_poly_eq0.
+  apply /negPn /negP => Hcontra.
+  rewrite leqNgt in Hsize.
+  move /negP in Hsize.
+  apply: Hsize.
+  replace (size pts) with (size (unzip1 (pts))).
+  2: by rewrite size_map.
+  apply: max_poly_roots => //.
+  apply /allP => x' /mapP [[x y] Hin Heq].
+  subst.
+  rewrite /root hornerD hornerN.
+  rewrite (Hpred x y) //.
+  rewrite (lagrange_poly_correct x y) //.
+  by rewrite GRing.subr_eq0 eq_refl.
+Qed.
+
+(**
+  We also prove some useful properties for how Lagrange polynomials behave when
+  added or subtracted, specifically with regards to points with [y = 0], which
+  are defined by [zero_points].
+  Specifically:
+  - [lagrange_sub_zero_cons]: Subtracting Langrange polynomials with similar points.
+  - [lagrange_add_zero_cons]: Adding Langrange polynomials where all but one points have [y = 0].
+  - [lagrange_zero]: Evaluating Lagrange polynomials where all points have [y = 0].
+*)
+Definition zero_points {R: ringType} (s: seq R): seq (R * R) :=
+  [seq (x, 0) | x <- s ].
+
+Lemma unzip1_zero_points {R: ringType} (s: seq R):
+  unzip1 (zero_points s) = s.
+Proof.
+  rewrite /unzip1 /zero_points.
+  elim: s => [// | a s IHs].
+  by rewrite !map_cons IHs.
+Qed.
+
+Lemma x_in_zero_points {R: ringType} (x y: R) (s: seq R):
+  (x, y) \in zero_points s ->
+  x \in s.
+Proof.
+  rewrite /zero_points.
+  elim: s => [// | a s IHs] H.
+  rewrite in_cons.
+  rewrite map_cons in_cons xpair_eqE in H.
+  destruct (x == a) eqn:Heq => //=.
+  by apply: IHs.
+Qed.
+
+Lemma y_in_zero_points {R: ringType} {x y: R} {s: seq R}:
+  (x, y) \in zero_points s ->
+  y = 0.
+Proof.
+  rewrite /zero_points.
+  elim: s => [// | a s IHs] H.
+  rewrite map_cons in_cons in H.
+  destruct ((x, y) == (a, 0)) eqn:Heq.
+  - move /eqP in Heq.
+    by case: Heq.
+  - by apply: IHs.
+Qed.
+
+Lemma pt_in_zero_points {R: ringType} {x: R} {s: seq R}:
+  x \in s ->
+  (x, 0) \in zero_points s.
+Proof.
+  rewrite /zero_points.
+  elim: s => [// | a s IHs] H /=.
+  rewrite in_cons in H.
+  rewrite in_cons.
+  destruct (x == a) eqn:Heq.
+  - move /eqP in Heq.
+    by rewrite Heq eq_refl.
+  - by rewrite xpair_eqE Heq IHs.
+Qed.
+
+Lemma lagrange_sub_zero {R: fieldType} (x: R) (l1 l2 r: seq (R * R)):
+  uniq (unzip1 (l1 ++ r)) ->
+  uniq (unzip1 (l2 ++ r)) ->
+  x \in unzip1 r ->
+  (lagrange_poly (l1 ++ r) - lagrange_poly (l2 ++ r)).[x] = 0.
+Proof.
+  rewrite hornerD hornerN.
+  generalize dependent l2.
+  generalize dependent l1.
+  elim: r => [// | a r IHr] l1 l2 Huniq1 Huniq2 Hin.
+  rewrite /= in_cons in Hin.
+  destruct (x == a.1) eqn:Heq.
+  - move /eqP in Heq.
+    rewrite Heq (lagrange_poly_correct a.1 a.2) //.
+    1: rewrite (lagrange_poly_correct a.1 a.2) ?GRing.subrr //.
+    all: by rewrite -surjective_pairing mem_cat in_cons eq_refl Bool.orb_true_r.
+  - rewrite -!cat_rcons -!cats1 in Huniq1 Huniq2*.
+    by apply: IHr.
+Qed.
+
+Lemma lagrange_sub_zero_cons {R: fieldType} (x y1 y2: R) (pts: seq (R * R)):
+  uniq (x :: unzip1 pts) ->
+  lagrange_poly ((x, y1) :: pts) - lagrange_poly ((x, y2) :: pts) =
+  lagrange_poly ((x, y1 - y2) :: zero_points (unzip1 pts)).
+Proof.
+  move=> Huniq.
+  apply: lagrange_poly_unique.
+  - by rewrite /unzip1 map_cons -/unzip1 unzip1_zero_points.
+  - apply: leq_trans.
+    1: by apply: size_add.
+    rewrite size_opp /= !size_map geq_max.
+    apply /andP.
+    split.
+    all: apply: leq_trans.
+    1,3: by apply: size_lagrange_poly.
+    all: by [].
+  - move=> x0 y0 Hin.
+    rewrite in_cons in Hin.
+    destruct (_ == _) eqn:Heq.
+    + move /eqP in Heq.
+      case: Heq => ? ?.
+      subst.
+      rewrite hornerD hornerN (lagrange_poly_correct x y1) //.
+      1: rewrite (lagrange_poly_correct x y2) //.
+      all: by rewrite in_cons eq_refl.
+    + rewrite (y_in_zero_points Hin).
+      rewrite -!(cat1s _ pts).
+      apply: lagrange_sub_zero => //.
+      by apply: (x_in_zero_points x0 y0).
+Qed.
+
+Lemma lagrange_add_zero {R: fieldType} (x: R) (l1 l2: seq (R * R)) (r: seq R):
+  uniq (unzip1 (l1 ++ zero_points r)) ->
+  uniq (unzip1 (l2 ++ zero_points r)) ->
+  x \in r ->
+  (lagrange_poly (l1 ++ zero_points r) + lagrange_poly (l2 ++ zero_points r)).[x] = 0.
+Proof.
+  rewrite hornerD.
+  generalize dependent l2.
+  generalize dependent l1.
+  elim: r => [// | a r IHr] l1 l2 Huniq1 Huniq2 Hin.
+  rewrite /= in_cons in Hin.
+  destruct (x == a) eqn:Heq.
+  - move /eqP in Heq.
+    rewrite Heq (lagrange_poly_correct a 0) //.
+    1: rewrite (lagrange_poly_correct a 0) ?GRing.addr0 //.
+    all: by rewrite mem_cat in_cons eq_refl Bool.orb_true_r.
+  - rewrite -!cat_rcons -!cats1 in Huniq1 Huniq2*.
+    by apply: IHr.
+Qed.
+
+Lemma lagrange_add_zero_cons {R: fieldType} (x y1 y2: R) (s: seq R):
+  uniq (x :: s) ->
+  lagrange_poly ((x, y1) :: zero_points s) +
+  lagrange_poly ((x, y2) :: zero_points s) =
+  lagrange_poly ((x, y1 + y2) :: zero_points s).
+Proof.
+  move=> Huniq.
+  apply: lagrange_poly_unique.
+  - by rewrite /unzip1 map_cons -/unzip1 unzip1_zero_points.
+  - apply: leq_trans.
+    1: by apply: size_add.
+    rewrite /= !size_map geq_max.
+    apply /andP.
+    split.
+    all: apply: leq_trans.
+    1,3: by apply: size_lagrange_poly.
+    all: by rewrite /= size_map.
+  - move=> x0 y0 Hin.
+    rewrite in_cons in Hin.
+    destruct (_ == _) eqn:Heq.
+    + move /eqP in Heq.
+      case: Heq => ? ?.
+      subst.
+      rewrite hornerD (lagrange_poly_correct x y1) //.
+      1: rewrite (lagrange_poly_correct x y2) //.
+      2,4: by rewrite in_cons eq_refl.
+      all: by rewrite /unzip1 map_cons -/unzip1 unzip1_zero_points.
+    + rewrite (y_in_zero_points Hin).
+      rewrite -!(cat1s _ (zero_points s)).
+      apply: lagrange_add_zero.
+      3: by apply: (x_in_zero_points x0 y0).
+      all: by rewrite /unzip1 map_cons -/unzip1 unzip1_zero_points.
+Qed.
+
+Lemma lagrange_zero {R: fieldType} (s: seq R):
+  uniq s ->
+  lagrange_poly (zero_points s) = 0.
+Proof.
+  move=> Huniq.
+  symmetry.
+  apply: lagrange_poly_unique.
+  - by rewrite unzip1_zero_points.
+  - by rewrite polyseq0.
+  - move=> x y Hin.
+    rewrite hornerC.
+    by rewrite (y_in_zero_points Hin).
+Qed.
+
+(**
+  We also define some functions that lets us treat polynomials like lists ending
+  in infinite zeroes, and prove some useful lemmas that they do indeed behave
+  like lists.
+*)
+Definition head_poly {R: ringType} (q: {poly R}): R := q`_0.
+Definition tail_poly {R: ringType} (q: {poly R}): {poly R} := Poly (behead q).
+
+Lemma head_cons_poly {R: ringType} (a: R) (q: {poly R}):
+  head_poly (cons_poly a q) = a.
+Proof.
+  by rewrite /head_poly coef_cons.
+Qed.
+
+Lemma tail_cons_poly {R: ringType} (a: R) (q: {poly R}):
+  tail_poly (cons_poly a q) = q.
+Proof.
+  rewrite /tail_poly polyseq_cons.
+  destruct (nilp q) eqn:Heq => /=.
+  2: by rewrite polyseqK.
+  rewrite /nilp size_poly_eq0 in Heq.
+  move /eqP in Heq.
+  rewrite Heq polyseqC.
+  by destruct (a != 0).
+Qed.
+
+Lemma size_tail_poly {R: ringType} (q: {poly R}):
+  size (tail_poly q) = (size q).-1.
+Proof.
+  rewrite /tail_poly.
+  case: q => [[|a s] /= Hs].
+  - by rewrite polyseq0.
+  - by rewrite (PolyK Hs).
+Qed.
+
+Lemma last_neq_0 {R: ringType} (a: R) (s: seq R):
+  (last a s != 0 -> last 1 s != 0).
+Proof.
+  case: s => H //=.
+  by apply: GRing.oner_neq0.
+Qed.
+
+Lemma cons_head_tail_poly {R: ringType} (q: {poly R}):
+  cons_poly (head_poly q) (tail_poly q) = q.
+Proof.
+  apply: poly_inj.
+  rewrite /head_poly /tail_poly polyseq_cons.
+  case: q => [[|a s] /= Hs].
+  1: by rewrite polyseq0.
+  rewrite (PolyK Hs).
+  destruct s => //=.
+  by rewrite polyseqC Hs.
+Qed.
+
+Lemma cons_eq_head_tail_poly {R: ringType} (a: R) (q: {poly R}):
+  a = head_poly q ->
+  cons_poly a (tail_poly q) = q.
+Proof.
+  move=> H.
+  by rewrite H cons_head_tail_poly.
+Qed.
+
+(**
+  We also prove two polynomials are equal if, and only if, all their
+  coefficients are equal.
+  This is then used to prove how [tail_poly] and [cons_poly] behaves when added
+  and negated.
+*)
+Lemma coef_poly_eq {R: ringType} (q1 q2: {poly R}):
+  (forall i, q1`_i = q2`_i) <-> q1 = q2.
+Proof.
+  split=> H.
+  2: by rewrite H.
+  apply: poly_inj.
+  move: H.
+  case: q2.
+  case: q1.
+  elim=> [|a1 s1 IHs1] Hs1 [|a2 s2 ] //= Hs2 H.
+  - move /eqP in Hs2.
+    destruct Hs2.
+    specialize (H (size s2)).
+    rewrite nth_nil nth_last in H.
+    by rewrite H.
+  - move /eqP in Hs1.
+    destruct Hs1.
+    specialize (H (size s1)).
+    rewrite nth_nil nth_last in H.
+    by rewrite -H.
+  - move: (fun i => H i.+1) => HS.
+    specialize (H 0%N).
+    simpl in *.
+    rewrite H.
+    f_equal.
+    apply: IHs1 => //.
+    all: apply: last_neq_0.
+    + by apply: Hs1.
+    + by apply: Hs2.
+Qed.
+
+Lemma tail_poly_add {R: ringType} (q1 q2: {poly R}):
+  tail_poly (q1 + q2) = tail_poly q1 + tail_poly q2.
+Proof.
+  apply coef_poly_eq => i.
+  by rewrite coefD !coef_Poly !nth_behead coefD.
+Qed.
+
+Lemma tail_poly_opp {R: ringType} (q: {poly R}):
+  tail_poly (-q) = -tail_poly q.
+Proof.
+  apply coef_poly_eq => i.
+  by rewrite coefN !coef_Poly !nth_behead coefN.
+Qed.
+
+Lemma cons_poly_add {R: ringType} (m m': R) (q1 q2: {poly R}):
+  (cons_poly m' (q1 + q2) = (cons_poly m q1) + cons_poly (m'-m) q2)%R.
+Proof.
+  apply coef_poly_eq => i.
+  rewrite coefD !coef_cons coefD.
+  case: i => //=.
+  by rewrite GRing.addrC -GRing.addrA GRing.addNr GRing.addr0.
+Qed.
+
+Local Open Scope nat_scope.
+
+(**
+  With the work on polynomials out of the way we can start to actually define
+  the scheme.
+*)
+Section ShamirSecretSharing_example.
+
+(**
+  [p] is the number of possible messages. It is is a [prime]. *)
+Variable (p: nat).
+
+Context (p_prime: prime p).
+
+(**
+  We have to use [(Zp_trunc (pdiv p)).+2] for [Word] to be considered a field.
+  This is important for uniqueness of Lagrange polynomials.
+*)
+Definition Word_N := (Zp_trunc (pdiv p)).+2.
+Definition Word := 'fin Word_N.
+
+Lemma words_p_eq:
+  Word_N = p.
+Proof.
+  by apply: Fp_cast.
+Qed.
+
+(**
+  Shares are simply a point in ['F_p], i.e. a pair.
+*)
+Definition Share: choice_type := Word × Word.
+
+Notation " 'word " := (Word) (in custom pack_type at level 2).
+Notation " 'word " := (Word) (at level 2): package_scope.
+
+Notation " 'share " := (Share) (in custom pack_type at level 2).
+Notation " 'share " := (Share) (at level 2): package_scope.
+
+(**
+  We can't use sequences directly in [choice_type] so instead we use a map from
+  natural numbers to the type.
+*)
+Definition chSeq t := chMap 'nat t.
+
+Notation " 'seq t " := (chSeq t) (in custom pack_type at level 2).
+Notation " 'seq t " := (chSeq t) (at level 2): package_scope.
+
+(**
+  We can't use sets directly in [choice_type] so instead we use a map to units.
+  We can then use [domm] to get the domain, which is a set.
+*)
+Definition chSet t := chMap t 'unit.
+
+Notation " 'set t " := (chSet t) (in custom pack_type at level 2).
+Notation " 'set t " := (chSet t) (at level 2): package_scope.
+
+(**
+  [n] is the number of shares.
+  It is always positive.
+*)
+Variable (n: nat).
+Context (n_positive: Positive n).
+
+(**
+  We cannot possibly have more than [p-1] shares.
+*)
+Context (n_ltn_p: n < p).
+
+(**
+  Each party gets a share.
+  We use a finity type to represent parties as it makes later proofs easier.
+*)
+Definition Party := 'fin n.
+
+Notation " 'party " := (Party) (in custom pack_type at level 2).
+Notation " 'party " := (Party) (at level 2): package_scope.
+
+(**
+  The share of each party is the point with [x = 1 + the party index].
+*)
+#[program]
+Definition party_to_word (x: Party): Word := @Ordinal _ x.+1 _.
+Next Obligation.
+  case: x => [x Hx] /=.
+  rewrite words_p_eq.
+  apply: leq_trans.
+  2: by apply: n_ltn_p.
+  by rewrite ltnS.
+Qed.
+
+(**
+  Finally we can define how actual shares are computed.
+  They are simply points on a polynomial [q].
+*)
+Definition make_share (q: {poly Word}) (x: Party): Share :=
+  (party_to_word x, q.[party_to_word x]).
+
+(**
+  This is a convenience function for computing the shares for a message [m].
+  [q] is a randomly sampled polynomial.
+*)
+Definition make_shares (m: Word) (q: {poly Word}) (U: seq Party): seq Share :=
+  map (make_share (cons_poly m q)) U.
+
+(**
+  In order to prove security in SSProve we need to define a bijection
+  The bijection between polynomials works like this:
+  1. We compute the shares for the parties [U], message [m] and random
+     polynomial [q].
+  2. Then we compute two Lagrange polynomials, [g] and [g'], through those
+     shares and, respectively, (0, m) and (0, m').
+  3. We then compute the tail of [g' - g] and add it to [q] giving us [q'].
+
+  It is secure, because [make_shares m' q' U] will yield the same [sh].
+
+  It is a bijection, because we can compute [sh] from [q'], from which we can
+  compute [g] and [g'], from which [q = q' - tail_poly (g' - g)].
+
+  [sec_poly_bij] and [bij_poly_bij] simply formalise the above intuitions.
+*)
+Definition poly_bij (U: seq Party) (m m': Word) (q: {poly Word}): {poly Word} :=
+  let sh := make_shares m q U in
+  let g  := lagrange_poly ((0%R, m ) :: sh) in
+  let g' := lagrange_poly ((0%R, m') :: sh) in
+  let q' := (q + tail_poly (g' - g))%R in
+  q'.
+
+Lemma leq_pred_S (a b: nat):
+  (a.-1 <= b) = (a <= b.+1).
+Proof.
+  by case: a.
+Qed.
+
+Lemma size_poly_bij {t: nat} (U: seq Party) (m m': Word) (q: {poly Word}):
+  size U <= t ->
+  size q <= t ->
+  size (poly_bij U m m' q) <= t.
+Proof.
+  move=> Hu Hq.
+  apply: leq_trans.
+  1: by apply: size_add.
+  rewrite geq_max.
+  apply /andP.
+  split => //.
+  rewrite size_tail_poly leq_pred_S.
+  apply: leq_trans.
+  1: by apply: size_add.
+  rewrite geq_max.
+  apply /andP.
+  split.
+  2: rewrite size_opp.
+  all: apply: (leq_trans (size_lagrange_poly _)).
+  all: by rewrite /= size_map.
+Qed.
+
+Lemma no_zero_share (U: seq Party) (m: Word) (q: {poly Word}):
+  0%R \notin unzip1 (make_shares m q U).
+Proof.
+  by elim: U.
+Qed.
+
+Lemma in_make_shares (x: Party) (U: seq Party) (m: Word) (q: {poly Word}):
+  (party_to_word x \in unzip1 (make_shares m q U)) = (x \in U).
+Proof.
+  elim: U => [// | b U IHu] /=.
+  rewrite in_cons.
+  destruct (x == b) eqn:Heq.
+  - move /eqP in Heq.
+    by rewrite Heq in_cons !eq_refl.
+  - by rewrite in_cons -val_eqE eqSS val_eqE Heq.
+Qed.
+
+Lemma uniq_make_shares (U: seq Party) (m: Word) (q: {poly Word}):
+  uniq U ->
+  uniq (unzip1 (make_shares m q U)).
+Proof.
+  elim: U => [// | a U IHu] /=.
+  move=> /andP [H1 H2].
+  by rewrite IHu // in_make_shares H1.
+Qed.
+
+Lemma make_shares_same_x (m m': Word) (U: seq Party) (q: {poly Word}):
+  unzip1 (make_shares m' q U) = unzip1 (make_shares m q U).
+Proof.
+  elim: U => [// | a U IHu] /=.
+  by rewrite IHu.
+Qed.
+
+Lemma sec_poly_bij_part (x: Party) (U: seq Party) (m m': Word) (q: {poly Word}):
+  uniq U ->
+  x \in U ->
+  (cons_poly m' (poly_bij U m m' q)).[party_to_word x] =
+  (cons_poly m                   q ).[party_to_word x].
+Proof.
+  move=> Huniq Hin.
+  rewrite (cons_poly_add m).
+  rewrite lagrange_sub_zero_cons.
+  2: by rewrite /= no_zero_share uniq_make_shares.
+  rewrite hornerD cons_eq_head_tail_poly.
+  2: {
+    rewrite /head_poly -horner_coef0.
+    rewrite (lagrange_poly_correct 0 (m' - m)) //.
+    - by rewrite /unzip1 /= -/unzip1 unzip1_zero_points no_zero_share uniq_make_shares.
+    - by rewrite in_cons eq_refl.
+  }
+  rewrite (lagrange_poly_correct (party_to_word x) 0%R) ?GRing.addr0 //.
+  - by rewrite /unzip1 /= -/unzip1 unzip1_zero_points no_zero_share uniq_make_shares.
+  - by rewrite in_cons pt_in_zero_points ?Bool.orb_true_r // in_make_shares.
+Qed.
+
+Lemma sec_poly_bij_rec (l r: seq Party) (m m': Word) (q: {poly Word}):
+  uniq (l ++ r) ->
+  make_shares m' (poly_bij (l ++ r) m m' q) r =
+  make_shares m                          q  r.
+Proof.
+  elim: r => [// | a r IHr] in l*.
+  rewrite -cat_rcons -cats1 /= => H.
+  rewrite IHr //.
+  rewrite /make_share sec_poly_bij_part //.
+  by rewrite mem_cat cats1 mem_rcons in_cons eq_refl.
+Qed.
+
+Lemma sec_poly_bij (U: seq Party) (m m': Word) (q: {poly Word}):
+  uniq U ->
+  make_shares m' (poly_bij U m m' q) U =
+  make_shares m                   q  U.
+Proof.
+  move=> H.
+  by rewrite (sec_poly_bij_rec [::]).
+Qed.
+
+Lemma bij_poly_bij (U: seq Party) (m m': Word) (q: {poly Word}):
+  uniq U ->
+  poly_bij U m' m (poly_bij U m m' q) = q.
+Proof.
+  move=> Huniq.
+  rewrite {1}/poly_bij.
+  rewrite sec_poly_bij //.
+  rewrite /poly_bij.
+  rewrite !lagrange_sub_zero_cons.
+  2,3: by rewrite /= no_zero_share uniq_make_shares.
+  rewrite -GRing.addrA -tail_poly_add.
+  rewrite (make_shares_same_x m' m).
+  rewrite lagrange_add_zero_cons.
+  2: by rewrite /= no_zero_share uniq_make_shares.
+  rewrite -GRing.opprB GRing.addNr.
+  rewrite /zero_points -map_cons -/(zero_points _).
+  rewrite lagrange_zero.
+  2: by rewrite /= no_zero_share uniq_make_shares.
+  by rewrite /tail_poly polyseq0 GRing.addr0.
+Qed.
+
+Instance p_pow_positive t:
+  Positive (p^t).
+Proof.
+  by rewrite /Positive expn_gt0 prime_gt0.
+Qed.
+
+(**
+  [PolyEnc] is an isomorphism we use to be able to represent polynomials in SSProve.
+  SSProve does not support using polynomials directly.
+  There are [p^t] polynomials of size [<= t] over the field ['F_p].
+
+  We want to sample [q] uniformly, but this is not directly possible in SSProve.
+  Instead we sample from [PolyEnc t] which is isomorphic to polynomials of
+  size [<= t] over ['F_p].
+
+  We then define a bijection between polynomials and [PolyEnc t] and vice versa.
+  Finally we combine all three bijections to create a bijection from [PolyEnc t]
+  to [PolyEnc t] that we can use to prove security of the protocol.
+*)
+Definition PolyEnc t := 'fin (p^t).
+
+#[program] Definition mod_p (a: nat): Word :=
+  @Ordinal _ (a %% p) _.
+Next Obligation.
+  by rewrite words_p_eq ltn_mod prime_gt0.
+Qed.
+
+Lemma mod_p_muln_p (a: nat) (m: Word):
+  mod_p (a * p + m) = m.
+Proof.
+  apply: ord_inj => /=.
+  by rewrite modnMDl -words_p_eq modn_small.
+Qed.
+
+Fixpoint nat_to_poly (t a: nat): {poly Word} :=
+  match t with
+  | 0 => 0
+  | t'.+1 => cons_poly (mod_p a) (nat_to_poly t' (a %/ p))
+  end.
+
+Fixpoint poly_to_nat (t: nat) (q: {poly Word}): nat :=
+  match t with
+  | 0 => 0
+  | t'.+1 => poly_to_nat t' (tail_poly q) * p + head_poly q
+  end.
+
+Lemma size_nat_to_poly (t a: nat):
+  size (nat_to_poly t a) <= t.
+Proof.
+  elim: t => [|t IHt] /= in a*.
+  1: by rewrite size_poly0.
+  rewrite size_cons_poly.
+  destruct (_ && _) => //.
+  by rewrite ltnS.
+Qed.
+
+Lemma size_poly_to_nat (t: nat) (q: {poly Word}):
+  poly_to_nat t q < p^t.
+Proof.
+  elim: t => [// | t IHt] /= in q*.
+  apply: (@leq_trans (poly_to_nat t (tail_poly q) * p + p)).
+  2: by rewrite expnSr -mulSnr leq_pmul2r // prime_gt0.
+  case: (head_poly q) => a Ha /=.
+  by rewrite ltn_add2l -words_p_eq.
+Qed.
+
+Lemma nat_poly_nat (t a: nat):
+  a < p^t ->
+  poly_to_nat t (nat_to_poly t a) = a.
+Proof.
+  elim: t a => [|t IHt] a H.
+  1: by destruct a.
+  rewrite expnS mulnC in H.
+  rewrite /= head_cons_poly tail_cons_poly IHt -?divn_eq //.
+  by rewrite ltn_divLR // prime_gt0.
+Qed.
+
+Lemma poly_nat_poly (t: nat) (q: {poly Word}):
+  size q <= t ->
+  nat_to_poly t (poly_to_nat t q) = q.
+Proof.
+  elim: t q => [|t IHt] q H.
+  1: {
+    rewrite size_poly_leq0 in H.
+    move /eqP in H.
+    by subst.
+  }
+  rewrite /= mod_p_muln_p.
+  rewrite divnMDl ?prime_gt0 // divn_small.
+  2: {
+    destruct (head_poly q) as [c Hc] => /=.
+    by rewrite -words_p_eq.
+  }
+  rewrite addn0 IHt ?cons_head_tail_poly //.
+  rewrite size_tail_poly.
+  by destruct (size q).
+Qed.
+
+(**
+  [t] is the number of shares needed for reconstruction.
+  [t'] is the maximum number of shares the scheme is secure against. This
+  happens to often be the number we actually care about so we will frequently
+  use it directly.
+*)
+Variable (t': nat).
+Definition t := t'.+1.
+
+(**
+  This is the final bijection used to
+*)
+#[program]
+Definition share_bij (U: seq Party) (m m': Word) (c: PolyEnc t'): PolyEnc t' :=
+  @Ordinal _ (poly_to_nat t' (poly_bij U m m' (nat_to_poly t' c))) _.
+Next Obligation.
+  by apply: size_poly_to_nat.
+Qed.
+
+Lemma sec_share_bij (U: seq Party) (m m': Word) (c: PolyEnc t'):
+  uniq U ->
+  (size U <= t')%N ->
+  make_shares m' (nat_to_poly t' (share_bij U m m' c)) U =
+  make_shares m  (nat_to_poly t'  c                  ) U.
+Proof.
+  move=> Huniq Hltn.
+  rewrite /share_bij /= poly_nat_poly ?size_poly_bij ?size_nat_to_poly //.
+  by apply: sec_poly_bij.
+Qed.
+
+Lemma bij_share_bij (U: seq Party) (m m': Word):
+  uniq U ->
+  (size U <= t')%N ->
+  bijective (share_bij U m m').
+Proof.
+  move=> Huniq Hleq.
+  exists (share_bij U m' m) => q.
+  all: apply: ord_inj.
+  all: rewrite /= poly_nat_poly ?size_poly_bij ?size_nat_to_poly //.
+  all: by rewrite bij_poly_bij ?nat_poly_nat.
+Qed.
+
+Local Open Scope package_scope.
+
+Definition shares: nat := 0.
+
+Definition mkpair {Lt Lf E}
+  (t: package Lt [interface] E) (f: package Lf [interface] E):
+  loc_GamePair E := fun b => if b then {locpackage t} else {locpackage f}.
+
+(**
+  Finally, we can define the packages and prove security of the protocol.
+  This part is fairly easy now that we have a bijection.
+*)
+Definition SHARE_pkg_tt:
+  package fset0 [interface]
+    [interface #val #[shares]: ('word × 'word) × 'set 'party → 'seq 'share ] :=
+  [package
+    #def #[shares] ('(ml, mr, U): ('word × 'word) × 'set 'party): 'seq 'share {
+      if size (domm U) >= t then ret emptym
+      else
+      q <$ uniform (p^t') ;;
+      let q := nat_to_poly t' q in
+      let sh := make_shares ml q (domm U) in
+      ret (fmap_of_seq sh)
+    }
+  ].
+
+Definition SHARE_pkg_ff:
+  package fset0 [interface]
+    [interface #val #[shares]: ('word × 'word) × 'set 'party → 'seq 'share ] :=
+  [package
+    #def #[shares] ('(ml, mr, U): ('word × 'word) × 'set 'party): 'seq 'share {
+      if size (domm U) >= t then ret emptym
+      else
+      q <$ uniform (p^t') ;;
+      let q := nat_to_poly t' q in
+      let sh := make_shares mr q (domm U) in
+      ret (fmap_of_seq sh)
+    }
+  ].
+
+Definition SHARE := mkpair SHARE_pkg_tt SHARE_pkg_ff.
+
+Lemma SHARE_equiv:
+  SHARE true ≈₀ SHARE false.
+Proof.
+  apply: eq_rel_perf_ind_eq.
+  simplify_eq_rel m.
+  apply rpost_weaken_rule with eq;
+    last by move=> [? ?] [? ?] [].
+  case: m => [[ml mr] U].
+  destruct (t <= size _) eqn:Heq.
+  1: by apply: rreflexivity_rule.
+  apply negbT in Heq.
+  rewrite -ltnNge ltnS in Heq.
+  apply: r_uniform_bij => [|q].
+  1: {
+    apply: (bij_share_bij (domm U) ml mr) => //.
+    by apply: uniq_fset.
+  }
+  rewrite sec_share_bij ?uniq_fset //.
+  by apply: rreflexivity_rule.
+Qed.
+
+(**
+  This corresponds to Theorem 3.13 from "The Joy of Cryptography".
+*)
+Theorem unconditional_secrecy LA A:
+  ValidPackage LA
+    [interface #val #[shares]: ('word × 'word) × 'set 'party → 'seq 'share ]
+    A_export A ->
+  Advantage SHARE A = 0%R.
+Proof.
+  move=> vA.
+  rewrite Advantage_E Advantage_sym.
+  by rewrite SHARE_equiv ?fdisjoints0.
+Qed.
+
+End ShamirSecretSharing_example.

--- a/theories/Crypt/examples/StretchPRG.v
+++ b/theories/Crypt/examples/StretchPRG.v
@@ -1,0 +1,199 @@
+(**
+  Really simply proof of Claim 5.5 from "The Joy of Cryptography" (p. 94).
+
+  It is simple and easy to follow.
+*)
+
+From Relational Require Import OrderEnrichedCategory GenericRulesSimple.
+
+Set Warnings "-notation-overridden,-ambiguous-paths".
+From mathcomp Require Import all_ssreflect all_algebra reals distr realsum
+  ssrnat ssreflect ssrfun ssrbool ssrnum eqtype choice seq.
+Set Warnings "notation-overridden,ambiguous-paths".
+
+From Mon Require Import SPropBase.
+From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
+  UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb
+  pkg_core_definition choice_type pkg_composition pkg_rhl Package Prelude.
+
+From extructures Require Import ord fset fmap.
+
+Import SPropNotations.
+
+Import PackageNotation.
+
+From Equations Require Import Equations.
+Require Equations.Prop.DepElim.
+
+Set Equations With UIP.
+
+Set Bullet Behavior "Strict Subproofs".
+Set Default Goal Selector "!".
+Set Primitive Projections.
+
+Import Num.Def.
+Import Num.Theory.
+Import Order.POrderTheory.
+
+Section StretchPRG_example.
+
+Definition tt := Datatypes.tt.
+
+Variable (n: nat).
+
+Definition Word_N: nat := 2^n.
+Definition Word: choice_type := 'fin Word_N.
+
+Notation " 'word " := (Word) (in custom pack_type at level 2).
+Notation " 'word " := (Word) (at level 2): package_scope.
+
+Context (PRG: Word -> Word * Word).
+
+Definition query: nat := 0.
+
+Definition mkpair {Lt Lf E}
+  (t: package Lt [interface] E) (f: package Lf [interface] E):
+  loc_GamePair E := fun b => if b then {locpackage t} else {locpackage f}.
+
+Definition GEN_pkg_tt:
+  package fset0 [interface]
+    [interface #val #[query]: 'unit → 'word × 'word ] :=
+  [package
+    #def #[query] (_: 'unit): 'word × 'word {
+      s <$ uniform Word_N ;;
+      ret (PRG s)
+    }
+  ].
+
+Definition GEN_pkg_ff:
+  package fset0 [interface]
+    [interface #val #[query]: 'unit → 'word × 'word ] :=
+  [package
+    #def #[query] (_: 'unit): 'word × 'word {
+      x <$ uniform Word_N ;;
+      y <$ uniform Word_N ;;
+      ret (x, y)
+    }
+  ].
+
+Definition GEN := mkpair GEN_pkg_tt GEN_pkg_ff.
+
+Definition GEN_STRETCH_pkg_tt:
+  package fset0 [interface]
+    [interface #val #[query]: 'unit → 'word × 'word × 'word ] :=
+  [package
+    #def #[query] (_: 'unit): 'word × 'word × 'word {
+      s <$ uniform Word_N ;;
+      let (x, y) := PRG s in
+      ret (x, PRG y)
+    }
+  ].
+
+Definition GEN_STRETCH_pkg_ff:
+  package fset0 [interface]
+    [interface #val #[query]: 'unit → 'word × 'word × 'word ] :=
+  [package
+    #def #[query] (_: 'unit): 'word × 'word × 'word {
+      x <$ uniform Word_N ;;
+      u <$ uniform Word_N ;;
+      v <$ uniform Word_N ;;
+      ret (x, (u, v))
+    }
+  ].
+
+Definition GEN_STRETCH := mkpair GEN_STRETCH_pkg_tt GEN_STRETCH_pkg_ff.
+
+Definition GEN_STRETCH_HYB_pkg_1:
+  package fset0
+    [interface #val #[query]: 'unit → 'word × 'word ]
+    [interface #val #[query]: 'unit → 'word × 'word × 'word ] :=
+  [package
+    #def #[query] (_: 'unit): 'word × 'word × 'word {
+      #import {sig #[query]: 'unit → 'word × 'word } as query ;;
+      '(x, y) ← query tt ;;
+      ret (x, PRG y)
+    }
+  ].
+
+Definition GEN_STRETCH_HYB_pkg_2:
+  package fset0
+    [interface #val #[query]: 'unit → 'word × 'word ]
+    [interface #val #[query]: 'unit → 'word × 'word × 'word ] :=
+  [package
+    #def #[query] (_: 'unit): 'word × 'word × 'word {
+      #import {sig #[query]: 'unit → 'word × 'word } as query ;;
+      x <$ uniform Word_N ;;
+      uv ← query tt ;;
+      ret (x, uv)
+    }
+  ].
+
+Lemma GEN_equiv_true:
+  GEN_STRETCH true ≈₀ GEN_STRETCH_HYB_pkg_1 ∘ GEN true.
+Proof.
+  apply: eq_rel_perf_ind_eq.
+  simplify_eq_rel m.
+  apply rpost_weaken_rule with eq;
+    last by move=> [? ?] [? ?] [].
+  simplify_linking.
+  ssprove_code_simpl.
+  by apply: rreflexivity_rule.
+Qed.
+
+Lemma GEN_HYB_equiv:
+  GEN_STRETCH_HYB_pkg_1 ∘ GEN false ≈₀ GEN_STRETCH_HYB_pkg_2 ∘ GEN true.
+Proof.
+  apply: eq_rel_perf_ind_eq.
+  simplify_eq_rel m.
+  apply rpost_weaken_rule with eq;
+    last by move=> [? ?] [? ?] [].
+  simplify_linking.
+  by apply: rreflexivity_rule.
+Qed.
+
+Lemma GEN_equiv_false:
+  GEN_STRETCH_HYB_pkg_2 ∘ GEN false ≈₀ GEN_STRETCH false.
+Proof.
+  apply: eq_rel_perf_ind_eq.
+  simplify_eq_rel m.
+  apply rpost_weaken_rule with eq;
+    last by move=> [? ?] [? ?] [].
+  simplify_linking.
+  by apply: rreflexivity_rule.
+Qed.
+
+Local Open Scope ring_scope.
+
+(**
+  The advantage an adversary can gain over the PRG, i.e. the chance by
+  which an adversary can distinguish the PRG from truly random numbers.
+  Negligible by assumption.
+*)
+Definition prg_epsilon := Advantage GEN.
+
+Theorem security_based_on_prg LA A:
+  ValidPackage LA
+    [interface #val #[query]: 'unit → 'word × 'word × 'word ]
+    A_export A ->
+  Advantage GEN_STRETCH A <=
+  prg_epsilon (A ∘ GEN_STRETCH_HYB_pkg_1) +
+  prg_epsilon (A ∘ GEN_STRETCH_HYB_pkg_2).
+Proof.
+  move=> vA.
+  rewrite Advantage_E Advantage_sym.
+  ssprove triangle (GEN_STRETCH true) [::
+    GEN_STRETCH_HYB_pkg_1 ∘ GEN true ;
+    GEN_STRETCH_HYB_pkg_1 ∘ GEN false ;
+    GEN_STRETCH_HYB_pkg_2 ∘ GEN true ;
+    GEN_STRETCH_HYB_pkg_2 ∘ GEN false
+  ] (GEN_STRETCH false) A
+  as ineq.
+  apply: le_trans.
+  1: by apply: ineq.
+  rewrite GEN_equiv_true ?fdisjointUr ?fdisjoints0 // GRing.add0r.
+  rewrite GEN_HYB_equiv ?fdisjointUr ?fdisjoints0 // GRing.addr0.
+  rewrite GEN_equiv_false ?fdisjointUr ?fdisjoints0 // GRing.addr0.
+  by rewrite /prg_epsilon !Advantage_E -!Advantage_link !(Advantage_sym (GEN true)).
+Qed.
+
+End StretchPRG_example.

--- a/theories/Crypt/examples/SymmRatchet.v
+++ b/theories/Crypt/examples/SymmRatchet.v
@@ -1,0 +1,480 @@
+(**
+  This formalises Claim 5.10 from "The Joy of Cryptography" (p. 111).
+  It shows how to work with loops.
+
+  The one part we cannot prove is the
+*)
+
+From Relational Require Import OrderEnrichedCategory GenericRulesSimple.
+
+Set Warnings "-notation-overridden,-ambiguous-paths".
+From mathcomp Require Import all_ssreflect all_algebra reals distr realsum
+  ssrnat ssreflect ssrfun ssrbool ssrnum eqtype choice seq.
+Set Warnings "notation-overridden,ambiguous-paths".
+
+From Mon Require Import SPropBase.
+From Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
+  UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb
+  pkg_core_definition choice_type pkg_composition pkg_rhl Package Prelude.
+
+From extructures Require Import ord fset fmap.
+
+Import SPropNotations.
+
+Import PackageNotation.
+
+From Equations Require Import Equations.
+Require Equations.Prop.DepElim.
+
+Set Equations With UIP.
+
+Set Bullet Behavior "Strict Subproofs".
+Set Default Goal Selector "!".
+Set Primitive Projections.
+
+Import Num.Def.
+Import Num.Theory.
+Import Order.POrderTheory.
+
+Section SymmRatchet_example.
+
+(**
+  We can't use sequences directly in [choice_type] so instead we use a map from
+  natural numbers to the type.
+*)
+Definition chSeq t := chMap 'nat t.
+
+Notation " 'seq t " := (chSeq t) (in custom pack_type at level 2).
+Notation " 'seq t " := (chSeq t) (at level 2): package_scope.
+
+(**
+  This function is equivalent to [fmap_of_seq], but its definition is simpler,
+  which makes it possible to prove that [unzip2] cancels it.
+  This is useful since each iteration of a loop has to convert between the
+  actual [seq] and the [chSeq] we can actually use in SSProve.
+*)
+Definition seq_to_chseq {T} (s: seq T) :=
+  mkfmap (zip (iota 0 (size s)) s).
+
+Lemma unzip2_seq_to_chseq {T} (s: seq T):
+  unzip2 (seq_to_chseq s) = s.
+Proof.
+  rewrite mkfmapK ?unzip2_zip ?unzip1_zip ?size_iota //.
+  rewrite (@eq_sorted _ _ ltn).
+  1: by apply: iota_ltn_sorted.
+  move=> a b.
+  by rewrite /Ord.lt /= ltn_neqAle Bool.andb_comm.
+Qed.
+
+Definition tt: 'unit := Datatypes.tt.
+
+Variable (n: nat).
+
+Definition Word_N: nat := 2^n.
+Definition Word: choice_type := 'fin Word_N.
+
+Notation " 'word " := (Word) (in custom pack_type at level 2).
+Notation " 'word " := (Word) (at level 2): package_scope.
+
+Context (PRG: Word -> Word * Word).
+Context (enc: Word -> Word -> Word).
+
+Definition ctxt: nat := 0.
+Definition query: nat := 1.
+Definition attack: nat := 2.
+
+Definition mkpair {Lt Lf E}
+  (t: package Lt [interface] E) (f: package Lf [interface] E):
+  loc_GamePair E := fun b => if b then {locpackage t} else {locpackage f}.
+
+(**
+  A [map_loop] is like the [map] function, but it can be used directly as [code]
+  in SSProve. This makes it possible to use features from SSProve inside it,
+  like sampling random values, calling an [#import]ed function, and even reading
+  or writing memory.
+
+  Alternatively, one can think of it as a for-loop that writes to the [i]th
+  location of an array on index [i].
+
+  It takes a sequence [s] to loop over, a state [a] and a function which returns
+  a mapped value, and a new [a] to be used in the next iteration of the loop.
+
+  It returns a pair of the mapped sequence as a [chSeq] (since SSProve cannot
+  work directly with [seq]), and the final state [a].
+*)
+Fixpoint map_loop {T} {U A: choice_type} (s: seq T) (a: A) (c: T -> A -> raw_code (U × A)):
+  raw_code (('seq U) × A) :=
+  match s with
+  | [::]    => ret (emptym, a)
+  | t :: s' =>
+    ua1 ← c t a ;;
+    ua2 ← map_loop s' ua1.2 c ;;
+    ret (seq_to_chseq (ua1.1 :: unzip2 ua2.1), ua2.2)
+  end.
+
+(**
+  This is a proof that a loop is valid code, as long as the loop body is valid
+  for all input values.
+*)
+Lemma map_loop_valid {T} {U A: choice_type} {L I} (s: seq T) (a: A) (c: T -> A -> raw_code (U × A)):
+  (forall t a', ValidCode L I (c t a')) ->
+  ValidCode L I (map_loop s a c).
+Proof.
+  move=> H.
+  elim: s => [|t s IHs] /= in a*.
+  - by apply: valid_ret.
+  - apply: valid_bind => ua1 /=.
+    apply: valid_bind => ua2.
+    by apply: valid_ret.
+Qed.
+
+(**
+  We add the validity proof to the [ssprove_valid_db] database, which lets
+  SSProve pick up on it automatically.
+*)
+Hint Extern 1 (ValidCode ?L ?I (map_loop ?s ?a ?c)) =>
+  eapply map_loop_valid ;
+  intro
+  : typeclass_instances ssprove_valid_db.
+
+(**
+  The next proof tells SSProve how to link code with a [map_loop]. Specifically,
+  it should link any functions called inside the loop body.
+*)
+Lemma code_link_map_loop {T} {U A: choice_type} (s: seq T) (a: A) (c: T -> A -> raw_code (U × A)) p:
+  code_link (map_loop s a c) p = map_loop s a (fun t a => code_link (c t a) p).
+Proof.
+  elim: s => [// | t s IHs] /= in a*.
+  rewrite code_link_bind.
+  f_equal.
+  apply: boolp.funext => ua1 /=.
+  by rewrite code_link_bind IHs.
+Qed.
+
+(**
+  We also add this to a database to help the [ssprove_code_simpl] tactic
+  automatically simplify loops.
+*)
+Hint Extern 50 (_ = code_link (map_loop _ _ _) _) =>
+  rewrite code_link_map_loop
+  : ssprove_code_simpl.
+
+Definition CTXT_pkg_tt:
+  package fset0
+    [interface]
+    [interface #val #[ctxt]: 'word → 'word ] :=
+  [package
+    #def #[ctxt] (m: 'word): 'word {
+      k <$ uniform Word_N ;;
+      ret (enc k m)
+    }
+  ].
+
+Definition CTXT_pkg_ff:
+  package fset0
+    [interface]
+    [interface #val #[ctxt]: 'word → 'word ] :=
+  [package
+    #def #[ctxt] (m: 'word): 'word {
+      c <$ uniform Word_N ;;
+      ret c
+    }
+  ].
+
+Definition CTXT := mkpair CTXT_pkg_tt CTXT_pkg_ff.
+
+(**
+  We only define security of the stretched PRG. It is not currently possible to
+  prove this is secure from a simple PRG definition, because the number of
+  iterations depends on the input.
+
+  StretchPRG.v contains a proof of a single iteration, and a technique similar
+  to the one in [PRFPRG.v] could be used to prove a fixed number of iterations,
+  but not a variable number. So, while we can argue informally that they are
+  indistinguishable, we cannot (yet) prove it inside SSProve, so instead we
+  leave it as an assumption.
+*)
+Definition GEN_STRETCH_pkg_tt:
+  package fset0 [interface]
+    [interface #val #[query]: 'nat → ('seq 'word) × 'word ] :=
+  [package
+    #def #[query] (k: 'nat): ('seq 'word) × 'word {
+      s0 <$ uniform Word_N ;;
+      @map_loop _ 'word _ (iota 0 k) s0 (fun _ si =>
+        ret (PRG si)
+      )
+    }
+  ].
+
+Definition GEN_STRETCH_pkg_ff:
+  package fset0 [interface]
+    [interface #val #[query]: 'nat → ('seq 'word) × 'word ] :=
+  [package
+    #def #[query] (k: 'nat): ('seq 'word) × 'word {
+      t ← @map_loop _ 'word _ (iota 0 k) tt (fun _ _ =>
+        ti <$ uniform Word_N ;;
+        ret (ti, tt)
+      ) ;;
+      sn <$ uniform Word_N ;;
+      ret (t.1, sn)
+    }
+  ].
+
+Definition GEN_STRETCH := mkpair GEN_STRETCH_pkg_tt GEN_STRETCH_pkg_ff.
+
+(**
+  The rest of the games are similar to the ones in the book.
+*)
+Definition ATTACK_pkg_tt:
+  package fset0 [interface]
+    [interface #val #[attack]: 'seq 'word → ('seq 'word) × 'word ] :=
+  [package
+    #def #[attack] (m: 'seq 'word): ('seq 'word) × 'word {
+      s0 <$ uniform Word_N ;;
+      @map_loop _ 'word _ (unzip2 m) s0 (fun mi si =>
+        let xy := PRG si in
+        ret (enc xy.1 mi, xy.2)
+      )
+    }
+  ].
+
+Definition ATTACK_pkg_ff:
+  package fset0 [interface]
+    [interface #val #[attack]: 'seq 'word → ('seq 'word) × 'word ] :=
+  [package
+    #def #[attack] (m: 'seq 'word): ('seq 'word) × 'word {
+      c ← @map_loop _ 'word _ (unzip2 m) tt (fun _ _ =>
+        ci <$ uniform Word_N ;;
+        ret (ci, tt)
+      ) ;;
+      sn <$ uniform Word_N ;;
+      ret (c.1, sn)
+    }
+  ].
+
+Definition ATTACK := mkpair ATTACK_pkg_tt ATTACK_pkg_ff.
+
+Definition ATTACK_GEN_pkg:
+  package fset0
+    [interface #val #[query]: 'nat → ('seq 'word) × 'word ]
+    [interface #val #[attack]: 'seq 'word → ('seq 'word) × 'word ] :=
+  [package
+    #def #[attack] (m: 'seq 'word): ('seq 'word) × 'word {
+      #import {sig #[query]: 'nat → ('seq 'word) × 'word } as query ;;
+      ts ← query (size m) ;;
+      c ← @map_loop _ 'word _ (zip (unzip2 ts.1) (unzip2 m)) tt (fun tm _ =>
+        let (ti, mi) := (tm.1, tm.2) in
+        ret (enc ti mi, tt)
+      ) ;;
+      ret (c.1, ts.2)
+    }
+  ].
+
+Definition ATTACK_HYB_pkg:
+  package fset0 [interface]
+    [interface #val #[attack]: 'seq 'word → ('seq 'word) × 'word ] :=
+  [package
+    #def #[attack] (m: 'seq 'word): ('seq 'word) × 'word {
+      c ← @map_loop _ 'word _ (unzip2 m) tt (fun mi _ =>
+        ti <$ uniform Word_N ;;
+        ret (enc ti mi, tt)
+      ) ;;
+      sn <$ uniform Word_N ;;
+      ret (c.1, sn)
+    }
+  ].
+
+Definition ATTACK_CTXT_pkg:
+  package fset0
+  [interface #val #[ctxt]: 'word → 'word ]
+    [interface #val #[attack]: 'seq 'word → ('seq 'word) × 'word ] :=
+  [package
+    #def #[attack] (m: 'seq 'word): ('seq 'word) × 'word {
+      #import {sig #[ctxt]: 'word → 'word } as ctxt ;;
+      c ← @map_loop _ 'word _ (unzip2 m) tt (fun mi _ =>
+        ci ← ctxt mi ;;
+        ret (ci, tt)
+      ) ;;
+      sn <$ uniform Word_N ;;
+      ret (c.1, sn)
+    }
+  ].
+
+Lemma ATTACK_equiv_true:
+  ATTACK true ≈₀ ATTACK_GEN_pkg ∘ GEN_STRETCH true.
+Proof.
+  apply: eq_rel_perf_ind_eq.
+  simplify_eq_rel m.
+  apply rpost_weaken_rule with eq;
+    last by move=> [? ?] [? ?] [].
+  simplify_linking.
+  ssprove_code_simpl.
+  ssprove_sync_eq=> s0.
+  erewrite bind_cong.
+  2: by [].
+  2: {
+    apply: boolp.funext => x.
+    erewrite (@code_link_map_loop _ 'word _ (zip _ _) tt) => /=.
+    erewrite bind_cong.
+    1,2: by [].
+    apply: boolp.funext => y.
+    by rewrite {1}(lock (y.1)).
+  }
+  rewrite -(bind_ret _ (map_loop (unzip2 m) s0 _)).
+  erewrite bind_cong.
+  2: by [].
+  2: {
+    apply: boolp.funext => x.
+    rewrite {1}(surjective_pairing x).
+    by rewrite {1}(lock x.1).
+  }
+  move: (@locked _) => /= X.
+  ssprove_code_simpl.
+  rewrite -(size_map snd) -/unzip2.
+  move: 0 (unzip2 m) => {m} a m.
+  elim: m => [|mi m IHm] /= in X a s0*.
+  1: by apply: rreflexivity_rule.
+  rewrite (lock seq_to_chseq).
+  ssprove_code_simpl.
+  case: (PRG s0) => [ti si] /=.
+  rewrite -lock.
+  erewrite (bind_cong _ _ (@map_loop _ 'word _ (iota a.+1 (size m)) si _)).
+  2: by [].
+  2: {
+    apply: boolp.funext => x.
+    by rewrite unzip2_seq_to_chseq.
+  }
+  ssprove_code_simpl.
+  by specialize (IHm (fun x => X (seq_to_chseq (enc ti mi :: unzip2 x)))).
+Qed.
+
+Lemma ATTACK_HYB_equiv_1:
+  ATTACK_GEN_pkg ∘ GEN_STRETCH false ≈₀ ATTACK_HYB_pkg.
+Proof.
+  apply: eq_rel_perf_ind_eq.
+  simplify_eq_rel m.
+  apply rpost_weaken_rule with eq;
+    last by move=> [? ?] [? ?] [].
+  simplify_linking.
+  rewrite cast_fun_K.
+  ssprove_code_simpl.
+  ssprove_swap_lhs 0.
+  ssprove_swap_rhs 0.
+  ssprove_sync_eq=> sn.
+  erewrite bind_cong.
+  2: by [].
+  2: {
+    apply: boolp.funext => x.
+    erewrite (@code_link_map_loop _ 'word _ (zip _ _) tt) => /=.
+    erewrite bind_cong.
+    1,2: by [].
+    apply: boolp.funext => y.
+    by rewrite {1}(lock (y.1)).
+  }
+  erewrite (bind_cong _ _ (map_loop (unzip2 m) tt _)).
+  2: by [].
+  2: {
+    apply: boolp.funext => x.
+    rewrite {1}(surjective_pairing x).
+    by rewrite {1}(lock x.1).
+  }
+  rewrite -(size_map snd) -/unzip2.
+  move: 0 (unzip2 m) (@locked _) => {m} a m X.
+  elim: m => [|mi m IHm] /= in X a*.
+  1: by apply: rreflexivity_rule.
+  rewrite (lock seq_to_chseq).
+  ssprove_code_simpl.
+  ssprove_sync_eq=> ci.
+  rewrite -lock.
+  erewrite (bind_cong _ _ (@map_loop _ 'word _ (iota a.+1 (size m)) tt _)).
+  2: by [].
+  2: {
+    apply: boolp.funext => x.
+    rewrite unzip2_seq_to_chseq.
+    by [].
+  }
+  ssprove_code_simpl.
+  specialize (IHm (fun s => X (seq_to_chseq (enc ci mi :: unzip2 s)))).
+  by simpl in IHm.
+Qed.
+
+Lemma ATTACK_HYB_equiv_2:
+  ATTACK_HYB_pkg ≈₀ ATTACK_CTXT_pkg ∘ CTXT true.
+Proof.
+  apply: eq_rel_perf_ind_eq.
+  simplify_eq_rel m.
+  apply rpost_weaken_rule with eq;
+    last by move=> [? ?] [? ?] [].
+  simplify_linking.
+  ssprove_code_simpl.
+  ssprove_swap_lhs 0.
+  ssprove_swap_rhs 0.
+  ssprove_sync_eq=> sn.
+  rewrite (@code_link_map_loop _ 'word _ (unzip2 m) tt _) /=.
+  simplify_linking.
+  by apply: rreflexivity_rule.
+Qed.
+
+Lemma ATTACK_equiv_false:
+  ATTACK_CTXT_pkg ∘ CTXT false ≈₀ ATTACK false.
+Proof.
+  apply: eq_rel_perf_ind_eq.
+  simplify_eq_rel m.
+  apply rpost_weaken_rule with eq;
+    last by move=> [? ?] [? ?] [].
+  simplify_linking.
+  ssprove_code_simpl.
+  ssprove_swap_lhs 0.
+  ssprove_swap_rhs 0.
+  ssprove_sync_eq=> sn.
+  rewrite (@code_link_map_loop _ 'word _ (unzip2 m) tt _) /=.
+  simplify_linking.
+  by apply: rreflexivity_rule.
+Qed.
+
+Local Open Scope ring_scope.
+
+(**
+  The advantage an adversary can gain over the stretched PRG, i.e. the chance by
+  which an adversary can distinguish the PRG from truly random numbers.
+  Negligible by assumption.
+*)
+Definition prg_epsilon := Advantage GEN_STRETCH.
+
+(**
+  The advantage an adversary can gain over the CPA-secure encryption, i.e. the
+  chance by which an adversary can distinguish a ciphertext of a known message
+  from a random ciphertext.
+  Negligible by assumption.
+*)
+Definition cpa_epsilon := Advantage CTXT.
+
+Lemma forward_secrecy_based_on_prg LA A:
+  ValidPackage LA
+    [interface #val #[attack]: 'seq 'word → ('seq 'word) × 'word ]
+    A_export A ->
+  Advantage ATTACK A <=
+  prg_epsilon (A ∘ ATTACK_GEN_pkg) +
+  cpa_epsilon (A ∘ ATTACK_CTXT_pkg).
+Proof.
+  move=> vA.
+  rewrite Advantage_E Advantage_sym.
+  ssprove triangle (ATTACK true) [::
+    ATTACK_GEN_pkg ∘ GEN_STRETCH true ;
+    ATTACK_GEN_pkg ∘ GEN_STRETCH false ;
+    pack ATTACK_HYB_pkg ;
+    ATTACK_CTXT_pkg ∘ CTXT true ;
+    ATTACK_CTXT_pkg ∘ CTXT false
+  ] (ATTACK false) A
+  as ineq.
+  apply: le_trans.
+  1: by apply: ineq.
+  rewrite ATTACK_equiv_true ?fdisjointUr ?fdisjoints0 // GRing.add0r.
+  rewrite ATTACK_HYB_equiv_1 ?fdisjointUr ?fdisjoints0 // GRing.addr0.
+  rewrite ATTACK_HYB_equiv_2 ?fdisjointUr ?fdisjoints0 // GRing.addr0.
+  rewrite ATTACK_equiv_false ?fdisjointUr ?fdisjoints0 // GRing.addr0.
+  rewrite /prg_epsilon /cpa_epsilon !Advantage_E -!Advantage_link.
+  by rewrite (Advantage_sym (GEN_STRETCH true)) (Advantage_sym (CTXT true)).
+Qed.
+
+End SymmRatchet_example.


### PR DESCRIPTION
This is the result of my master's thesis. The proofs are from [The Joy of Cryptography](https://joyofcryptography.com), adapted to SSProve.

Namely:
 - [Theorem 3.6](https://github.com/Som1Lse/joy-of-ssprove/blob/main/theories/SecretSharing.v) (Simple secret-sharing scheme)
 - [Theorems 3.8, 3.9, and 3.13](https://github.com/Som1Lse/joy-of-ssprove/blob/main/theories/ShamirSecretSharing.v) (Shamir's secret-sharing scheme)
 - [Claim 5.5](https://github.com/Som1Lse/joy-of-ssprove/blob/main/theories/StretchPRG.v) (Extending the Stretch of a PRG)
 - [Claim 5.10](https://github.com/Som1Lse/joy-of-ssprove/blob/main/theories/SymmRatchet.v) (Symmetric Ratchet)
 - [Claim 6.3](https://github.com/Som1Lse/joy-of-ssprove/blob/main/theories/PRFPRG.v) (Constructing a PRG from a PRF)
 - [Claim 9.4](https://github.com/Som1Lse/joy-of-ssprove/blob/main/theories/PRPCCA.v) (CCA-secure encryption from a strong PRP)
 - [Claim 10.4](https://github.com/Som1Lse/joy-of-ssprove/blob/main/theories/PRFMAC.v) (A PRF is a MAC)
 - [Claim 10.10](https://github.com/Som1Lse/joy-of-ssprove/blob/main/theories/MACCCA.v) (CCA-security from a MAC scheme)

I am particularly happy with [`ShamirSecretSharing.v`](https://github.com/Som1Lse/joy-of-ssprove/blob/main/theories/ShamirSecretSharing.v), which proves perfect security of Shamir's secret sharing scheme. It shows how to use a Coq library (specifically [mathcomp.algebra.poly](https://math-comp.github.io/htmldoc/mathcomp.algebra.poly.html)) in SSProve, and I find the proof is fairly well structured and elegant.

There is also [`SymmRatchet.v`](https://github.com/Som1Lse/joy-of-ssprove/blob/main/theories/SymmRatchet.v), which demonstrates a way to write `for`-loops in SSProve, and prove properties about them.

[`PRPCCA.v`](https://github.com/Som1Lse/joy-of-ssprove/blob/main/theories/PRPCCA.v) is particularly complicated, and probably the least elegant. Most of the rest are fairly straightforward.
