### PR TITLE
Make the CI jobs manually executable

### DIFF
--- a/.github/workflows/nix-action-8.18.yml
+++ b/.github/workflows/nix-action-8.18.yml
@@ -228,3 +228,4 @@ on:
   push:
     branches:
     - main
+  workflow_dispatch:

--- a/.github/workflows/nix-action-8.19.yml
+++ b/.github/workflows/nix-action-8.19.yml
@@ -228,3 +228,4 @@ on:
   push:
     branches:
     - main
+  workflow_dispatch:

--- a/.github/workflows/nix-action-8.20.yml
+++ b/.github/workflows/nix-action-8.20.yml
@@ -228,3 +228,4 @@ on:
   push:
     branches:
     - main
+  workflow_dispatch:

--- a/.github/workflows/nix-action-9.0.yml
+++ b/.github/workflows/nix-action-9.0.yml
@@ -228,3 +228,4 @@ on:
   push:
     branches:
     - main
+  workflow_dispatch:

--- a/.github/workflows/nix-action-MC-dev.yml
+++ b/.github/workflows/nix-action-MC-dev.yml
@@ -153,3 +153,4 @@ on:
   push:
     branches:
     - master
+  workflow_dispatch:

--- a/.nix/coq-overlays/ssprove/default.nix
+++ b/.nix/coq-overlays/ssprove/default.nix
@@ -14,7 +14,7 @@
 
   inherit version;
   defaultVersion = with lib.versions; lib.switch [coq.coq-version mathcomp-ssreflect.version] [
-    { cases = [(range "8.18" "8.20") "2.3.0"]; out = "0.2.3"; }
+    { cases = [(range "8.18" "9.0") (range "2.1.0" "2.4.0")]; out = "0.2.4"; }
     { cases = [(range "8.18" "8.20") (range "2.1.0" "2.2.0")]; out = "0.2.2"; }
     # This is the original dependency:
     # { cases = ["8.17" "1.18.0"]; out = "0.1.0"; }
@@ -28,6 +28,7 @@
 
   releaseRev = v: "v${v}";
 
+  release."0.2.4".sha256 = "sha256-uglr47aDgSkKi2JyVyN+2BrokZISZUAE8OUylGjy7ds=";
   release."0.2.3".sha256 = "sha256-Y3dmNIF36IuIgrVILteofOv8e5awKfq93S4YN7enswI=";
   release."0.2.2".sha256 = "sha256-tBF8equJd6hKZojpe+v9h6Tg9xEnMTVFgOYK7ZnMfxk=";
   release."0.2.1".sha256 = "sha256-X00q5QFxdcGWeNqOV/PLTOqQyyfqFEinbGUTO7q8bC4=";


### PR DESCRIPTION
Add back manual workflow triggers, these were removed by accident when updating Nix workflows in an earlier PR.

Also adds the 0.2.4 SSProve release to the Nix configuration.