### PR TITLE
Add documentation, clarification and optimization of the joy of state separating proofs

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -90,6 +90,7 @@ theories/Crypt/examples/SigmaProtocol.v
 theories/Crypt/examples/Schnorr.v
 # theories/Crypt/examples/OVN.v
 theories/Crypt/examples/Executor.v
+theories/Crypt/examples/PolynomialUtils.v
 
 # Examples from https://github.com/Som1Lse/joy-of-ssprove
 theories/Crypt/examples/MACCCA.v

--- a/theories/Crypt/examples/PolynomialUtils.v
+++ b/theories/Crypt/examples/PolynomialUtils.v
@@ -51,6 +51,8 @@
 Set Warnings "-notation-overridden,-ambiguous-paths".
 From mathcomp Require Import all_ssreflect all_algebra reals distr realsum
   ssrnat ssreflect ssrfun ssrbool ssrnum eqtype choice seq.
+
+From Coq Require Bool.
 Set Warnings "notation-overridden,ambiguous-paths".
 
 Set Bullet Behavior "Strict Subproofs".

--- a/theories/Crypt/examples/PolynomialUtils.v
+++ b/theories/Crypt/examples/PolynomialUtils.v
@@ -10,7 +10,7 @@
 (*                                                                            *)
 (* Is the polinomial defined as:                                              *)
 (*                                                                            *)
-(*   f(x) = y_1 * l_1(x) + ... + y_d+1 * l_d+1                                *)
+(*   f(x) = y_1 * l_1(x) + ... + y_d+1 * l_d+1(x)                                *)
 (*                                                                            *)
 (* where each of the l_i(x) is defined as:                                    *)
 (*                                                                            *)

