### PR TITLE
Adapt CI to upcoming GitHub actions changes

### DIFF
--- a/.github/workflows/opam-build.yml
+++ b/.github/workflows/opam-build.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Try to restore opam cache
         id: opam-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: "~/.opam"
           key: opam-${{github.base_ref}}-${{github.ref}}
@@ -39,7 +39,7 @@ jobs:
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Runs a set of commands using the runners shell
       - name: Build

--- a/.github/workflows/opam-build.yml
+++ b/.github/workflows/opam-build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install OCaml
         uses: avsm/setup-ocaml@v1
         with:
-          ocaml-version: 4.14.1
+          ocaml-version: 4.14.2
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout repo

--- a/.github/workflows/opam-build.yml
+++ b/.github/workflows/opam-build.yml
@@ -13,6 +13,11 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Concurrency group used to cancel old runs
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"

--- a/.github/workflows/opam-build.yml
+++ b/.github/workflows/opam-build.yml
@@ -18,7 +18,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -47,4 +47,3 @@ jobs:
           opam repo add coq-released https://coq.inria.fr/opam/released
           opam install coq.8.18.0 coq-equations.1.3+8.18 coq-mathcomp-ssreflect.2.1.0 coq-mathcomp-analysis.1.0.0 coq-extructures.0.4.0 coq-deriving.0.2.0
           opam exec -- make -j4
-


### PR DESCRIPTION
The `ubuntu-latest` image is switching from `ubuntu-22.04` to `ubuntu-24.04`, this breaks `setup-ocaml@v1` which we depend on in CI.
To keep CI working we switch to using `ubuntu-22.04`.

This PR also updates the cache and checkout actions to the most recent versions since `v2` is being deprecated next month.