### PR TITLE
Configure SSProve nix cache

### DIFF
--- a/.github/workflows/nix-action-8.18.yml
+++ b/.github/workflows/nix-action-8.18.yml
@@ -30,11 +30,12 @@ jobs:
       uses: cachix/install-nix-action@v27
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
-    - name: Cachix setup coq
+    - name: Cachix setup ssprove
       uses: cachix/cachix-action@v15
       with:
-        extraPullNames: coq-community, math-comp
-        name: coq
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        extraPullNames: coq, coq-community, math-comp
+        name: ssprove
     - id: stepCheck
       name: Checking presence of CI target coq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr
@@ -77,11 +78,12 @@ jobs:
       uses: cachix/install-nix-action@v27
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
-    - name: Cachix setup coq
+    - name: Cachix setup ssprove
       uses: cachix/cachix-action@v15
       with:
-        extraPullNames: coq-community, math-comp
-        name: coq
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        extraPullNames: coq, coq-community, math-comp
+        name: ssprove
     - id: stepCheck
       name: Checking presence of CI target mathcomp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr
@@ -156,11 +158,12 @@ jobs:
       uses: cachix/install-nix-action@v27
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
-    - name: Cachix setup coq
+    - name: Cachix setup ssprove
       uses: cachix/cachix-action@v15
       with:
-        extraPullNames: coq-community, math-comp
-        name: coq
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        extraPullNames: coq, coq-community, math-comp
+        name: ssprove
     - id: stepCheck
       name: Checking presence of CI target mathcomp-analysis
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr
@@ -224,11 +227,12 @@ jobs:
       uses: cachix/install-nix-action@v27
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
-    - name: Cachix setup coq
+    - name: Cachix setup ssprove
       uses: cachix/cachix-action@v15
       with:
-        extraPullNames: coq-community, math-comp
-        name: coq
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        extraPullNames: coq, coq-community, math-comp
+        name: ssprove
     - id: stepCheck
       name: Checking presence of CI target ssprove
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr

--- a/.github/workflows/nix-action-8.19.yml
+++ b/.github/workflows/nix-action-8.19.yml
@@ -30,11 +30,12 @@ jobs:
       uses: cachix/install-nix-action@v27
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
-    - name: Cachix setup coq
+    - name: Cachix setup ssprove
       uses: cachix/cachix-action@v15
       with:
-        extraPullNames: coq-community, math-comp
-        name: coq
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        extraPullNames: coq, coq-community, math-comp
+        name: ssprove
     - id: stepCheck
       name: Checking presence of CI target coq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr
@@ -77,11 +78,12 @@ jobs:
       uses: cachix/install-nix-action@v27
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
-    - name: Cachix setup coq
+    - name: Cachix setup ssprove
       uses: cachix/cachix-action@v15
       with:
-        extraPullNames: coq-community, math-comp
-        name: coq
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        extraPullNames: coq, coq-community, math-comp
+        name: ssprove
     - id: stepCheck
       name: Checking presence of CI target mathcomp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr
@@ -156,11 +158,12 @@ jobs:
       uses: cachix/install-nix-action@v27
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
-    - name: Cachix setup coq
+    - name: Cachix setup ssprove
       uses: cachix/cachix-action@v15
       with:
-        extraPullNames: coq-community, math-comp
-        name: coq
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        extraPullNames: coq, coq-community, math-comp
+        name: ssprove
     - id: stepCheck
       name: Checking presence of CI target mathcomp-analysis
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr
@@ -224,11 +227,12 @@ jobs:
       uses: cachix/install-nix-action@v27
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
-    - name: Cachix setup coq
+    - name: Cachix setup ssprove
       uses: cachix/cachix-action@v15
       with:
-        extraPullNames: coq-community, math-comp
-        name: coq
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        extraPullNames: coq, coq-community, math-comp
+        name: ssprove
     - id: stepCheck
       name: Checking presence of CI target ssprove
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr

--- a/.github/workflows/nix-action-8.20.yml
+++ b/.github/workflows/nix-action-8.20.yml
@@ -30,11 +30,12 @@ jobs:
       uses: cachix/install-nix-action@v27
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
-    - name: Cachix setup coq
+    - name: Cachix setup ssprove
       uses: cachix/cachix-action@v15
       with:
-        extraPullNames: coq-community, math-comp
-        name: coq
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        extraPullNames: coq, coq-community, math-comp
+        name: ssprove
     - id: stepCheck
       name: Checking presence of CI target coq
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr
@@ -77,11 +78,12 @@ jobs:
       uses: cachix/install-nix-action@v27
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
-    - name: Cachix setup coq
+    - name: Cachix setup ssprove
       uses: cachix/cachix-action@v15
       with:
-        extraPullNames: coq-community, math-comp
-        name: coq
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        extraPullNames: coq, coq-community, math-comp
+        name: ssprove
     - id: stepCheck
       name: Checking presence of CI target mathcomp
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr
@@ -156,11 +158,12 @@ jobs:
       uses: cachix/install-nix-action@v27
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
-    - name: Cachix setup coq
+    - name: Cachix setup ssprove
       uses: cachix/cachix-action@v15
       with:
-        extraPullNames: coq-community, math-comp
-        name: coq
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        extraPullNames: coq, coq-community, math-comp
+        name: ssprove
     - id: stepCheck
       name: Checking presence of CI target mathcomp-analysis
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr
@@ -224,11 +227,12 @@ jobs:
       uses: cachix/install-nix-action@v27
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
-    - name: Cachix setup coq
+    - name: Cachix setup ssprove
       uses: cachix/cachix-action@v15
       with:
-        extraPullNames: coq-community, math-comp
-        name: coq
+        authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        extraPullNames: coq, coq-community, math-comp
+        name: ssprove
     - id: stepCheck
       name: Checking presence of CI target ssprove
       run: "nb_dry_run=$(NIXPKGS_ALLOW_UNFREE=1 nix-build --no-out-link \\\n   --argstr

--- a/.nix/config.nix
+++ b/.nix/config.nix
@@ -80,6 +80,7 @@
   ## name here. For instance, coq-community projects can use
   ## the following line instead of the one above:
   # cachix.coq-community.authToken = "CACHIX_AUTH_TOKEN";
+  cachix.ssprove.authToken = "CACHIX_AUTH_TOKEN";
 
   ## Or if you have a signing key for a given Cachix cache:
   # cachix.my-cache.signingKey = "CACHIX_SIGNING_KEY"


### PR DESCRIPTION
The math-comp and coq-community CI caches seem to often be missing caches for the dependencies we need, so we add a write cache for SSProve dependencies.