--- a/theories/Crypt/examples/PolynomialUtils.v
+++ b/theories/Crypt/examples/PolynomialUtils.v
@@ -1,0 +1,592 @@
+(******************************************************************************)
+(* Proof of different properties of polynomials, more concretely around       *)
+(* the existence and uniqueness of the Lagrange polynomial.                   *)
+(* We also formalise Theorem 3.8 from the book "The joy of cryptography"      *)
+(*                                                                            *)
+(*                                                                            *)
+(* The Lagrange interpolation polynomial for a set of d+1 points:             *)
+(*                                                                            *)
+(*   {(x_1, y_1), ..., (x_d+1, y_d+1)} where x_i != x_j                       *)  
+(*                                                                            *)
+(* Is the polinomial defined as:                                              *)
+(*                                                                            *)
+(*   f(x) = y_1 * l_1(x) + ... + y_d+1 * l_d+1                                *)
+(*                                                                            *)
+(* where each of the l_i(x) is defined as:                                    *)
+(*                                                                            *)
+(* l_i(x) = (x-x_1) * (x-x_2) *...* (x-x_i-1) * (x-x_i+1)* ... * (x-x_d+1)    *)
+(*           --------------------------------------------------------------   *)
+(*                         (x_i-x_1) * ... * (x_i-x_d+1)                      *)
+(*                                                                            *)
+(*                                                                            *)
+(* Section Lagrange_Poly                                                      *)
+(*     lagrange_poly pts == given a set of points(pts) it returns the         *)
+(*                          lagrange polynomial(f(x)).                        *)
+(*    lagrange_basis s x == returns each of the l_i(x) given x = x_i and      *)
+(*                          s = [x_1; x_2; ... ; x_d+1].                      *)
+(*  lagrange_poly_part j == returns y_i * l_i(x) for a certain j =            *)
+(*                          ((x_i, y_i), [(x_1, y_1), ..., (x_d+1, y_d+1)]).  *)
+(*             subseqs s == returns a list of pairs where each pair           *)
+(*                          represents a point(first) and the list of the     *)
+(*                          rest of the points needed for calculating l_i(x). *)
+(*                          E.g:                                              *)   
+(*                          subseqs [(1,2); (2,3); (3, 4)] =                  *)
+(*                          [((1,2), [(2,3);(3,4)]);                          *)
+(*                           ((2,3), [(1,2) ;(3,4)]);                         *)
+(*                           ((3,4), [(1,2); (2,3))])                         *)
+(*                          ]                                                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+Set Warnings "-notation-overridden,-ambiguous-paths".
+From mathcomp Require Import all_ssreflect all_algebra reals distr realsum
+  ssrnat ssreflect ssrfun ssrbool ssrnum eqtype choice seq.
+Set Warnings "notation-overridden,ambiguous-paths".
+
+Set Bullet Behavior "Strict Subproofs".
+Set Default Goal Selector "!".
+Set Primitive Projections.
+
+Local Open Scope ring_scope.
+
+Section Lagrange_Poly. 
+
+Definition lagrange_basis {R: unitRingType} (s: seq R) (x: R): {poly R} :=
+  \prod_(c <- s) ((x-c)^-1 *: Poly [:: -c ; 1]).
+
+Definition lagrange_poly_part {R: unitRingType} (j: R * R * seq (R * R)): {poly R} :=
+  j.1.2 *: lagrange_basis (unzip1 j.2) j.1.1.
+
+Fixpoint subseqs_rec {T} l m r: seq (T * seq T) :=
+  match r with
+  | [::] => [:: (m, l)]
+  | a :: r' => (m, l ++ r) :: subseqs_rec (l ++ [:: m]) a r'
+  end.
+
+Definition subseqs {T} (s: seq T): seq (T * seq T) :=
+  match s with
+  | [::] => [::]
+  | m :: r => subseqs_rec [::] m r
+  end.
+
+Definition lagrange_poly {R: unitRingType} (pts: seq (R * R)): {poly R} :=
+  \sum_(j <- subseqs pts) lagrange_poly_part j.
+
+(**
+  We prove some fundamental properties of Lagrange Interpolation.
+  Specifically:
+  - [size_lagrange_poly]: The size of a Lagrange polynomial is [<= size pts].
+  - [lagrange_poly_correct]: Evaluating a Lagrange polynomial at a point gives the corresponding y value.
+  - [lagrange_poly_unique]: There is exactly one polynomial with size [<= size pts], 
+    that satisfies [lagrange_poly_correct].
+
+  These together formalise Theorem 3.8 and 3.9 from the book
+*)
+
+(* If we evaluate l_i(x) for any of the points used to build it, we obtain 0 *)
+Lemma lagrange_basis_0 {R: comUnitRingType} (x1 x: R) (s: seq R):
+  x \in s ->
+  (lagrange_basis s x1).[x] = 0.
+Proof.
+  rewrite /lagrange_basis.
+  elim: s => [// | a s IHs].
+  rewrite in_cons big_cons hornerM hornerZ !horner_cons hornerC GRing.mul0r GRing.add0r GRing.mul1r.
+  destruct (x == a) eqn:Heq.
+  - move /eqP in Heq.
+    by rewrite Heq GRing.subrr GRing.mulr0 GRing.mul0r.
+  - move=> H.
+    by rewrite IHs // GRing.mulr0.
+Qed.
+
+(* If we evaluate l_i(x) for the point x_i we obtain 1 *)
+Lemma lagrange_basis_1 {R: fieldType} (x: R) (s: seq R):
+  (x \notin s) = ((lagrange_basis s x).[x] == 1).
+Proof.
+  rewrite /lagrange_basis.
+  elim: s => [|a s IHs].
+  1: by rewrite big_nil hornerC eq_refl.
+  rewrite in_cons big_cons hornerM hornerZ !horner_cons hornerC GRing.mul0r GRing.add0r GRing.mul1r.
+  destruct (x == a) eqn:Heq.
+  - move /eqP in Heq.
+    by rewrite Heq GRing.subrr GRing.mulr0 GRing.mul0r eq_sym GRing.oner_eq0.
+  - apply negbT in Heq.
+    rewrite -GRing.subr_eq0 in Heq.
+    by rewrite GRing.mulVf // GRing.mul1r IHs.
+Qed.
+
+(* The size of l_i(x) polynomial is <= size of the sequence is built uppon. *)
+Lemma size_lagrange_basis {R: fieldType} (x: R) (s: seq R):
+  (size (lagrange_basis s x) <= S (size s))%N.
+Proof.
+  rewrite /lagrange_basis.
+  elim: s => [|a s IHs].
+  1: by rewrite big_nil size_poly1.
+  rewrite big_cons.
+  destruct (x == a) eqn:Heq.
+  1: {
+    move /eqP in Heq.
+    by rewrite Heq GRing.subrr GRing.invr0 -mul_polyC polyC0 !GRing.mul0r size_poly0.
+  }
+  apply negbT in Heq.
+  apply: leq_trans.
+  1: by apply: size_mul_leq.
+  rewrite size_scale.
+  - by rewrite (@PolyK R 0) // GRing.oner_neq0.
+  - by rewrite GRing.invr_neq0 // GRing.subr_eq0.
+Qed.
+
+Definition dif_points {A : eqType} { B : Type} (l : seq (A * B)) := (uniq (unzip1 l)).
+
+
+Ltac simpl_dif_point :=
+  rewrite /dif_points /unzip1 ?map_cons ?map_cat ?cons_uniq -?/unzip1.
+
+(*
+   Proof that when we construct (partially) our polynomial, the evaluation for an x_i in the list is
+   zero.
+*)
+Lemma lagrange_poly_part_0 {R : fieldType} (x: R) (l : seq (R * R)) m r:
+  x \in unzip1 l ->
+  (\sum_(j <- subseqs_rec l m r) lagrange_poly_part j).[x] = 0.
+Proof.
+  elim: r l m => [|m' r IHr] l [x0 y0] Hin.
+  1: by rewrite big_seq1 hornerZ lagrange_basis_0 ?GRing.mulr0.
+  rewrite /= big_cons hornerD hornerZ.
+  rewrite lagrange_basis_0 ?IHr ?GRing.mulr0 ?GRing.add0r //.
+  all: simpl_dif_point; by rewrite mem_cat Hin.
+Qed.
+
+Lemma uniq_unzip1_in {S T: eqType} (a: S * T) (s: seq (S * T)):
+  dif_points (a :: s) ->
+  a.1 \notin unzip1 s.
+Proof.
+  unfold dif_points. simpl_dif_point.
+  by move => /andP [].
+Qed.
+
+(**
+   If we have a list of different points (l ++ m :: r) and (x, y) \in m::r
+   we have that the sum over the j <- (subseqs_rec l m r) of the l_j(x) when 
+   evaluated in x is equal to y. 
+*)
+Lemma lagrange_poly_part_correct {R: fieldType} (x y: R) l m r:
+  dif_points (l ++ (m :: r)) ->
+  (x, y) \in m :: r ->
+  (\sum_(j <- subseqs_rec l m r) lagrange_poly_part j).[x] = y.
+Proof.
+  elim: r l m => [|m' r IHr] l [x0 y0] Huniq Hin.
+  1: {
+    rewrite big_seq1 hornerZ.
+    rewrite mem_seq1 in Hin.
+    move /eqP in Hin.
+    case: Hin => -> ->.
+    move: Huniq. simpl_dif_point.
+    rewrite uniq_catC -/unzip1 /= => Huniq.
+    move: Huniq => /andP [Hnotin Huniq].
+    rewrite lagrange_basis_1 in Hnotin.
+    move /eqP in Hnotin.
+    by rewrite Hnotin GRing.mulr1.
+  }
+  rewrite /= big_cons hornerD hornerZ.
+  rewrite in_cons in Hin.
+  move: Hin => /orP [/eqP Heq|Hin].
+  1: {
+    case: Heq => -> ->.
+    rewrite lagrange_poly_part_0 ?GRing.addr0 //.
+    2: by rewrite /unzip1 map_cat mem_cat Bool.orb_comm mem_seq1 eq_refl.
+    rewrite /dif_points /unzip1 map_cat uniq_catC -map_cat cat_cons -/unzip1 in Huniq.
+    apply (uniq_unzip1_in (x0, y0)) in Huniq.
+    rewrite /unzip1 map_cat mem_cat Bool.orb_comm -mem_cat -map_cat -/unzip1 in Huniq.
+    rewrite lagrange_basis_1 /= in Huniq.
+    move /eqP in Huniq.
+    by rewrite Huniq GRing.mulr1.
+  }
+  rewrite IHr //.
+  2: by rewrite -catA cat_cons.
+  rewrite lagrange_basis_0 ?GRing.mulr0 ?GRing.add0r //.
+  apply (map_f fst) in Hin.
+  by rewrite /unzip1 map_cat mem_cat Bool.orb_comm Hin.
+Qed.
+
+(**
+   Proof that the size of a Lagrange polynomial is [<= size pts] for
+   the second recursive case. 
+*)
+Lemma size_lagrange_poly_part {R: fieldType} l (m: R * R) r:
+  (size (\sum_(j <- subseqs_rec l m r) lagrange_poly_part j)%R <= size (l ++ m :: r))%N.
+Proof.
+  generalize dependent m.
+  generalize dependent l.
+  elim: r => /= [|m' r IHr] l m.
+  1: {
+    rewrite big_seq1 size_cat addn1.
+    apply: leq_trans.
+    1: by apply: size_scale_leq.
+    apply: leq_trans.
+    - by apply: size_lagrange_basis.
+    - by rewrite /unzip1 size_map ltnSn.
+  }
+  rewrite big_cons.
+  apply: leq_trans.
+  1: by apply: size_add.
+  rewrite geq_max.
+  apply /andP.
+  split.
+  - rewrite /lagrange_poly_part /=.
+    apply: leq_trans.
+    1: by apply: size_scale_leq.
+    replace (size (l ++ [:: m, m' & r])) with (size (unzip1 (l ++ [:: m' & r]))).+1.
+    1: by apply: size_lagrange_basis.
+    by rewrite /unzip1 size_map !size_cat -addnS.
+  - replace (size (l ++ [:: m, m' & r])) with (size ((l ++ [:: m]) ++ m' :: r)).
+    1: by apply: IHr.
+    by rewrite !size_cat addn1 !addnS.
+Qed.
+
+(* The size of a Lagrange polynomial is [<= size pts]. *)
+Lemma size_lagrange_poly {R: fieldType} (pts: seq (R * R)):
+  (size (lagrange_poly pts) <= size pts)%N.
+Proof.
+  case: pts => [|m r].
+  - by rewrite /lagrange_poly big_nil size_poly0.
+  - by apply: (size_lagrange_poly_part [::]).
+Qed.
+
+(* Evaluating a Lagrange polynomial at a point gives the corresponding y value. *)
+Lemma lagrange_poly_correct {R: fieldType} (x y: R) pts:
+  dif_points pts ->
+  (x, y) \in pts ->
+  (lagrange_poly pts).[x] = y.
+Proof.
+  case: pts => [// | m r] Huniq Hin.
+  by apply: lagrange_poly_part_correct.
+Qed.
+
+(**
+   There is exactly one polynomial with size [<= size pts], that satisfies [lagrange_poly_correct].
+   This is a stronger version of Theorem 3.9 of the book.
+*)
+Lemma lagrange_poly_unique {R: fieldType} (pts: seq (R * R)) (q: {poly R}):
+  dif_points pts ->
+  (size q <= size pts)%N ->
+  (forall x y, (x, y) \in pts -> q.[x] = y) ->
+  q = lagrange_poly pts.
+Proof.
+  move=> Huniq Hsize1 Hpred.
+  assert (size (q - lagrange_poly pts)%R <= size pts)%N as Hsize.
+  1: {
+    move: (size_lagrange_poly pts) => Hsize2.
+    apply: leq_trans.
+    1: apply: size_add.
+    by rewrite geq_max size_opp Hsize1 Hsize2.
+  }
+  apply /eqP.
+  rewrite -GRing.subr_eq0 -size_poly_eq0.
+  rewrite size_poly_eq0.
+  apply /negPn /negP => Hcontra.
+  rewrite leqNgt in Hsize.
+  move /negP in Hsize.
+  apply: Hsize.
+  replace (size pts) with (size (unzip1 (pts))).
+  2: by rewrite size_map.
+  apply: max_poly_roots => //.
+  apply /allP => x' /mapP [[x y] Hin Heq].
+  subst.
+  rewrite /root hornerD hornerN.
+  rewrite (Hpred x y) //.
+  rewrite (lagrange_poly_correct x y) //.
+  by rewrite GRing.subr_eq0 eq_refl.
+Qed.
+
+(**
+  We also prove some useful properties for how Lagrange polynomials behave when
+  added or subtracted, specifically with regards to points with [y = 0], which
+  are defined by [zero_points].
+  Specifically:
+  - [lagrange_sub_zero_cons]: Subtracting Langrange polynomials with similar points.
+  - [lagrange_add_zero_cons]: Adding Langrange polynomials where all but one points have [y = 0].
+  - [lagrange_zero]: Evaluating Lagrange polynomials where all points have [y = 0].
+*)
+Definition zero_points {R: ringType} (s: seq R): seq (R * R) :=
+  [seq (x, 0) | x <- s ].
+
+Lemma unzip1_zero_points {R: ringType} (s: seq R):
+  unzip1 (zero_points s) = s.
+Proof.
+  rewrite /unzip1 /zero_points.
+  elim: s => [// | a s IHs].
+  by rewrite !map_cons IHs.
+Qed.
+
+Lemma x_in_zero_points {R: ringType} (x y: R) (s: seq R):
+  (x, y) \in zero_points s ->
+  x \in s.
+Proof.
+  rewrite /zero_points.
+  elim: s => [// | a s IHs] H.
+  rewrite in_cons.
+  rewrite map_cons in_cons xpair_eqE in H.
+  destruct (x == a) eqn:Heq => //=.
+  by apply: IHs.
+Qed.
+
+Lemma y_in_zero_points {R: ringType} {x y: R} {s: seq R}:
+  (x, y) \in zero_points s ->
+  y = 0.
+Proof.
+  rewrite /zero_points.
+  elim: s => [// | a s IHs] H.
+  rewrite map_cons in_cons in H.
+  destruct ((x, y) == (a, 0)) eqn:Heq.
+  - move /eqP in Heq.
+    by case: Heq.
+  - by apply: IHs.
+Qed.
+
+Lemma pt_in_zero_points {R: ringType} {x: R} {s: seq R}:
+  x \in s ->
+  (x, 0) \in zero_points s.
+Proof.
+  rewrite /zero_points.
+  elim: s => [// | a s IHs] H /=.
+  rewrite in_cons in H.
+  rewrite in_cons.
+  destruct (x == a) eqn:Heq.
+  - move /eqP in Heq.
+    by rewrite Heq eq_refl.
+  - by rewrite xpair_eqE Heq IHs.
+Qed.
+
+Lemma lagrange_sub_zero {R: fieldType} (x: R) (l1 l2 r: seq (R * R)):
+  dif_points (l1 ++ r) ->
+  dif_points (l2 ++ r) ->
+  x \in unzip1 r ->
+  (lagrange_poly (l1 ++ r) - lagrange_poly (l2 ++ r)).[x] = 0.
+Proof.
+  rewrite hornerD hornerN.
+  generalize dependent l2.
+  generalize dependent l1.
+  elim: r => [// | a r IHr] l1 l2 Huniq1 Huniq2 Hin.
+  rewrite /= in_cons in Hin.
+  destruct (x == a.1) eqn:Heq.
+  - move /eqP in Heq.
+    rewrite Heq (lagrange_poly_correct a.1 a.2) //.
+    1: rewrite (lagrange_poly_correct a.1 a.2) ?GRing.subrr //.
+    all: by rewrite -surjective_pairing mem_cat in_cons eq_refl Bool.orb_true_r.
+  - rewrite -!cat_rcons -!cats1 in Huniq1 Huniq2*.
+    by apply: IHr.
+Qed.
+
+Lemma lagrange_sub_zero_cons {R: fieldType} (x y1 y2: R) (pts: seq (R * R)):
+  uniq (x :: unzip1 pts) ->
+  lagrange_poly ((x, y1) :: pts) - lagrange_poly ((x, y2) :: pts) =
+  lagrange_poly ((x, y1 - y2) :: zero_points (unzip1 pts)).
+Proof.
+  move=> Huniq.
+  apply: lagrange_poly_unique.
+  - simpl_dif_point. by rewrite unzip1_zero_points.
+  - apply: leq_trans.
+    1: by apply: size_add.
+    rewrite size_opp /= !size_map geq_max.
+    apply /andP.
+    split.
+    all: apply: leq_trans.
+    1,3: by apply: size_lagrange_poly.
+    all: by [].
+  - move=> x0 y0 Hin.
+    rewrite in_cons in Hin.
+    destruct (_ == _) eqn:Heq.
+    + move /eqP in Heq.
+      case: Heq => ? ?.
+      subst.
+      rewrite hornerD hornerN (lagrange_poly_correct x y1) //.
+      1: rewrite (lagrange_poly_correct x y2) //.
+      all: by rewrite in_cons eq_refl.
+    + rewrite (y_in_zero_points Hin).
+      rewrite -!(cat1s _ pts).
+      apply: lagrange_sub_zero => //.
+      by apply: (x_in_zero_points x0 y0).
+Qed.
+
+Lemma lagrange_add_zero {R: fieldType} (x: R) (l1 l2: seq (R * R)) (r: seq R):
+  dif_points (l1 ++ zero_points r) ->
+  dif_points (l2 ++ zero_points r) ->
+  x \in r ->
+  (lagrange_poly (l1 ++ zero_points r) + lagrange_poly (l2 ++ zero_points r)).[x] = 0.
+Proof.
+  rewrite hornerD.
+  generalize dependent l2.
+  generalize dependent l1.
+  elim: r => [// | a r IHr] l1 l2 Huniq1 Huniq2 Hin.
+  rewrite /= in_cons in Hin.
+  destruct (x == a) eqn:Heq.
+  - move /eqP in Heq.
+    rewrite Heq (lagrange_poly_correct a 0) //.
+    1: rewrite (lagrange_poly_correct a 0) ?GRing.addr0 //.
+    all: by rewrite mem_cat in_cons eq_refl Bool.orb_true_r.
+  - rewrite -!cat_rcons -!cats1 in Huniq1 Huniq2 *.
+    by apply: IHr.
+Qed.
+
+
+Lemma lagrange_add_zero_cons {R: fieldType} (x y1 y2: R) (s: seq R):
+  uniq (x :: s) ->
+  lagrange_poly ((x, y1) :: zero_points s) +
+  lagrange_poly ((x, y2) :: zero_points s) =
+  lagrange_poly ((x, y1 + y2) :: zero_points s).
+Proof.
+  move=> Huniq.
+  apply: lagrange_poly_unique.
+  - simpl_dif_point. by rewrite unzip1_zero_points.
+  - apply: leq_trans.
+    1: by apply: size_add.
+    rewrite /= !size_map geq_max.
+    apply /andP.
+    split.
+    all: apply: leq_trans.
+    1,3: by apply: size_lagrange_poly.
+    all: by rewrite /= size_map.
+  - move=> x0 y0 Hin.
+    rewrite in_cons in Hin.
+    destruct (_ == _) eqn:Heq.
+    + move /eqP in Heq.
+      case: Heq => ? ?.
+      subst.
+      rewrite hornerD (lagrange_poly_correct x y1) //.
+      1: rewrite (lagrange_poly_correct x y2) //.
+      2,4: by rewrite in_cons eq_refl.
+      all: simpl_dif_point; by rewrite unzip1_zero_points.
+    + rewrite (y_in_zero_points Hin).
+      rewrite -!(cat1s _ (zero_points s)).
+      apply: lagrange_add_zero.
+      3: by apply: (x_in_zero_points x0 y0).
+      all: simpl_dif_point; by rewrite unzip1_zero_points.
+Qed.
+
+Lemma lagrange_zero {R: fieldType} (s: seq R):
+  uniq s ->
+  lagrange_poly (zero_points s) = 0.
+Proof.
+  move=> Huniq.
+  symmetry.
+  apply: lagrange_poly_unique.
+  - simpl_dif_point. by rewrite unzip1_zero_points.
+  - by rewrite polyseq0.
+  - move=> x y Hin.
+    rewrite hornerC.
+    by rewrite (y_in_zero_points Hin).
+Qed.
+
+(**
+  We also define some functions that lets us treat polynomials like lists ending
+  in infinite zeroes, and prove some useful lemmas that they do indeed behave
+  like lists.
+*)
+Definition head_poly {R: ringType} (q: {poly R}): R := q`_0.
+Definition tail_poly {R: ringType} (q: {poly R}): {poly R} := Poly (behead q).
+
+Lemma head_cons_poly {R: ringType} (a: R) (q: {poly R}):
+  head_poly (cons_poly a q) = a.
+Proof.
+  by rewrite /head_poly coef_cons.
+Qed.
+
+Lemma tail_cons_poly {R: ringType} (a: R) (q: {poly R}):
+  tail_poly (cons_poly a q) = q.
+Proof.
+  rewrite /tail_poly polyseq_cons.
+  destruct (nilp q) eqn:Heq => /=.
+  2: by rewrite polyseqK.
+  rewrite /nilp size_poly_eq0 in Heq.
+  move /eqP in Heq.
+  rewrite Heq polyseqC.
+  by case: (a != 0).
+Qed.
+
+Lemma size_tail_poly {R: ringType} (q: {poly R}):
+  size (tail_poly q) = (size q).-1.
+Proof.
+  rewrite /tail_poly.
+  case: q => [[|a s] /= Hs].
+  - by rewrite polyseq0.
+  - by rewrite (PolyK Hs).
+Qed.
+
+Lemma last_neq_0 {R: ringType} (a: R) (s: seq R):
+  (last a s != 0 -> last 1 s != 0).
+Proof.
+  case: s => H //=.
+  by apply: GRing.oner_neq0.
+Qed.
+
+Lemma cons_head_tail_poly {R: ringType} (q: {poly R}):
+  cons_poly (head_poly q) (tail_poly q) = q.
+Proof.
+  apply: poly_inj.
+  rewrite /head_poly /tail_poly polyseq_cons.
+  case: q => [[|a s] /= Hs].
+  1: by rewrite polyseq0.
+  rewrite (PolyK Hs).
+  destruct s => //=.
+  by rewrite polyseqC Hs.
+Qed.
+
+Lemma cons_eq_head_tail_poly {R: ringType} (a: R) (q: {poly R}):
+  a = head_poly q ->
+  cons_poly a (tail_poly q) = q.
+Proof.
+  move=> H.
+  by rewrite H cons_head_tail_poly.
+Qed.
+
+(**
+  Proof that two polynomials are equal if, and only if, all their
+  coefficients are equal.
+
+  Used to prove how [tail_poly] and [cons_poly] behaves when added
+  and negated.
+*)
+Lemma coef_poly_eq {R: ringType} (q1 q2: {poly R}):
+  (forall i, q1`_i = q2`_i) <-> q1 = q2.
+Proof.
+  split=> H.
+  2: by rewrite H.
+  apply: poly_inj.
+  move: H.
+  case: q2.
+  case: q1.
+  elim=> [|a1 s1 IHs1] Hs1 [|a2 s2 ] //= Hs2 H.
+  - move /eqP in Hs2.
+    destruct Hs2. specialize (H (size s2)).
+    rewrite nth_nil nth_last in H.
+    by rewrite H.
+  - move /eqP in Hs1.
+    destruct Hs1. specialize (H (size s1)).
+    rewrite nth_nil nth_last in H.
+    by rewrite -H.
+  - move: (fun i => H i.+1) => HS.
+    specialize (H 0%N). simpl in *.
+    rewrite H. f_equal.
+    apply: IHs1 => //.
+    all: apply: last_neq_0.
+    + by apply: Hs1.
+    + by apply: Hs2.
+Qed.
+
+Lemma tail_poly_add {R: ringType} (q1 q2: {poly R}):
+  tail_poly (q1 + q2) = tail_poly q1 + tail_poly q2.
+Proof.
+  apply coef_poly_eq => i.
+  by rewrite coefD !coef_Poly !nth_behead coefD.
+Qed.
+
+Lemma cons_poly_add {R: ringType} (m m': R) (q1 q2: {poly R}):
+  (cons_poly m' (q1 + q2) = (cons_poly m q1) + cons_poly (m'-m) q2)%R.
+Proof.
+  apply coef_poly_eq => i.
+  rewrite coefD !coef_cons coefD.
+  case: i => //=.
+  by rewrite GRing.addrC -GRing.addrA GRing.addNr GRing.addr0.
+Qed.
+
+End Lagrange_Poly.

--- a/theories/Crypt/examples/PolynomialUtils.v
+++ b/theories/Crypt/examples/PolynomialUtils.v
@@ -49,6 +49,11 @@ Set Primitive Projections.
 
 Local Open Scope ring_scope.
 
+Definition dif_points {A : eqType} { B : Type} (l : seq (A * B)) := (uniq (unzip1 l)).
+
+Ltac simpl_dif_point :=
+  rewrite /dif_points /unzip1 ?map_cons ?map_cat ?cons_uniq -?/unzip1.
+
 Section Lagrange_Poly. 
 
 Definition lagrange_basis {R: unitRingType} (s: seq R) (x: R): {poly R} :=
@@ -134,12 +139,6 @@ Proof.
   - by rewrite (@PolyK R 0) // GRing.oner_neq0.
   - by rewrite GRing.invr_neq0 // GRing.subr_eq0.
 Qed.
-
-Definition dif_points {A : eqType} { B : Type} (l : seq (A * B)) := (uniq (unzip1 l)).
-
-
-Ltac simpl_dif_point :=
-  rewrite /dif_points /unzip1 ?map_cons ?map_cat ?cons_uniq -?/unzip1.
 
 (*
    Proof that when we construct (partially) our polynomial, the evaluation for an x_i in the list is

--- a/theories/Crypt/examples/SecretSharing.v
+++ b/theories/Crypt/examples/SecretSharing.v
@@ -41,6 +41,9 @@ Set Primitive Projections.
 Import Num.Def.
 Import Num.Theory.
 Import Order.POrderTheory.
+Import BinNat.
+Import BinNums.
+Import Nnat.
 
 Section SecretSharing_example.
 
@@ -60,42 +63,42 @@ Definition Word: choice_type := chFin (mkpos Word_N).
   Lemmas for the [plus] obligation.
 *)
 Lemma pow2_inj m:
-  (2 ^ m)%N = BinNat.N.to_nat (BinNat.N.pow (BinNums.Npos (BinNums.xO 1%AC)) (BinNat.N.of_nat m)).
-Proof.
+  (2 ^ m)%nat = (N.to_nat (N.pow (Npos (xO 1%AC)) (N.of_nat m))).
+Proof. 
   elim: m => [// | m IHm].
-  rewrite expnSr Nnat.Nat2N.inj_succ BinNat.N.pow_succ_r' Nnat.N2Nat.inj_mul PeanoNat.Nat.mul_comm.
+  rewrite expnSr Nat2N.inj_succ N.pow_succ_r' N2Nat.inj_mul PeanoNat.Nat.mul_comm.
   by apply: f_equal2.
 Qed.
 
 Lemma log2_lt_pow2 w m:
-  (w.+1 < 2^m)%N ->
-  BinNat.N.lt (BinNat.N.log2 (BinNat.N.of_nat w.+1)) (BinNat.N.of_nat m).
+  (w.+1 < 2^m)%nat ->
+  N.lt (N.log2 (N.of_nat w.+1)) (N.of_nat m).
 Proof.
   move=> H.
-  rewrite -BinNat.N.log2_lt_pow2.
-  - rewrite /BinNat.N.lt Nnat.N2Nat.inj_compare PeanoNat.Nat.compare_lt_iff -pow2_inj Nnat.Nat2N.id.
+  rewrite -N.log2_lt_pow2.
+  - rewrite /N.lt N2Nat.inj_compare PeanoNat.Nat.compare_lt_iff -pow2_inj Nat2N.id.
     by apply /ltP.
-  - rewrite Nnat.Nat2N.inj_succ.
-    by apply: BinNat.N.lt_0_succ.
+  - rewrite Nat2N.inj_succ.
+    by apply: N.lt_0_succ.
 Qed.
 
 #[program] Definition plus (w k: Word): Word :=
-  @Ordinal _ (BinNat.N.to_nat (BinNat.N.lxor
-    (BinNat.N.of_nat (nat_of_ord w))
-    (BinNat.N.of_nat (nat_of_ord k)))) _.
+  @Ordinal _ (N.to_nat (N.lxor
+    (N.of_nat (nat_of_ord w))
+    (N.of_nat (nat_of_ord k)))) _.
 Next Obligation.
   move: w k => [[|w] Hw] [[|k] Hk].
   1-3: by rewrite /= ?Pnat.SuccNat2Pos.id_succ.
   move: (log2_lt_pow2 _ _ Hw) => H1.
   move: (log2_lt_pow2 _ _ Hk) => H2.
-  move: (BinNat.N.max_lub_lt _ _ _ H1 H2) => Hm.
-  case: (BinNat.N.eq_dec (BinNat.N.lxor (BinNat.N.of_nat w.+1) (BinNat.N.of_nat k.+1)) BinNat.N0) => H0.
+  move: (N.max_lub_lt _ _ _ H1 H2) => Hm.
+  case: (N.eq_dec (N.lxor (N.of_nat w.+1) (N.of_nat k.+1)) N0) => H0.
   1: by rewrite H0 expn_gt0.
-  move: (BinNat.N.log2_lxor (BinNat.N.of_nat w.+1) (BinNat.N.of_nat k.+1)) => Hbound.
-  move: (BinNat.N.le_lt_trans _ _ _ Hbound Hm).
-  rewrite -BinNat.N.log2_lt_pow2.
-  2: by apply BinNat.N.neq_0_lt_0.
-  rewrite /BinNat.N.lt Nnat.N2Nat.inj_compare PeanoNat.Nat.compare_lt_iff -pow2_inj.
+  move: (N.log2_lxor (N.of_nat w.+1) (N.of_nat k.+1)) => Hbound.
+  move: (N.le_lt_trans _ _ _ Hbound Hm).
+  rewrite -N.log2_lt_pow2.
+  2: by apply N.neq_0_lt_0.
+  rewrite /N.lt N2Nat.inj_compare PeanoNat.Nat.compare_lt_iff -pow2_inj.
   by move /ltP.
 Qed.
 
@@ -109,7 +112,7 @@ Lemma plus_comm m k:
 Proof.
   apply: ord_inj.
   case: m => m ? /=.
-  by rewrite BinNat.N.lxor_comm.
+  by rewrite N.lxor_comm.
 Qed.
 
 Lemma plus_assoc m l k:
@@ -117,8 +120,8 @@ Lemma plus_assoc m l k:
 Proof.
   apply: ord_inj.
   case: m => m ? /=.
-  rewrite !Nnat.N2Nat.id.
-  by rewrite BinNat.N.lxor_assoc.
+  rewrite !N2Nat.id.
+  by rewrite N.lxor_assoc.
 Qed.
 
 Lemma plus_involutive m k:
@@ -127,10 +130,10 @@ Proof.
   rewrite plus_assoc.
   apply: ord_inj.
   case: m => m ? /=.
-  rewrite Nnat.N2Nat.id.
-  rewrite BinNat.N.lxor_nilpotent.
-  rewrite BinNat.N.lxor_0_r.
-  by rewrite Nnat.Nat2N.id.
+  rewrite N2Nat.id.
+  rewrite N.lxor_nilpotent.
+  rewrite N.lxor_0_r.
+  by rewrite Nat2N.id.
 Qed.
 
 #[local] Open Scope package_scope.

--- a/theories/Crypt/examples/SecretSharing.v
+++ b/theories/Crypt/examples/SecretSharing.v
@@ -221,8 +221,8 @@ Lemma SHARE_equiv:
   SHARE true ≈₀ SHARE false.
 Proof.
   (**
-    Since the games have no state, we don’t need to maintain an invariant, and only
-    need to ensure the games have the same output distribution.
+    Since the games have no state, we don’t need to maintain an invariant, and 
+    only need to ensure the games have the same output distribution.
   *)
   apply: eq_rel_perf_ind_eq.
 
@@ -262,7 +262,7 @@ Proof.
     exists (fun x => x ⊕ (ml ⊕ mr)) => x.
     all: by apply: plus_involutive.
   }
-  (* Since there exists a bijection, they must have the same output distribution *)
+  (* Because of the bijection, they must have the same output distribution *)
   rewrite plus_assoc. rewrite plus_involutive.
   by apply: rreflexivity_rule.
 Qed.

--- a/theories/Crypt/examples/SecretSharing.v
+++ b/theories/Crypt/examples/SecretSharing.v
@@ -16,10 +16,10 @@
 (* * Section SecretSharing_example					                                  *)
 (*    Word == type for the words in the protocol       			                  *)
 (*   'word == notation for Word						                                    *)
-(*    plus == receives two Words and returns the XOR of them		                *)
+(*    plus == receives two Words and returns the XOR of them		              *)
 (*   m ⊕ k == XOR of words m and k					                                  *)	
-(*  'seq t == local choice_type for sequences				                        *)
-(*  'set t == local choice_type for sets 				                            *)
+(*  'seq t == local choice_type for sequences				                          *)
+(*  'set t == local choice_type for sets 				                              *)
 (******************************************************************************)
 
 From SSProve.Relational Require Import OrderEnrichedCategory GenericRulesSimple.

--- a/theories/Crypt/examples/SecretSharing.v
+++ b/theories/Crypt/examples/SecretSharing.v
@@ -111,7 +111,7 @@ Next Obligation.
   case: (N.eq_dec (N.lxor (N.of_nat w.+1) (N.of_nat k.+1)) N0) => H0.
   
   (* lxor (w+1) (k+1) <> 0 *)
-  2: by rewrite H0 expn_gt0.
+  1: by rewrite H0 expn_gt0.
   (* lxor (w+1) (k+1) <> 0 *)
   move => {H1 H2}.
   move: (N.log2_lxor (N.of_nat w.+1) (N.of_nat k.+1)) => Hbound.

--- a/theories/Crypt/examples/SecretSharing.v
+++ b/theories/Crypt/examples/SecretSharing.v
@@ -44,12 +44,15 @@ Import Order.POrderTheory.
 Import BinNat.
 Import BinNums.
 Import Nnat.
+Import BinPosDef.
 
 Section SecretSharing_example.
 
 Variable (n: nat).
 
 Definition Word_N: nat := 2^n.
+
+(*Type that expresses that all the words have to be less or equal of 2^n?*)
 Definition Word: choice_type := chFin (mkpos Word_N).
 
 (**
@@ -63,16 +66,15 @@ Definition Word: choice_type := chFin (mkpos Word_N).
   Lemmas for the [plus] obligation.
 *)
 Lemma pow2_inj m:
-  (2 ^ m)%nat = (N.to_nat (N.pow (Npos (xO 1%AC)) (N.of_nat m))).
-Proof. 
+  (2 ^ m)%nat = N.to_nat (2 ^ (N.of_nat m)).
+Proof.
   elim: m => [// | m IHm].
   rewrite expnSr Nat2N.inj_succ N.pow_succ_r' N2Nat.inj_mul PeanoNat.Nat.mul_comm.
   by apply: f_equal2.
 Qed.
 
 Lemma log2_lt_pow2 w m:
-  (w.+1 < 2^m)%nat ->
-  N.lt (N.log2 (N.of_nat w.+1)) (N.of_nat m).
+  (w.+1 < 2^m)%nat -> ((N.log2 (N.of_nat w.+1)) < (N.of_nat m))%N.
 Proof.
   move=> H.
   rewrite -N.log2_lt_pow2.

--- a/theories/Crypt/examples/SecretSharing.v
+++ b/theories/Crypt/examples/SecretSharing.v
@@ -1,26 +1,26 @@
-(*****************************************************************************)
-(*                             Secret Sharing                                *)
-(*                                                                           *)
-(* Formalization of Theorem 3.6 from "The Joy of Cryptography" (p. 51).      *)
-(* It is a simple 2-out-of-2 secret-sharing scheme with perfect security,    *)
-(* based on XOR. Messages are n-bit words, and the scheme works by letting   *)
-(* the first share to be a random word, and the second share be the first    *)
-(* share XOR'ed with the message.                                            *) 
-(*                                                                           *)
-(* At the beginning we prove some properties for the plus operator, such as  *)
-(* associativity or involutive.                                              *)
-(* The final statement ([unconditional_secrecy]) is equivalent to that of    *)
-(* the books: The scheme achieves perfect security with up to two shares     *) 
-(* (non-inclusive).                                                          *)
-(*									                                                         *)
-(* * Section SecretSharing_example					                                 *)
-(*   Word == Definition for the finite type of size 2^n			                 *)
-(*   'word == Notation for Word						                                   *)
-(*   plus == receives two Words and returns the XOR of them		               *)
-(*   m ⊕ k == XOR of words m and k					                                 *)	
-(*   'seq t == Local choice_type for sequences				                       *)
-(*   'set t == Local choice_type for sets 				                           *)
-(*****************************************************************************)
+(******************************************************************************)
+(*                             Secret Sharing                                 *)
+(*                                                                            *)
+(* Formalization of Theorem 3.6 from "The Joy of Cryptography" (p. 51).       *)
+(* It is a simple 2-out-of-2 secret-sharing scheme with perfect security,     *)
+(* based on XOR. Messages are n-bit words, and the scheme works by letting    *)
+(* the first share to be a random word, and the second share be the first     *)
+(* share XOR'ed with the message.                                             *) 
+(*                                                                            *)
+(* At the beginning we prove some properties for the plus operator, such as   *)
+(* associativity or involutive.                                               *)
+(* The final statement ([unconditional_secrecy]) is equivalent to that of     *)
+(* the books: The scheme achieves perfect security with up to two shares      *) 
+(* (non-inclusive).                                                           *)
+(*									                                                          *)
+(* * Section SecretSharing_example					                                  *)
+(*    Word == type for the words in the protocol       			                  *)
+(*   'word == notation for Word						                                    *)
+(*    plus == receives two Words and returns the XOR of them		                *)
+(*   m ⊕ k == XOR of words m and k					                                  *)	
+(*  'seq t == local choice_type for sequences				                        *)
+(*  'set t == local choice_type for sets 				                            *)
+(******************************************************************************)
 
 From SSProve.Relational Require Import OrderEnrichedCategory GenericRulesSimple.
 
@@ -63,7 +63,7 @@ Variable (n: nat).
 
 Definition Word_N: nat := 2^n.
 
-(* We define words to belong to the finite type of size Word_N *)
+(* We define words to belong to the finite type of size Word_N                *)
 Definition Word: choice_type := chFin (mkpos Word_N).
 
 (******************************************************************************)
@@ -155,19 +155,16 @@ Qed.
 Notation " 'word " := (Word) (in custom pack_type at level 2).
 Notation " 'word " := (Word) (at level 2): package_scope.
 
-(**
-  We can't use sequences directly in [choice_type] so instead we use a map from
-  natural numbers to the type.
-*)
+(* We can't use sequences directly in [choice_type] so instead we use a       *)
+(* map from natural numbers to the type.                                      *)
 Definition chSeq t := chMap 'nat t.
 
 Notation " 'seq t " := (chSeq t) (in custom pack_type at level 2).
 Notation " 'seq t " := (chSeq t) (at level 2): package_scope.
 
-(**
-  We can't use sets directly in [choice_type] so instead we use a map to units.
-  We can then use [domm] to get the domain, which is a set.
-*)
+(* We can't use sets directly in [choice_type] so instead we use a map to     *)
+(* units. We can then use [domm] to get the domain, which is a set.           *)
+
 Definition chSet t := chMap t 'unit.
 
 Notation " 'set t " := (chSet t) (in custom pack_type at level 2).

--- a/theories/Crypt/examples/SecretSharing.v
+++ b/theories/Crypt/examples/SecretSharing.v
@@ -123,13 +123,6 @@ Notation "m ⊕ k" := (plus m k) (at level 70).
 (**
   Some lemmas for [plus] itself.
 *)
-Lemma plus_comm m k:
-  (m ⊕ k) = (k ⊕ m).
-Proof.
-  apply: ord_inj.
-  case: m => m ? /=.
-  by rewrite N.lxor_comm.
-Qed.
 
 Lemma plus_assoc m l k:
   ((m ⊕ l) ⊕ k) = (m ⊕ (l ⊕ k)).

--- a/theories/Crypt/examples/SecretSharing.v
+++ b/theories/Crypt/examples/SecretSharing.v
@@ -232,8 +232,7 @@ Proof.
 
   (* We can weaken the postcondition*)
   apply rpost_weaken_rule with eq.
-  (*???*)
-  2 : by move=> [? ?] [? ?] [].
+  2: by move=> [? ?] [? ?] [].
 
   (* Unpack m as ml, mr and U *)
   case m => [[ml mr] U].
@@ -242,7 +241,6 @@ Proof.
   case: (_ (domm U)) => {U} [|a U] /=.
   (* domm U = ∅ *)
   1: by apply: rreflexivity_rule.
-
   (* domm U != ∅ *)
   (* Case distinction over the set U *)
   case: U => [|b U].

--- a/theories/Crypt/examples/ShamirSecretSharing.v
+++ b/theories/Crypt/examples/ShamirSecretSharing.v
@@ -1,31 +1,50 @@
-(*****************************************************************************)
-(*                          Shamir Secret Sharing                            *)
-(*                                                                           *)
-(* This formalises Theorem 3.13 from "The Joy of Cryptography" (p. 60).      *)
-(* It formalises Shamir's Secret Sharing scheme and proves that it has       *) 
-(* perfect security. It is a t-out-of-n secret sharing scheme over the       *) 
-(* field ['F_p].                                                             *) 
-(*                                                                           *)
-(* We also formalise Theorem 3.8 from the book. We skip Lemma 3.12,          *)
-(* since the bijection technique used in this proof doesn't benefit from     *)
-(* the extra steps. (Note, earlier commits did include it, so if you         *)
-(* are interested, feel free to check out the commit history.)               *)
-(*                                                                           *)
-(* After this the remaining part of the proof is just using that bijection    *)
-(* to prove the scheme is secure.                                             *)       
-(*                                                                           *)
-(* This differs a bit from the proof in "The Joy of Cryptography" since      *)
-(* our proof is based on the construction of a bijection, whereas the one    *)
-(* in the book is based on statistical analysis.                             *)
-(*                                                                           *)
-(* This is arguably harder to prove, but it is the method that is directly   *)
-(* supported by SSProve, and it is also easier to verify that you got it     *)
-(* right.                                                                    *)
-(*                                                                           *)
-(* The final statement ([unconditional_secrecy]) is equivalent to that of    *)
-(* the book: The scheme achieves perfect secrecy, for any [t], [n] and any   *)
-(* prime [p].                                                                *)
-(*****************************************************************************)
+(******************************************************************************)
+(*                          Shamir Secret Sharing                             *)
+(*                                                                            *)
+(* This formalises Theorem 3.13 from "The Joy of Cryptography" (p. 60).       *)
+(* It formalises Shamir's Secret Sharing scheme and proves that it has        *) 
+(* perfect security. It is a t-out-of-n secret sharing scheme over the        *) 
+(* field 'F_p.                                                                *)
+(*                                                                            *) 
+(* To prove security in SSProve, we need to define a bijection for the        *)
+(* random polynomials f_r and f_l. The bijection is:                          *)
+(*                                                                            *)
+(*   f_r(x) = f_l(x) + g_r(x) - g_l(x) = m_r + x * q_r(x)                     *)                             
+(*                                                                            *)
+(* The proof conducted here differs a bit from the one in the book, since     *)
+(* our proof is based on the construction of a bijection, whereas the one     *)
+(* in the book is based on statistical analysis.                              *)
+(*                                                                            *)
+(* We skip Lemma 3.12, since the bijection technique used in this proof       *)
+(* doesn't benefit from the extra steps. (Note, earlier commits did include   *)
+(* it, so if you are interested, feel free to check out the commit history.   *)
+(*                                                                            *)
+(* Since SSProve does not support using polynomials directly, we represent    *)
+(* polynomials with an inhabited finite type of size p^t (PolyEnc t) because  *) 
+(* there are [p^t] polynomials of size [<= t] over the field ['F_p].          *)
+(*                                                                            *)
+(* We then define a bijection functions between polynomials and [PolyEnc t].  *)
+(* We combine all three bijections to create a bijection from [PolyEnc t]     *)
+(* to [PolyEnc t] that we can use to prove security of the protocol.          *)
+(*                                                                            *)
+(* The final statement (unconditional_secrecy) is equivalent to that of       *)
+(* the book: The scheme achieves perfect secrecy, for any t, n and any        *)
+(* prime p.                                                                   *)
+(*                                                                            *)
+(* Section ShamirSecretSharing_example                                        *)
+(*   Word == type of the words in the protocol       			                    *)
+(*  'word == notation for Word						                                    *)
+(*  Share == type of the shares in the protocol                               *)
+(* 'share == notation for Share                                               *)
+(*  Party == type of the parties in the protocol                              *)
+(* 'party == notation for Party                                               *)
+(*      t == the number of shares needed for reconstruction.                  *)
+(*     t' == the maximum number of shares the scheme is secure against.       *)
+(*      n == number of shares.                                                *)
+(*      p == number of possible messages. It is is a prime.                   *)
+(* 'seq t == local choice_type for sequences				                          *)
+(* 'set t == local choice_type for sets 				                              *)
+(******************************************************************************)
 
 From SSProve.Relational Require Import OrderEnrichedCategory GenericRulesSimple.
 
@@ -39,6 +58,7 @@ From SSProve.Crypt Require Import Axioms ChoiceAsOrd SubDistr Couplings
   UniformDistrLemmas FreeProbProg Theta_dens RulesStateProb
   pkg_core_definition choice_type pkg_composition pkg_rhl Package Prelude.
 
+From SSProve.Crypt.examples Require Import PolynomialUtils.
 
 From extructures Require Import ord fset fmap.
 
@@ -61,595 +81,16 @@ Import Order.POrderTheory.
 
 Local Open Scope ring_scope.
 
-(**
-  First step is to define Lagrange interpolation. This is implemented in the 
-  [lagrange_poly] function, which is split up into several helper functions.
-
-  The Lagrange interpolation polynomial for a set of d+1 points:
-  
-    {(x_1, y_1), ..., (x_d+1, y_d+1)} where x_i != x_j 
-  
-  Is the polinomial defined as:
-
-    f(x) = y_1 * l_1(x) + ... + y_d+1 * l_d+1 
-
-  where each of the l_i(x) is defined as:
-    
-  l_i(x) = (x-x_1) * (x-x_2) *...* (x-x_i-1) * (x-x_i+1)* ... * (x-x_d+1)
-          ----------------------------------------------------------------
-                        (x_i-x_1) * ... * (x_i-x_d+1)
-*)
-
-(* Returns each of the l_i(x) given x = x_i and s = [x_1; x_2; ... ; x_d+1] *)
-
-Definition lagrange_basis {R: unitRingType} (s: seq R) (x: R): {poly R} :=
-  \prod_(c <- s) ((x-c)^-1 *: Poly [:: -c ; 1]).
-
-(* Returns y_i * l_i(x) for a certain j = ((x_i, y_i), [(x_1, y_1), ..., (x_d+1, y_d+1)]) *)
-
-Definition lagrange_poly_part {R: unitRingType} (j: R * R * seq (R * R)): {poly R} :=
-  j.1.2 *: lagrange_basis (unzip1 j.2) j.1.1.
-
-(**
-  The funtion subseqs returns a list of pairs where each pair represents a point(first) and the 
-  list of the rest of the points needed for calculating l_i(x).
-
-  Example: 
-    subseqs [(1,2); (2,3); (3, 4)] = [((1,2), [(2,3);(3,4)]); ((2,3), [(1,2) ;(3,4)]); ((3,4), [(1,2); (2,3))])]
-*)
-
-Fixpoint subseqs_rec {T} l m r: seq (T * seq T) :=
-  match r with
-  | [::] => [:: (m, l)]
-  | a :: r' => (m, l ++ r) :: subseqs_rec (l ++ [:: m]) a r'
-  end.
-
-Definition subseqs {T} (s: seq T): seq (T * seq T) :=
-  match s with
-  | [::] => [::]
-  | m :: r => subseqs_rec [::] m r
-  end.
-
-(* Return the linear combination that defines f(x) *)
-
-Definition lagrange_poly {R: unitRingType} (pts: seq (R * R)): {poly R} :=
-  \sum_(j <- subseqs pts) lagrange_poly_part j.
-
-(**
-  Then we prove some fundamental properties of Lagrange Interpolation.
-  Specifically:
-  - [size_lagrange_poly]: The size of a Lagrange polynomial is [<= size pts].
-  - [lagrange_poly_correct]: Evaluating a Lagrange polynomial at a point gives the corresponding y value.
-  - [lagrange_poly_unique]: There is exactly one polynomial with size [<= size pts], 
-    that satisfies [lagrange_poly_correct].
-
-  These together formalise Theorem 3.8 and 3.9 from the book
-*)
-
-(* If we evaluate l_i(x) for any of the points used to build it, we obtain 0 *)
-Lemma lagrange_basis_0 {R: comUnitRingType} (x1 x: R) (s: seq R):
-  x \in s ->
-  (lagrange_basis s x1).[x] = 0.
-Proof.
-  rewrite /lagrange_basis.
-  elim: s => [// | a s IHs].
-  rewrite in_cons big_cons hornerM hornerZ !horner_cons hornerC GRing.mul0r GRing.add0r GRing.mul1r.
-  destruct (x == a) eqn:Heq.
-  - move /eqP in Heq.
-    by rewrite Heq GRing.subrr GRing.mulr0 GRing.mul0r.
-  - move=> H.
-    by rewrite IHs // GRing.mulr0.
-Qed.
-
-(* If we evaluate l_i(x) for the point x_i we obtain 1 *)
-Lemma lagrange_basis_1 {R: fieldType} (x: R) (s: seq R):
-  (x \notin s) = ((lagrange_basis s x).[x] == 1).
-Proof.
-  rewrite /lagrange_basis.
-  elim: s => [|a s IHs].
-  1: by rewrite big_nil hornerC eq_refl.
-  rewrite in_cons big_cons hornerM hornerZ !horner_cons hornerC GRing.mul0r GRing.add0r GRing.mul1r.
-  destruct (x == a) eqn:Heq.
-  - move /eqP in Heq.
-    by rewrite Heq GRing.subrr GRing.mulr0 GRing.mul0r eq_sym GRing.oner_eq0.
-  - apply negbT in Heq.
-    rewrite -GRing.subr_eq0 in Heq.
-    by rewrite GRing.mulVf // GRing.mul1r IHs.
-Qed.
-
-(* The size of l_i(x) polynomial is <= size of the sequence is built uppon. *)
-Lemma size_lagrange_basis {R: fieldType} (x: R) (s: seq R):
-  (size (lagrange_basis s x) <= S (size s))%N.
-Proof.
-  rewrite /lagrange_basis.
-  elim: s => [|a s IHs].
-  1: by rewrite big_nil size_poly1.
-  rewrite big_cons.
-  destruct (x == a) eqn:Heq.
-  1: {
-    move /eqP in Heq.
-    by rewrite Heq GRing.subrr GRing.invr0 -mul_polyC polyC0 !GRing.mul0r size_poly0.
-  }
-  apply negbT in Heq.
-  apply: leq_trans.
-  1: by apply: size_mul_leq.
-  rewrite size_scale.
-  - by rewrite (@PolyK R 0) // GRing.oner_neq0.
-  - by rewrite GRing.invr_neq0 // GRing.subr_eq0.
-Qed.
-
-Definition dif_points {A : eqType} { B : Type} (l : seq (A * B)) := (uniq (unzip1 l)).
-
-
-Ltac simpl_dif_point :=
-  rewrite /dif_points /unzip1 ?map_cons ?map_cat ?cons_uniq -?/unzip1.
-
-(*
-   Proof that when we contruct (partially) our polynomial, the evaluation for an x_i in the list is
-   zero.
-*)
-Lemma lagrange_poly_part_0 {R : fieldType} (x: R) (l : seq (R * R)) m r:
-  x \in unzip1 l ->
-  (\sum_(j <- subseqs_rec l m r) lagrange_poly_part j).[x] = 0.
-Proof.
-  elim: r l m => [|m' r IHr] l [x0 y0] Hin.
-  1: by rewrite big_seq1 hornerZ lagrange_basis_0 ?GRing.mulr0.
-  rewrite /= big_cons hornerD hornerZ.
-  rewrite lagrange_basis_0 ?IHr ?GRing.mulr0 ?GRing.add0r //.
-  all: simpl_dif_point; by rewrite mem_cat Hin.
-Qed.
-
-Lemma uniq_unzip1_in {S T: eqType} (a: S * T) (s: seq (S * T)):
-  dif_points (a :: s) ->
-  a.1 \notin unzip1 s.
-Proof.
-  unfold dif_points. simpl_dif_point.
-  by move => /andP [].
-Qed.
-
-(**
-   If we have a list of different points (l ++ m :: r) and (x, y) \in m::r
-   we have that the sum over the j <- (subseqs_rec l m r) of the l_j(x) when 
-   evaluated in x is equal to y. 
-*)
-Lemma lagrange_poly_part_correct {R: fieldType} (x y: R) l m r:
-  dif_points (l ++ (m :: r)) ->
-  (x, y) \in m :: r ->
-  (\sum_(j <- subseqs_rec l m r) lagrange_poly_part j).[x] = y.
-Proof.
-  elim: r l m => [|m' r IHr] l [x0 y0] Huniq Hin.
-  1: {
-    rewrite big_seq1 hornerZ.
-    rewrite mem_seq1 in Hin.
-    move /eqP in Hin.
-    case: Hin => -> ->.
-    move: Huniq. simpl_dif_point.
-    rewrite uniq_catC -/unzip1 /= => Huniq.
-    move: Huniq => /andP [Hnotin Huniq].
-    rewrite lagrange_basis_1 in Hnotin.
-    move /eqP in Hnotin.
-    by rewrite Hnotin GRing.mulr1.
-  }
-  rewrite /= big_cons hornerD hornerZ.
-  rewrite in_cons in Hin.
-  move: Hin => /orP [/eqP Heq|Hin].
-  1: {
-    case: Heq => -> ->.
-    rewrite lagrange_poly_part_0 ?GRing.addr0 //.
-    2: by rewrite /unzip1 map_cat mem_cat Bool.orb_comm mem_seq1 eq_refl.
-    rewrite /dif_points /unzip1 map_cat uniq_catC -map_cat cat_cons -/unzip1 in Huniq.
-    apply (uniq_unzip1_in (x0, y0)) in Huniq.
-    rewrite /unzip1 map_cat mem_cat Bool.orb_comm -mem_cat -map_cat -/unzip1 in Huniq.
-    rewrite lagrange_basis_1 /= in Huniq.
-    move /eqP in Huniq.
-    by rewrite Huniq GRing.mulr1.
-  }
-  rewrite IHr //.
-  2: by rewrite -catA cat_cons.
-  rewrite lagrange_basis_0 ?GRing.mulr0 ?GRing.add0r //.
-  apply (map_f fst) in Hin.
-  by rewrite /unzip1 map_cat mem_cat Bool.orb_comm Hin.
-Qed.
-
-(**
-   Proof that the size of a Lagrange polynomial is [<= size pts] for
-   the second recursive case. 
-*)
-Lemma size_lagrange_poly_part {R: fieldType} l (m: R * R) r:
-  (size (\sum_(j <- subseqs_rec l m r) lagrange_poly_part j)%R <= size (l ++ m :: r))%N.
-Proof.
-  generalize dependent m.
-  generalize dependent l.
-  elim: r => /= [|m' r IHr] l m.
-  1: {
-    rewrite big_seq1 size_cat addn1.
-    apply: leq_trans.
-    1: by apply: size_scale_leq.
-    apply: leq_trans.
-    - by apply: size_lagrange_basis.
-    - by rewrite /unzip1 size_map ltnSn.
-  }
-  rewrite big_cons.
-  apply: leq_trans.
-  1: by apply: size_add.
-  rewrite geq_max.
-  apply /andP.
-  split.
-  - rewrite /lagrange_poly_part /=.
-    apply: leq_trans.
-    1: by apply: size_scale_leq.
-    replace (size (l ++ [:: m, m' & r])) with (size (unzip1 (l ++ [:: m' & r]))).+1.
-    1: by apply: size_lagrange_basis.
-    by rewrite /unzip1 size_map !size_cat -addnS.
-  - replace (size (l ++ [:: m, m' & r])) with (size ((l ++ [:: m]) ++ m' :: r)).
-    1: by apply: IHr.
-    by rewrite !size_cat addn1 !addnS.
-Qed.
-
-(* The size of a Lagrange polynomial is [<= size pts]. *)
-Lemma size_lagrange_poly {R: fieldType} (pts: seq (R * R)):
-  (size (lagrange_poly pts) <= size pts)%N.
-Proof.
-  case: pts => [|m r].
-  - by rewrite /lagrange_poly big_nil size_poly0.
-  - by apply: (size_lagrange_poly_part [::]).
-Qed.
-
-(* Evaluating a Lagrange polynomial at a point gives the corresponding y value. *)
-Lemma lagrange_poly_correct {R: fieldType} (x y: R) pts:
-  dif_points pts ->
-  (x, y) \in pts ->
-  (lagrange_poly pts).[x] = y.
-Proof.
-  case: pts => [// | m r] Huniq Hin.
-  by apply: lagrange_poly_part_correct.
-Qed.
-
-(**
-   There is exactly one polynomial with size [<= size pts], that satisfies [lagrange_poly_correct].
-   This is a stronger version of Theorem 3.9 of the book.
-*)
-Lemma lagrange_poly_unique {R: fieldType} (pts: seq (R * R)) (q: {poly R}):
-  dif_points pts ->
-  (size q <= size pts)%N ->
-  (forall x y, (x, y) \in pts -> q.[x] = y) ->
-  q = lagrange_poly pts.
-Proof.
-  move=> Huniq Hsize1 Hpred.
-  assert (size (q - lagrange_poly pts)%R <= size pts)%N as Hsize.
-  1: {
-    move: (size_lagrange_poly pts) => Hsize2.
-    apply: leq_trans.
-    1: apply: size_add.
-    by rewrite geq_max size_opp Hsize1 Hsize2.
-  }
-  apply /eqP.
-  rewrite -GRing.subr_eq0 -size_poly_eq0.
-  rewrite size_poly_eq0.
-  apply /negPn /negP => Hcontra.
-  rewrite leqNgt in Hsize.
-  move /negP in Hsize.
-  apply: Hsize.
-  replace (size pts) with (size (unzip1 (pts))).
-  2: by rewrite size_map.
-  apply: max_poly_roots => //.
-  apply /allP => x' /mapP [[x y] Hin Heq].
-  subst.
-  rewrite /root hornerD hornerN.
-  rewrite (Hpred x y) //.
-  rewrite (lagrange_poly_correct x y) //.
-  by rewrite GRing.subr_eq0 eq_refl.
-Qed.
-
-(**
-  We also prove some useful properties for how Lagrange polynomials behave when
-  added or subtracted, specifically with regards to points with [y = 0], which
-  are defined by [zero_points].
-  Specifically:
-  - [lagrange_sub_zero_cons]: Subtracting Langrange polynomials with similar points.
-  - [lagrange_add_zero_cons]: Adding Langrange polynomials where all but one points have [y = 0].
-  - [lagrange_zero]: Evaluating Lagrange polynomials where all points have [y = 0].
-*)
-Definition zero_points {R: ringType} (s: seq R): seq (R * R) :=
-  [seq (x, 0) | x <- s ].
-
-Lemma unzip1_zero_points {R: ringType} (s: seq R):
-  unzip1 (zero_points s) = s.
-Proof.
-  rewrite /unzip1 /zero_points.
-  elim: s => [// | a s IHs].
-  by rewrite !map_cons IHs.
-Qed.
-
-Lemma x_in_zero_points {R: ringType} (x y: R) (s: seq R):
-  (x, y) \in zero_points s ->
-  x \in s.
-Proof.
-  rewrite /zero_points.
-  elim: s => [// | a s IHs] H.
-  rewrite in_cons.
-  rewrite map_cons in_cons xpair_eqE in H.
-  destruct (x == a) eqn:Heq => //=.
-  by apply: IHs.
-Qed.
-
-Lemma y_in_zero_points {R: ringType} {x y: R} {s: seq R}:
-  (x, y) \in zero_points s ->
-  y = 0.
-Proof.
-  rewrite /zero_points.
-  elim: s => [// | a s IHs] H.
-  rewrite map_cons in_cons in H.
-  destruct ((x, y) == (a, 0)) eqn:Heq.
-  - move /eqP in Heq.
-    by case: Heq.
-  - by apply: IHs.
-Qed.
-
-Lemma pt_in_zero_points {R: ringType} {x: R} {s: seq R}:
-  x \in s ->
-  (x, 0) \in zero_points s.
-Proof.
-  rewrite /zero_points.
-  elim: s => [// | a s IHs] H /=.
-  rewrite in_cons in H.
-  rewrite in_cons.
-  destruct (x == a) eqn:Heq.
-  - move /eqP in Heq.
-    by rewrite Heq eq_refl.
-  - by rewrite xpair_eqE Heq IHs.
-Qed.
-
-Lemma lagrange_sub_zero {R: fieldType} (x: R) (l1 l2 r: seq (R * R)):
-  dif_points (l1 ++ r) ->
-  dif_points (l2 ++ r) ->
-  x \in unzip1 r ->
-  (lagrange_poly (l1 ++ r) - lagrange_poly (l2 ++ r)).[x] = 0.
-Proof.
-  rewrite hornerD hornerN.
-  generalize dependent l2.
-  generalize dependent l1.
-  elim: r => [// | a r IHr] l1 l2 Huniq1 Huniq2 Hin.
-  rewrite /= in_cons in Hin.
-  destruct (x == a.1) eqn:Heq.
-  - move /eqP in Heq.
-    rewrite Heq (lagrange_poly_correct a.1 a.2) //.
-    1: rewrite (lagrange_poly_correct a.1 a.2) ?GRing.subrr //.
-    all: by rewrite -surjective_pairing mem_cat in_cons eq_refl Bool.orb_true_r.
-  - rewrite -!cat_rcons -!cats1 in Huniq1 Huniq2*.
-    by apply: IHr.
-Qed.
-
-Lemma lagrange_sub_zero_cons {R: fieldType} (x y1 y2: R) (pts: seq (R * R)):
-  uniq (x :: unzip1 pts) ->
-  lagrange_poly ((x, y1) :: pts) - lagrange_poly ((x, y2) :: pts) =
-  lagrange_poly ((x, y1 - y2) :: zero_points (unzip1 pts)).
-Proof.
-  move=> Huniq.
-  apply: lagrange_poly_unique.
-  - simpl_dif_point. by rewrite unzip1_zero_points.
-  - apply: leq_trans.
-    1: by apply: size_add.
-    rewrite size_opp /= !size_map geq_max.
-    apply /andP.
-    split.
-    all: apply: leq_trans.
-    1,3: by apply: size_lagrange_poly.
-    all: by [].
-  - move=> x0 y0 Hin.
-    rewrite in_cons in Hin.
-    destruct (_ == _) eqn:Heq.
-    + move /eqP in Heq.
-      case: Heq => ? ?.
-      subst.
-      rewrite hornerD hornerN (lagrange_poly_correct x y1) //.
-      1: rewrite (lagrange_poly_correct x y2) //.
-      all: by rewrite in_cons eq_refl.
-    + rewrite (y_in_zero_points Hin).
-      rewrite -!(cat1s _ pts).
-      apply: lagrange_sub_zero => //.
-      by apply: (x_in_zero_points x0 y0).
-Qed.
-
-Lemma lagrange_add_zero {R: fieldType} (x: R) (l1 l2: seq (R * R)) (r: seq R):
-  dif_points (l1 ++ zero_points r) ->
-  dif_points (l2 ++ zero_points r) ->
-  x \in r ->
-  (lagrange_poly (l1 ++ zero_points r) + lagrange_poly (l2 ++ zero_points r)).[x] = 0.
-Proof.
-  rewrite hornerD.
-  generalize dependent l2.
-  generalize dependent l1.
-  elim: r => [// | a r IHr] l1 l2 Huniq1 Huniq2 Hin.
-  rewrite /= in_cons in Hin.
-  destruct (x == a) eqn:Heq.
-  - move /eqP in Heq.
-    rewrite Heq (lagrange_poly_correct a 0) //.
-    1: rewrite (lagrange_poly_correct a 0) ?GRing.addr0 //.
-    all: by rewrite mem_cat in_cons eq_refl Bool.orb_true_r.
-  - rewrite -!cat_rcons -!cats1 in Huniq1 Huniq2 *.
-    by apply: IHr.
-Qed.
-
-
-Lemma lagrange_add_zero_cons {R: fieldType} (x y1 y2: R) (s: seq R):
-  uniq (x :: s) ->
-  lagrange_poly ((x, y1) :: zero_points s) +
-  lagrange_poly ((x, y2) :: zero_points s) =
-  lagrange_poly ((x, y1 + y2) :: zero_points s).
-Proof.
-  move=> Huniq.
-  apply: lagrange_poly_unique.
-  - simpl_dif_point. by rewrite unzip1_zero_points.
-  - apply: leq_trans.
-    1: by apply: size_add.
-    rewrite /= !size_map geq_max.
-    apply /andP.
-    split.
-    all: apply: leq_trans.
-    1,3: by apply: size_lagrange_poly.
-    all: by rewrite /= size_map.
-  - move=> x0 y0 Hin.
-    rewrite in_cons in Hin.
-    destruct (_ == _) eqn:Heq.
-    + move /eqP in Heq.
-      case: Heq => ? ?.
-      subst.
-      rewrite hornerD (lagrange_poly_correct x y1) //.
-      1: rewrite (lagrange_poly_correct x y2) //.
-      2,4: by rewrite in_cons eq_refl.
-      all: simpl_dif_point; by rewrite unzip1_zero_points.
-    + rewrite (y_in_zero_points Hin).
-      rewrite -!(cat1s _ (zero_points s)).
-      apply: lagrange_add_zero.
-      3: by apply: (x_in_zero_points x0 y0).
-      all: simpl_dif_point; by rewrite unzip1_zero_points.
-Qed.
-
-Lemma lagrange_zero {R: fieldType} (s: seq R):
-  uniq s ->
-  lagrange_poly (zero_points s) = 0.
-Proof.
-  move=> Huniq.
-  symmetry.
-  apply: lagrange_poly_unique.
-  - simpl_dif_point. by rewrite unzip1_zero_points.
-  - by rewrite polyseq0.
-  - move=> x y Hin.
-    rewrite hornerC.
-    by rewrite (y_in_zero_points Hin).
-Qed.
-
-(**
-  We also define some functions that lets us treat polynomials like lists ending
-  in infinite zeroes, and prove some useful lemmas that they do indeed behave
-  like lists.
-*)
-Definition head_poly {R: ringType} (q: {poly R}): R := q`_0.
-Definition tail_poly {R: ringType} (q: {poly R}): {poly R} := Poly (behead q).
-
-Lemma head_cons_poly {R: ringType} (a: R) (q: {poly R}):
-  head_poly (cons_poly a q) = a.
-Proof.
-  by rewrite /head_poly coef_cons.
-Qed.
-
-Lemma tail_cons_poly {R: ringType} (a: R) (q: {poly R}):
-  tail_poly (cons_poly a q) = q.
-Proof.
-  rewrite /tail_poly polyseq_cons.
-  destruct (nilp q) eqn:Heq => /=.
-  2: by rewrite polyseqK.
-  rewrite /nilp size_poly_eq0 in Heq.
-  move /eqP in Heq.
-  rewrite Heq polyseqC.
-  by case: (a != 0).
-Qed.
-
-Lemma size_tail_poly {R: ringType} (q: {poly R}):
-  size (tail_poly q) = (size q).-1.
-Proof.
-  rewrite /tail_poly.
-  case: q => [[|a s] /= Hs].
-  - by rewrite polyseq0.
-  - by rewrite (PolyK Hs).
-Qed.
-
-Lemma last_neq_0 {R: ringType} (a: R) (s: seq R):
-  (last a s != 0 -> last 1 s != 0).
-Proof.
-  case: s => H //=.
-  by apply: GRing.oner_neq0.
-Qed.
-
-Lemma cons_head_tail_poly {R: ringType} (q: {poly R}):
-  cons_poly (head_poly q) (tail_poly q) = q.
-Proof.
-  apply: poly_inj.
-  rewrite /head_poly /tail_poly polyseq_cons.
-  case: q => [[|a s] /= Hs].
-  1: by rewrite polyseq0.
-  rewrite (PolyK Hs).
-  destruct s => //=.
-  by rewrite polyseqC Hs.
-Qed.
-
-Lemma cons_eq_head_tail_poly {R: ringType} (a: R) (q: {poly R}):
-  a = head_poly q ->
-  cons_poly a (tail_poly q) = q.
-Proof.
-  move=> H.
-  by rewrite H cons_head_tail_poly.
-Qed.
-
-(**
-  Proof that two polynomials are equal if, and only if, all their
-  coefficients are equal.
-
-  Used to prove how [tail_poly] and [cons_poly] behaves when added
-  and negated.
-*)
-Lemma coef_poly_eq {R: ringType} (q1 q2: {poly R}):
-  (forall i, q1`_i = q2`_i) <-> q1 = q2.
-Proof.
-  split=> H.
-  2: by rewrite H.
-  apply: poly_inj.
-  move: H.
-  case: q2.
-  case: q1.
-  elim=> [|a1 s1 IHs1] Hs1 [|a2 s2 ] //= Hs2 H.
-  - move /eqP in Hs2.
-    destruct Hs2. specialize (H (size s2)).
-    rewrite nth_nil nth_last in H.
-    by rewrite H.
-  - move /eqP in Hs1.
-    destruct Hs1. specialize (H (size s1)).
-    rewrite nth_nil nth_last in H.
-    by rewrite -H.
-  - move: (fun i => H i.+1) => HS.
-    specialize (H 0%N). simpl in *.
-    rewrite H. f_equal.
-    apply: IHs1 => //.
-    all: apply: last_neq_0.
-    + by apply: Hs1.
-    + by apply: Hs2.
-Qed.
-
-Lemma tail_poly_add {R: ringType} (q1 q2: {poly R}):
-  tail_poly (q1 + q2) = tail_poly q1 + tail_poly q2.
-Proof.
-  apply coef_poly_eq => i.
-  by rewrite coefD !coef_Poly !nth_behead coefD.
-Qed.
-
-Lemma cons_poly_add {R: ringType} (m m': R) (q1 q2: {poly R}):
-  (cons_poly m' (q1 + q2) = (cons_poly m q1) + cons_poly (m'-m) q2)%R.
-Proof.
-  apply coef_poly_eq => i.
-  rewrite coefD !coef_cons coefD.
-  case: i => //=.
-  by rewrite GRing.addrC -GRing.addrA GRing.addNr GRing.addr0.
-Qed.
-
 Local Open Scope nat_scope.
 
-(**
-  With the work on polynomials out of the way we can start to actually define
-  the scheme.
-*)
 Section ShamirSecretSharing_example.
 
-(**
-  [p] is the number of possible messages. It is is a [prime]. *)
 Variable (p: nat).
 
 Context (p_prime: prime p).
 
-(**
-  We have to use [(Zp_trunc (pdiv p)).+2] for [Word] to be considered a field.
-  This is important for uniqueness of Lagrange polynomials.
-*)
+(* We have to use [(Zp_trunc (pdiv p)).+2] for [Word] to be considered a      *)
+(* field. This is important for uniqueness of Lagrange polynomials.           *)
 
 Definition Word_N := (Zp_trunc (pdiv p)).+2.
 Definition Word := 'fin Word_N.
@@ -660,9 +101,7 @@ Proof.
   by apply: Fp_cast.
 Qed.
 
-(**
-  Shares are simply a point in ['F_p], i.e. a pair.
-*)
+(* Shares are simply a point in ['F_p], i.e. a pair.                          *)
 Definition Share: choice_type := Word × Word.
 
 Notation " 'word " := (Word) (in custom pack_type at level 2).
@@ -671,48 +110,37 @@ Notation " 'word " := (Word) (at level 2): package_scope.
 Notation " 'share " := (Share) (in custom pack_type at level 2).
 Notation " 'share " := (Share) (at level 2): package_scope.
 
-(**
-  We can't use sequences directly in [choice_type] so instead we use a map from
-  natural numbers to the type.
-*)
+(* We can't use sequences directly in [choice_type] so instead we use a map   *)
+(* from natural numbers to the type.                                          *)
+
 Definition chSeq t := chMap 'nat t.
 
 Notation " 'seq t " := (chSeq t) (in custom pack_type at level 2).
 Notation " 'seq t " := (chSeq t) (at level 2): package_scope.
 
-(**
-  We can't use sets directly in [choice_type] so instead we use a map to units.
-  We can then use [domm] to get the domain, which is a set.
-*)
+(* We can't use sets directly in [choice_type] so instead we use a map to     *)
+(* units. We can then use [domm] to get the domain, which is a set.           *)
+
 Definition chSet t := chMap t 'unit.
 
 Notation " 'set t " := (chSet t) (in custom pack_type at level 2).
 Notation " 'set t " := (chSet t) (at level 2): package_scope.
 
-(**
-  [n] is the number of shares.
-  It is always positive.
-*)
+(* [n] is the number of shares.                                               *)
 Variable (n: nat).
 Context (n_positive: Positive n).
 
-(**
-  We cannot possibly have more than [p-1] shares.
-*)
+(* We cannot possibly have more than [p-1] shares.                            *)
 Context (n_ltn_p: n < p).
 
-(**
-  Each party gets a share.
-  We use a finity type to represent parties as it makes later proofs easier.
-*)
+(* Each party gets a share. We use a finity type to represent parties as it   *)
+(* makes later proofs easier.                                                 *)
 Definition Party := 'fin n.
 
 Notation " 'party " := (Party) (in custom pack_type at level 2).
 Notation " 'party " := (Party) (at level 2): package_scope.
 
-(**
-  The share of each party is the point with [x = 1 + the party index].
-*)
+(* The share of each party is the point with [x = 1 + the party index].       *)
 #[program]
 Definition party_to_word (x: Party): Word := @Ordinal _ x.+1 _.
 Next Obligation.
@@ -723,44 +151,16 @@ Next Obligation.
   by rewrite ltnS.
 Qed.
 
-(**
-  Finally we can define how actual shares are computed.
-  They are simply points on a polynomial [q].
-*)
+(* Shares are points on a polynomial [q].                                     *)
 Definition make_share (q: {poly Word}) (x: Party): Share :=
   (party_to_word x, q.[party_to_word x]).
 
-(**
-  This is a convenience function for computing the shares for a message [m].
-  [q] is a randomly sampled polynomial.
-*)
+(* This is a convenience function for computing the shares for a message [m]. *)
+(* [q] is a randomly sampled polynomial.                                      *)
 Definition make_shares (m: Word) (q: {poly Word}) (U: seq Party): seq Share :=
   map (make_share (cons_poly m q)) U.
 
-(**
-  In order to prove security in SSProve we need to define a bijection for the random polynomials q.
-  To satisfy the security property, the bijection must compute a q_r from any q_l, such that:
-    
-    m_l + i * q_l(i) = m_r + i * q_r(i) for i \in U
-  
-  To do this, we compute the set of shares, S, as the corresponding points of the polynomial
-  f_l(x) = m_l + x * q_l(x), that is: s_i = (i, f_l(i)) for i \in U.
-  
-  Next, we compute the Lagrange interpolations of {(0, ml)} ∪ S and {(0, mr)} ∪ S, respectively called
-  g_l  and g_r. Since g_l(0) = m_l, we know the first coefficeint of g_l is m_l. Similarly, the first 
-  coefficient of g_r is m_r. We can then define:
-
-    f_r(x) = f_l(x) + g_r(x) - g_l(x) = m_l + m_r - m_l + x * q_r(x) = m_r + x * q_r(x)
-
-  It is secure, because [make_shares m' q' U] will yield the same result as the original
-  [make shares m q U].
-
-  It is a bijection, because we can compute [sh] from [q'], from which we can
-  compute [g] and [g'], from which [q = q' - tail_poly (g' - g)]. Therefore, there is an inverse.
-
-  [sec_poly_bij] and [bij_poly_bij] simply formalise the above intuitions.
-*)
-
+(* Bijection *)
 Definition poly_bij (U: seq Party) (m m': Word) (q: {poly Word}): {poly Word} :=
   let sh := make_shares m q U in
   let g  := lagrange_poly ((0%R, m ) :: sh) in
@@ -828,6 +228,11 @@ Proof.
   by rewrite IHu.
 Qed.
 
+(*Ask why this is not imported*)
+Ltac simpl_dif_point :=
+  rewrite /dif_points /unzip1 ?map_cons ?map_cat ?cons_uniq -?/unzip1.
+
+
 Lemma sec_poly_bij_part (x: Party) (U: seq Party) (m m': Word) (q: {poly Word}):
   uniq U ->
   x \in U ->
@@ -841,11 +246,13 @@ Proof.
   2: {
     rewrite /head_poly -horner_coef0.
     rewrite (lagrange_poly_correct 0 (m' - m)) //.
-    - simpl_dif_point. by rewrite unzip1_zero_points no_zero_share uniq_make_shares.
+    - simpl_dif_point. 
+      by rewrite unzip1_zero_points no_zero_share uniq_make_shares.
     - by rewrite in_cons eq_refl.
   }
   rewrite (lagrange_poly_correct (party_to_word x) 0%R) ?GRing.addr0 //.
-  - simpl_dif_point. by rewrite unzip1_zero_points no_zero_share uniq_make_shares.
+  - simpl_dif_point. 
+    by rewrite unzip1_zero_points no_zero_share uniq_make_shares.
   - by rewrite in_cons pt_in_zero_points ?Bool.orb_true_r // in_make_shares.
 Qed.
 
@@ -895,19 +302,7 @@ Proof.
   by rewrite /Positive expn_gt0 prime_gt0.
 Qed.
 
-(**
-  [PolyEnc] is an isomorphism we use to be able to represent polynomials in SSProve.
-  SSProve does not support using polynomials directly.
-  There are [p^t] polynomials of size [<= t] over the field ['F_p].
-
-  We want to sample [q] uniformly, but this is not directly possible in SSProve.
-  Instead we sample from [PolyEnc t] which is isomorphic to polynomials of
-  size [<= t] over ['F_p].
-
-  We then define a bijection between polynomials and [PolyEnc t] and vice versa.
-  Finally we combine all three bijections to create a bijection from [PolyEnc t]
-  to [PolyEnc t] that we can use to prove security of the protocol.
-*)
+(* Representation of polynomials for SSProve*)
 Definition PolyEnc t := 'fin (p ^ t).
 
 #[program] Definition mod_p (a: nat): Word :=
@@ -986,18 +381,11 @@ Proof.
   destruct (size q) eqn:P; by rewrite P.
 Qed.
 
-(**
-  [t] is the number of shares needed for reconstruction.
-  [t'] is the maximum number of shares the scheme is secure against. This
-  happens to often be the number we actually care about so we will frequently
-  use it directly.
-*)
 Variable (t': nat).
 Definition t := t'.+1.
 
-(**
-  This is the final bijection used to. We prove to analogus lemmas as the ones stated above.
-*)
+(* This is the final bijection explained in the header. We prove the          *)
+(* analogus lemmas as the ones stated above.                                  *)
 #[program]
 Definition share_bij (U: seq Party) (m m': Word) (c: PolyEnc t'): PolyEnc t' :=
   @Ordinal _ (poly_to_nat t' (poly_bij U m m' (nat_to_poly t' c))) _.
@@ -1030,6 +418,7 @@ Qed.
 
 Local Open Scope package_scope.
 
+(*  Identifier of the signature *)
 Definition shares : nat := 0.
 
 Definition mkpair {Lt Lf E}

--- a/theories/Crypt/examples/ShamirSecretSharing.v
+++ b/theories/Crypt/examples/ShamirSecretSharing.v
@@ -695,6 +695,7 @@ Notation " 'set t " := (chSet t) (at level 2): package_scope.
   It is always positive.
 *)
 Variable (n: nat).
+Context (n_positive: Positive n).
 
 (**
   We cannot possibly have more than [p-1] shares.
@@ -886,6 +887,13 @@ Proof.
   rewrite lagrange_zero.
   2: by rewrite /= no_zero_share uniq_make_shares.
   by rewrite /tail_poly polyseq0 GRing.addr0.
+Qed.
+
+
+Instance p_pow_positive t:
+  Positive (p ^ t).
+Proof.
+  by rewrite /Positive expn_gt0 prime_gt0.
 Qed.
 
 (**

--- a/theories/Crypt/examples/ShamirSecretSharing.v
+++ b/theories/Crypt/examples/ShamirSecretSharing.v
@@ -228,11 +228,6 @@ Proof.
   by rewrite IHu.
 Qed.
 
-(*Ask why this is not imported*)
-Ltac simpl_dif_point :=
-  rewrite /dif_points /unzip1 ?map_cons ?map_cat ?cons_uniq -?/unzip1.
-
-
 Lemma sec_poly_bij_part (x: Party) (U: seq Party) (m m': Word) (q: {poly Word}):
   uniq U ->
   x \in U ->

--- a/theories/Crypt/examples/ShamirSecretSharing.v
+++ b/theories/Crypt/examples/ShamirSecretSharing.v
@@ -180,21 +180,18 @@ Definition dif_points {A : eqType} { B : Type} (l : seq (A * B)) := (uniq (unzip
 Ltac simpl_dif_point :=
   rewrite /dif_points /unzip1 ?map_cons ?map_cat ?cons_uniq -?/unzip1.
 
-(* Assuming that all the x_i in l m & r are different(uniq (unzip1 (l ++ (m :: r))))*)
-
-(* WARNING possible extra hypothesis: consult *)
-
-(* When x is not a point in the list l, (...)*)
+(*
+   Proof that when we contruct (partially) our polynomial, the evaluation for an x_i in the list is
+   zero.
+*)
 Lemma lagrange_poly_part_0 {R : fieldType} (x: R) (l : seq (R * R)) m r:
-  (*dif_points (l ++ (m :: r)) ->*)
   x \in unzip1 l ->
   (\sum_(j <- subseqs_rec l m r) lagrange_poly_part j).[x] = 0.
 Proof.
-  elim: r l m => [|m' r IHr] l [x0 y0] (*Huniq*) Hin.
+  elim: r l m => [|m' r IHr] l [x0 y0] Hin.
   1: by rewrite big_seq1 hornerZ lagrange_basis_0 ?GRing.mulr0.
   rewrite /= big_cons hornerD hornerZ.
   rewrite lagrange_basis_0 ?IHr ?GRing.mulr0 ?GRing.add0r //.
-  (*1: by rewrite -catA cat_cons.*)
   all: simpl_dif_point; by rewrite mem_cat Hin.
 Qed.
 

--- a/theories/Crypt/examples/ShamirSecretSharing.v
+++ b/theories/Crypt/examples/ShamirSecretSharing.v
@@ -302,6 +302,10 @@ Proof.
   by rewrite /Positive expn_gt0 prime_gt0.
 Qed.
 
+(******************************************************************************)
+(**************Definition and lemmas for polynomials in SSProve****************)
+(******************************************************************************)
+
 (* Representation of polynomials for SSProve*)
 Definition PolyEnc t := 'fin (p ^ t).
 
@@ -416,6 +420,10 @@ Proof.
   by rewrite bij_poly_bij ?nat_poly_nat.
 Qed.
 
+(******************************************************************************)
+(********************Definition of the games.**********************************)
+(******************************************************************************)
+
 Local Open Scope package_scope.
 
 (*  Identifier of the signature *)
@@ -458,6 +466,10 @@ Definition SHARE_pkg_ff:
   ].
 
 Definition SHARE := mkpair SHARE_pkg_tt SHARE_pkg_ff.
+
+(******************************************************************************)
+(************Proof that the games are equivalent.******************************)
+(******************************************************************************)
 
 Lemma SHARE_equiv:
   SHARE true ≈₀ SHARE false.
@@ -503,9 +515,10 @@ Proof.
   by apply: rreflexivity_rule.
 Qed.
 
-(**
-  This corresponds to Theorem 3.13 from "The Joy of Cryptography".
-*)
+(******************************************************************************)
+(********Proof to the Theorem 3.13 from "The Joy of Cryptography".*************)
+(******************************************************************************)
+
 Theorem unconditional_secrecy LA A:
   ValidPackage LA
     [interface #val #[shares]: ('word × 'word) × 'set 'party → 'seq 'share ]

--- a/theories/Crypt/examples/ShamirSecretSharing.v
+++ b/theories/Crypt/examples/ShamirSecretSharing.v
@@ -620,13 +620,6 @@ Proof.
   by rewrite coefD !coef_Poly !nth_behead coefD.
 Qed.
 
-Lemma tail_poly_opp {R: ringType} (q: {poly R}):
-  tail_poly (-q) = -tail_poly q.
-Proof.
-  apply coef_poly_eq => i.
-  by rewrite coefN !coef_Poly !nth_behead coefN.
-Qed.
-
 Lemma cons_poly_add {R: ringType} (m m': R) (q1 q2: {poly R}):
   (cons_poly m' (q1 + q2) = (cons_poly m q1) + cons_poly (m'-m) q2)%R.
 Proof.
@@ -702,7 +695,6 @@ Notation " 'set t " := (chSet t) (at level 2): package_scope.
   It is always positive.
 *)
 Variable (n: nat).
-Context (n_positive: Positive n).
 
 (**
   We cannot possibly have more than [p-1] shares.
@@ -894,12 +886,6 @@ Proof.
   rewrite lagrange_zero.
   2: by rewrite /= no_zero_share uniq_make_shares.
   by rewrite /tail_poly polyseq0 GRing.addr0.
-Qed.
-
-Instance p_pow_positive t:
-  Positive (p ^ t).
-Proof.
-  by rewrite /Positive expn_gt0 prime_gt0.
 Qed.
 
 (**

--- a/theories/Crypt/examples/ShamirSecretSharing.v
+++ b/theories/Crypt/examples/ShamirSecretSharing.v
@@ -206,7 +206,7 @@ Lemma in_make_shares (x: Party) (U: seq Party) (m: Word) (q: {poly Word}):
 Proof.
   elim: U => [// | b U IHu] /=.
   rewrite in_cons.
-  destruct (x == b) eqn:Heq.
+  case Heq: (x == b).
   - move /eqP in Heq.
     by rewrite Heq in_cons !eq_refl.
   - by rewrite in_cons -val_eqE eqSS val_eqE Heq.
@@ -335,7 +335,7 @@ Proof.
   elim: t => [|t IHt] /= in a*.
   1: by rewrite size_poly0.
   rewrite size_cons_poly.
-  destruct (_ && _) => //.
+  case: (_ && _) => //.
   by rewrite ltnS.
 Qed.
 
@@ -354,7 +354,7 @@ Lemma nat_poly_nat (t a: nat):
   poly_to_nat t (nat_to_poly t a) = a.
 Proof.
   elim: t a => [|t IHt] a H.
-  1: by destruct a.
+  1: by move: H; case a.
   rewrite expnS mulnC in H.
   rewrite /= head_cons_poly tail_cons_poly IHt -?divn_eq //.
   by rewrite ltn_divLR // prime_gt0.
@@ -372,12 +372,13 @@ Proof.
   rewrite /= mod_p_muln_p.
   rewrite divnMDl ?prime_gt0 // divn_small.
   2: {
-    destruct (head_poly q) as [c Hc] => /=.
+    case (head_poly q) as [c Hc] => /=.
     by rewrite -words_p_eq.
   }
   rewrite addn0 IHt ?cons_head_tail_poly //.
   rewrite size_tail_poly.
-  destruct (size q) eqn:P; by rewrite P.
+  move: (size q) H => size_q. 
+  case size_q => [| IHsize_q'] H; exact H.
 Qed.
 
 Variable (t': nat).
@@ -486,28 +487,26 @@ Proof.
   case: m => [[ml mr] U].
 
   (* Perform case analysis over the following inequality *)
-  destruct (t <= size (domm U)) eqn:Heq; rewrite Heq.
+  case Hsize: (t <= size (domm U)).
+  (*destruct (t <= size (domm U)) eqn:Heq; rewrite Heq.*)
   (* First case is very easy since we return emptym in both cases *)
-  1: apply: rreflexivity_rule. 
+  - apply: rreflexivity_rule.
   
   (* t > size(domm U) *)
-  apply negbT in Heq.
-  rewrite -ltnNge ltnS in Heq.
+  - move: Hsize => /negbT. rewrite -ltnNge ltnS => Hsize.
   (**
      We need to prove it is bijective and that the operations performed after the sampling
      result in the program returning the same distribution of values. 
   *)
   apply: r_uniform_bij => [|q].
   (* Bijection *)
-  1: {
-    apply: (bij_share_bij (domm U) ml mr) => //.
-    by apply: uniq_fset.
-  }
-  (* Since there exists a bijection, we finish by proving that the last operations are
-     equivalent
-  *)
-  rewrite sec_share_bij ?uniq_fset //.
-  by apply: rreflexivity_rule.
+    + apply: (bij_share_bij (domm U) ml mr) => //.
+      by apply: uniq_fset.
+    (* Since there exists a bijection, we finish by proving that the last operations are
+      equivalent
+    *)
+    + rewrite sec_share_bij ?uniq_fset //.
+      by apply: rreflexivity_rule.
 Qed.
 
 (******************************************************************************)


### PR DESCRIPTION
I mostly added comments, but also a new definition for a recurrent pattern and a Ltac tactic associated with it. The `lagrange_poly_part_0` had an extra hypothesis that was not used in the proof, so I got rid of it. Same for some lemmas and definitions that were not used.