### PR TITLE
Remove trim and internalize locations

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -407,7 +407,7 @@ of the export interface of `p₁` and when the sets of locations are compatible
 (given by `fcompat`, which is usually derived automatically).
 
 Parallel composition of (raw) packages `p₀` and `p₁` is written `par p₀ p₁`.
-It is valid if we have `fesparate p₀ p₁` and compatible sets of locations both
+It is valid if we have `fseparate p₀ p₁` and compatible sets of locations both
 of which are usually automatic.
 
 Finally, the identity package is defined as `ID I` where `I` is an interface.
@@ -516,7 +516,7 @@ AdvantageE (G₀ G₁ A : raw_package) : R
 The result is a real number, of type `R`.
 
 We also have an alternative version simply style `Advantage` which takes in a
-pair of games as a function `bool → raw_pacakge`: 
+pair of games as a function `bool → raw_package`: 
 
 ```coq
 Advantage (G : bool → raw_package) (A : raw_package) : R

--- a/DOC.md
+++ b/DOC.md
@@ -63,7 +63,7 @@ else (
 ```
 where `ℓ` is defined as
 ```coq
-Definition ℓ : Location := ('option 'nat ; 0).
+Definition ℓ : Location := (0, 'option 'nat).
 ```
 
 It first imports two procedures with respective identifiers `0` and `1` and
@@ -83,8 +83,8 @@ Injects any pure value into `raw_code`.
 
 #### Memory access
 
-A `Location` is a pair of a type in `choice_type` and a natural number
-representing an identifier, for instance `('nat ; 12) : Location`.
+A `Location` is a pair of a natural number representing an identifier
+and a type in `choice_type`, for instance `(12, 'nat) : Location`.
 One can *read* memory as follows:
 ```coq
 x ← get ℓ ;; k x
@@ -223,22 +223,20 @@ locations.
 
 #### Set of locations
 
-The set of locations is expected as an `{fset Location }` using the finite
-sets of the [extructures] library. For our purposes, it is advisable to write
-them directly as list which of locations which is then cast to an `fset` using
-the `fset` operation, as below:
+The set of locations is expected as type `Locations` using the finite maps
+of the [extructures] library. For our purposes, it is advisable to write
+them directly as list of locations using the following syntax:
 ```coq
-fset [:: ℓ₀ ; ℓ₁ ; ℓ₂ ]
+[fmap ℓ₀ ; ℓ₁ ; ℓ₂ ]
 ```
-This is the best way to leverage the automation that we introduced.
-Nevertheless, in some cases it might be more convenient to use the union
-(`:|:`) operator of [extructures].
+An empty location map is written `emptym` and in some cases it might be
+necessary to use the union (`unionm`) operator of [extructures].
 
 #### Interfaces
 
-An interface is a set of signatures (`opsig`) corresponding to the procedures
-that a piece of code *can* import and use.
-Rather than writing them as `fset` directly, we provide special convenient
+An interface is a finite map (`fmap`) of signatures (`opsig`) corresponding
+to the procedures that a piece of code *can* import and use.
+Rather than writing them as `fmap` directly, we provide special convenient
 notations, as well the type `Interface`.
 
 Interfaces are wrapped in the `[interface]` container which behaves like lists.
@@ -294,20 +292,20 @@ fill in the validity proof.
 ```coq
 Obligation Tactic := idtac.
 
-Definition ℓ : Location := ('nat ; 0).
+Definition ℓ : Location := (0, 'nat).
 
-Equations? foo : code fset0 [interface] 'nat :=
+Equations? foo : code emptym [interface] 'nat :=
   foo := {code
     n ← get ℓ ;;
     ret n
   }.
 Proof.
   ssprove_valid.
-  (* We have to prove ℓ \in fset0 which does not hold. *)
+  (* We have to prove (fhas emptym ℓ.1) which does not hold. *)
 Abort.
 ```
-We can then see where the mistake was and change the empty interface to
-something containing `ℓ` like `fset [:: ℓ ]`.
+We can then see where the mistake was and change `emptym` to
+something containing `ℓ` like `[fmap ℓ ]`.
 
 Note that `ssprove_valid` and the inference for `ValidCode` can be extended
 with hints. The former using the `ssprove_valid_db` database, the latter with the
@@ -324,8 +322,8 @@ form `src → raw_code tgt` distinguished by their signatures. This notion of
 `raw_package` will prove the most efficient when proving results about packages,
 such as advantages.
 However, we provide a syntax to define valid packages by construction, *i.e.*
-of type `package L I E` where each procedure must be `ValidCode L I tgt` and
-the lot of them must implement export interface `E`.
+of type `package I E` where each procedure must be `ValidCode L I tgt` for a
+a chosen set of locations `L` and the lot of them must implement export interface `E`.
 
 The syntax for valid packages is similar to that of interfaces. Better explained
 on an example:
@@ -333,7 +331,6 @@ on an example:
 ```coq
 Definition test :
   package
-    fset0
     [interface
       val #[0] : 'nat → 'bool ;
       val #[1] : 'bool → 'unit
@@ -343,7 +340,7 @@ Definition test :
       val #[3] : 'bool × 'bool → 'bool
     ]
   :=
-  [package
+  [package emptym ;
     def #[2] (n : 'nat) : 'nat {
       #import {sig #[0] : 'nat → 'bool } as f ;;
       #import {sig #[1] : 'bool → 'unit } as g ;;
@@ -362,9 +359,10 @@ Definition test :
 Packages are wrapped in the `[package]` container which behaves like lists.
 They are of the form
 ```coq
-[package d₀ ; d₁ ; … ; dₙ ]
+[package L ; d₀ ; d₁ ; … ; dₙ ]
 ```
-where the `dᵢ` are declarations, given using a special syntax:
+where `L` is the locations of the package` and `dᵢ` are declarations, given
+using a special syntax:
 ```coq
 def #[ id ] (x : src) : tgt { e }
 ```
@@ -383,8 +381,8 @@ In the example above we also explicitly gave an export interface while the
 information is already present in the declaration. As such in can be omitted
 as on the simpler example below:
 ```coq
-Definition test' : package fset0 [interface] _ :=
-  [package
+Definition test' : package [interface] _ :=
+  [package emptym ;
     def #[ 0 ] (n : 'nat) : 'nat {
       ret (n + n)%N
     } ;
@@ -400,39 +398,26 @@ they are what the programs *can* use, not what they *exactly* use.
 
 One of the key points of SSP is its package algebra with sequential and parallel
 composition as well as the identity package. All these operations are defined on
-`raw_packages` directly but extend to `package` with the `{package}` and
-`{locpackage}` notations.
+`raw_packages` directly but extend to `package` with the `{package}` notation.
 
 Sequential composition is called `link` in SSProve and can be written
 `p₀ ∘ p₁`. It represents `p₀` where all *imports* are replaced by the inlined
-procedures of `p₁`. It is valid when the export interface of `p₁` matches the
-import interface of `p₀`.
+procedures of `p₁`. It is valid when the import interface of `p₀` is a subset
+of the export interface of `p₁` and when the sets of locations are compatible
+(given by `fcompat`, which is usually derived automatically).
 
 Parallel composition of (raw) packages `p₀` and `p₁` is written `par p₀ p₁`.
-It is valid if we have `Parable p₀ p₁` (which is a class).
-The resulting package must have the union of locations of its components, as
-such automation can be lacking on that front, so it might be a good idea to rely
-on `Equations` again:
-```coq
-Equations? pkg : package L I E :=
-  pkg := {package (par p₀ p₁) ∘ p₂ }.
-Proof.
-  ssprove_valid.
-  (* Now deal with the goals *)
-```
+It is valid if we have `fesparate p₀ p₁` and compatible sets of locations both
+of which are usually automatic.
 
 Finally, the identity package is defined as `ID I` where `I` is an interface.
-It both imports and exports `I` by simply forwarding the calls.
-It is valid as long as `I` does not include two signatures sharing the same
-identifier, as overloading is not possible in our packages. This property is
-written `flat I` and can be inferred automatically by `ssprove_ valid`.
+It both imports and exports `I` by simply forwarding the calls and is valid
+for any interface `I`.
 
 As illustrated above, `{package p }` casts a raw package to some
-`package L I E`, trying to infer the proof. We also have `{locpackage p }`
-which will cast to `loc_package I E` which is essentially the same as `package`
-but where the set of locations is internalised.
+`package I E`, trying to infer the proof.
 
-**Note:** `loc_package` and `package` both have implicit coercions to
+**Note:** `package` has an implicit coercion to
 `raw_package`. This means that, for instance, if `p₀` and `p₁` are both
 `package` then, `{package p₀ ∘ p₁ }` is a valid expression, and will be complete
 if the interfaces match.
@@ -470,7 +455,7 @@ Lemma link_assoc :
 ```coq
 Lemma par_commut :
   ∀ p1 p2,
-    Parable p1 p2 →
+    fseparate p1 p2 →
     par p1 p2 = par p2 p1.
 ```
 
@@ -488,8 +473,6 @@ Lemma par_assoc :
 Lemma link_id :
   ∀ L I E p,
     ValidPackage L I E p →
-    flat I →
-    trimmed E p →
     link p (ID I) = p.
 ```
 
@@ -497,13 +480,8 @@ Lemma link_id :
 Lemma id_link :
   ∀ L I E p,
     ValidPackage L I E p →
-    trimmed E p →
     link (ID E) p = p.
 ```
-
-These laws require the package `p` to be valid but also to be `trimmed` which
-means that it doesn't implement more than it exports. For packages constructed
-as in [[Packages]], this is always the case.
 
 #### Interchange between sequential and parallel composition
 
@@ -514,9 +492,7 @@ Lemma interchange :
     ValidPackage L₂ E D p₂ →
     ValidPackage L₃ C B p₃ →
     ValidPackage L₄ F E p₄ →
-    trimmed A p₁ →
-    trimmed D p₂ →
-    Parable p₃ p₄ →
+    fseparate p₃ p₄ →
     par (p₁ ∘ p₃) (p₂ ∘ p₄) = (par p₁ p₂) ∘ (par p₃ p₄).
 ```
 The last line can be read as
@@ -540,25 +516,21 @@ AdvantageE (G₀ G₁ A : raw_package) : R
 The result is a real number, of type `R`.
 
 We also have an alternative version simply style `Advantage` which takes in a
-`GamePair`:
-```coq
-Definition GamePair :=
-  bool → raw_package.
-```
+pair of games as a function `bool → raw_pacakge`: 
 
 ```coq
-Advantage (G : GamePair) (A : raw_package) : R
+Advantage (G : bool → raw_package) (A : raw_package) : R
 ```
 
 The two definitions are equivalent, as stated by the following. `AdvantageE`
 should be preferred as it is slightly less constrained.
 ```coq
 Lemma Advantage_E :
-  ∀ (G : GamePair) A,
+  ∀ (G : bool → raw_package) A,
     Advantage G A = AdvantageE (G false) (G true) A.
 ```
 
-We have several useful lemmata on advantage. We will list the important ones
+We have several useful lemmas on advantage. We will list the important ones
 below.
 
 ```coq
@@ -613,8 +585,8 @@ It is equivalent to the following:
 ```coq
 ∀ LA A,
   ValidPackage LA E A_export A →
-  fdisjoint LA L₀ →
-  fdisjoint LA L₁ →
+  fseparate LA L₀ →
+  fseparate LA L₁ →
   AdvantageE G₀ G₁ A = 0.
 ```
 So one can use `G₀ ≈₀ G₁` to rewrite an advantage to `0`, typically after using
@@ -714,7 +686,7 @@ The lemma in question is
 ```coq
 Lemma code_link_scheme :
   ∀ A c p,
-    @ValidCode fset0 [interface] A c →
+    @ValidCode emptym [interface] A c →
     code_link c p = c.
 ```
 stating that code which does not import anything (here we add the unnecessary
@@ -811,7 +783,7 @@ stateless, import-less program:
 ```coq
 Lemma r_swap_scheme_cmd :
   ∀ {A B : choiceType} (s : raw_code A) (c : command B),
-    ValidCode fset0 [interface] s →
+    ValidCode emptym [interface] s →
     ⊢ ⦃ λ '(s₀, s₁), s₀ = s₁ ⦄
       x ← s ;; y ← cmd c ;; ret (x,y) ≈
       y ← cmd c ;; x ← s ;; ret (x,y)
@@ -841,8 +813,8 @@ it is more constrained:
 Lemma r_reflexivity_alt :
   ∀ {A : choiceType} {L} pre (c : raw_code A),
     ValidCode L [interface] c →
-    (∀ ℓ, ℓ \in L → get_pre_cond ℓ pre) →
-    (∀ ℓ v, ℓ \in L → put_pre_cond ℓ v pre) →
+    (∀ ℓ, fhas L ℓ → get_pre_cond ℓ pre) →
+    (∀ ℓ v, fhas L ℓ → put_pre_cond ℓ v pre) →
     ⊢ ⦃ λ '(s₀, s₁), pre (s₀, s₁) ⦄
       c ≈ c
     ⦃ λ '(b₀, s₀) '(b₁, s₁), b₀ = b₁ ∧ pre (s₀, s₁) ⦄.
@@ -1067,7 +1039,7 @@ Another invariant we propose is called `heap_ignore` and is defined as
 ```coq
 Definition heap_ignore (L : {fset Location}) :=
   λ '(h₀, h₁),
-    ∀ (ℓ : Location), ℓ \notin L → get_heap h₀ ℓ = get_heap h₁ ℓ.
+    ∀ (ℓ : Location), ℓ.1 \notin domm L → get_heap h₀ ℓ = get_heap h₁ ℓ.
 ```
 It only states equality of heaps on locations that are not in `L`, the set of
 *ignored* locations. It is a valid invariant as long as the ignored locations
@@ -1076,7 +1048,7 @@ locations of the adversary).
 ```coq
 Lemma Invariant_heap_ignore :
   ∀ L L₀ L₁,
-    fsubset L (L₀ :|: L₁) →
+    fsubmap L (unionm L₀ L₁) →
     Invariant L₀ L₁ (heap_ignore L).
 ```
 
@@ -1120,8 +1092,8 @@ It is a semi-invariant provided that the locations belong to the programs:
 ```coq
 Lemma SemiInvariant_couple_lhs :
   ∀ L₀ L₁ ℓ ℓ' (R : _ → _ → Prop),
-    ℓ \in L₀ :|: L₁ →
-    ℓ' \in L₀ :|: L₁ →
+    fhas L₀ ℓ  →
+    fhas L₀ ℓ' →
     R (get_heap empty_heap ℓ) (get_heap empty_heap ℓ') →
     SemiInvariant L₀ L₁ (couple_lhs ℓ ℓ' h).
 ```
@@ -1158,9 +1130,9 @@ essentially the same way.
 ```coq
 Lemma SemiInvariant_triple_rhs :
   ∀ L₀ L₁ ℓ₁ ℓ₂ ℓ₃ (R : _ → _ → _ → Prop),
-    ℓ₁ \in L₀ :|: L₁ →
-    ℓ₂ \in L₀ :|: L₁ →
-    ℓ₃ \in L₀ :|: L₁ →
+    fhas L₁ ℓ₁ →
+    fhas L₁ ℓ₂ →
+    fhas L₁ ℓ₃ →
     R (get_heap empty_heap ℓ₁) (get_heap empty_heap ℓ₂) (get_heap empty_heap ℓ₃) →
     SemiInvariant L₀ L₁ (triple_rhs ℓ₁ ℓ₂ ℓ₃ R).
 ```

--- a/README.md
+++ b/README.md
@@ -118,10 +118,9 @@ safely be assumed to be in [theories/Crypt].
 The formalisation of packages can be found in the [package] directory.
 
 The definition of packages can be found in [pkg_core_definition.v].
-Herein, `package L I E` is the type of packages with set of locations `L`,
-import interface `I` and export interface `E`. It is defined on top of
-`raw_package` which does not contain the information about its interfaces
-and the locations it uses.
+Herein, `package I E` is the type of packages with import interface `I`
+and export interface `E`. It is defined on top of `raw_package` which does
+not contain the information about its interfaces and the locations it uses.
 
 Package laws, as introduced in the paper, are all stated and proven in
 [pkg_composition.v] directly on raw packages. This technical detail is not
@@ -138,13 +137,14 @@ Definition link (p1 p2 : raw_package) : raw_package.
 ```
 
 Linking is valid if the export and import match, and its set of locations
-is the union of those from both packages (`:|:` denotes union of sets):
+is the union of those from both packages (`unionm` denotes union of `fmap`s):
 ```coq
 Lemma valid_link :
   ∀ L1 L2 I M E p1 p2,
     ValidPackage L1 M E p1 →
     ValidPackage L2 I M p2 →
-    ValidPackage (L1 :|: L2) I E (link p1 p2).
+    fcompat L1 L2 →
+    ValidPackage (unionm L1 L2) I E (link p1 p2).
 ```
 
 Associativity is stated as follows:
@@ -170,19 +170,23 @@ The validity of parallel composition can be proven with the following lemma:
 ```coq
 Lemma valid_par :
   ∀ L1 L2 I1 I2 E1 E2 p1 p2,
-    Parable p1 p2 →
     ValidPackage L1 I1 E1 p1 →
     ValidPackage L2 I2 E2 p2 →
+    fseparate p1 p2 →
+    fcompat L1 L2 →
+    fcompat I1 I2 →
     ValidPackage (L1 :|: L2) (I1 :|: I2) (E1 :|: E2) (par p1 p2).
 ```
 
-The `Parable` condition checks that the export interfaces are indeed disjoint.
+The `fseparate` condition checks that the export interfaces are indeed disjoint.
+The `fcompat conditions check that the locations and imports are compatible i.e.
+that if they define the same key it also has the same value.
 
 We have commutativity as follows:
 ```coq
 Lemma par_commut :
   ∀ p1 p2,
-    Parable p1 p2 →
+    fseparate p1 p2 →
     par p1 p2 = par p2 p1.
 ```
 This lemma does not work on arbitrary raw packages, it requires that the
@@ -205,24 +209,14 @@ Definition ID (I : Interface) : raw_package.
 Its validity is stated as
 ```coq
 Lemma valid_ID :
-  ∀ L I,
-    flat I →
-    ValidPackage L I I (ID I).
+  ∀ L I, ValidPackage L I I (ID I).
 ```
-
-The extra `flat I` condition on the interface essentially forbids overloading:
-there cannot be two procedures in `I` that share the same name, but have
-different types. While our type of interface could in theory allow such
-overloading, the way we build packages forbids us from ever implementing them,
-hence the restriction.
 
 The two identity laws are as follows:
 ```coq
 Lemma link_id :
   ∀ L I E p,
     ValidPackage L I E p →
-    flat I →
-    trimmed E p →
     link p (ID I) = p.
 ```
 
@@ -230,14 +224,11 @@ Lemma link_id :
 Lemma id_link :
   ∀ L I E p,
     ValidPackage L I E p →
-    trimmed E p →
     link (ID E) p = p.
 ```
 
-In both cases, we ask that the package we link the identity package with is
-`trimmed`, meaning that it implements *exactly* its export interface and nothing
-more. Packages created through our operations always verify this property
-(as such it can be checked automatically on those).
+In both cases, the package is required to be a valid on specific
+interfaces that match with the interface argument for ID.
 
 #### Interchange between sequential and parallel composition
 
@@ -250,15 +241,13 @@ Lemma interchange :
     ValidPackage L2 E D p2 →
     ValidPackage L3 C B p3 →
     ValidPackage L4 F E p4 →
-    trimmed A p1 →
-    trimmed D p2 →
-    Parable p3 p4 →
+    fseparate p3 p4 →
     par (link p1 p3) (link p2 p4) = link (par p1 p2) (par p3 p4).
 ```
 where the last line can be read as
 `(p1 ∘ p3) || (p2 ∘ p4) = (p1 || p2) ∘ (p3 || p4)`.
 
-It once again requires some validity and trimming properties.
+It once again requires some validity and separation properties.
 
 
 ### Examples
@@ -273,8 +262,8 @@ Theorem security_based_on_prf :
   ∀ LA A,
     ValidPackage LA
       [interface val #[i1] : 'word → 'word × 'word ] A_export A →
-    fdisjoint LA (IND_CPA false).(locs) →
-    fdisjoint LA (IND_CPA true).(locs) →
+    fseparate LA (IND_CPA false).(locs) →
+    fseparate LA (IND_CPA true).(locs) →
     Advantage IND_CPA A <=
     prf_epsilon (A ∘ MOD_CPA_ff_pkg) +
     statistical_gap A +
@@ -297,8 +286,8 @@ The security theorem is the following:
 Theorem ElGamal_OT :
   ∀ LA A,
     ValidPackage LA [interface val #[challenge_id'] : 'plain → 'cipher] A_export A →
-    fdisjoint LA (ots_real_vs_rnd true).(locs) →
-    fdisjoint LA (ots_real_vs_rnd false).(locs) →
+    fseparate LA (ots_real_vs_rnd true).(locs) →
+    fseparate LA (ots_real_vs_rnd false).(locs) →
     Advantage ots_real_vs_rnd A <= AdvantageE DH_rnd DH_real (A ∘ Aux).
 ```
 
@@ -330,8 +319,8 @@ while the final security theorem is the following:
 Theorem PKE_security :
   ∀ LA A,
     ValidPackage LA PKE_CCA_out A_export A →
-    fdisjoint LA PKE_CCA_loc →
-    fdisjoint LA Aux_loc →
+    fseparate LA PKE_CCA_loc →
+    fseparate LA Aux_loc →
     Advantage (PKE_CCA KEM_DEM) A <=
     Advantage KEM_CCA (A ∘ (MOD_CCA KEM_DEM) ∘ par (ID KEM_out) (DEM true)) +
     Advantage DEM_CCA (A ∘ (MOD_CCA KEM_DEM) ∘ par (KEM false) (ID DEM_out)) +
@@ -372,7 +361,7 @@ Theorem commitment_binding :
     ValidPackage LAdv [interface] [interface
       val #[ ADV ] : chStatement → chSoundness
     ] Adv →
-    fdisjoint LA (Sigma_locs :|: LAdv) →
+    fseparate LA (Sigma_locs :|: LAdv) →
     AdvantageE (Com_Binding ∘ Adv) (Special_Soundness_f ∘ Adv) A <=
     ɛ_soundness A Adv.
 ```
@@ -385,8 +374,8 @@ Theorem schnorr_com_hiding :
     ValidPackage LA [interface
       val #[ HIDING ] : chInput → chMessage
     ] A_export A →
-    fdisjoint LA Com_locs →
-    fdisjoint LA Sigma_locs →
+    fseparate LA Com_locs →
+    fseparate LA Sigma_locs →
     AdvantageE (Hiding_real ∘ Sigma_to_Com ∘ SHVZK_ideal) (Hiding_ideal ∘ Sigma_to_Com ∘ SHVZK_ideal) A <= 0.
 ```
 
@@ -401,7 +390,7 @@ Theorem schnorr_com_binding :
     ValidPackage LAdv [interface] [interface
       val #[ ADV ] : chStatement → chSoundness
     ] Adv →
-    fdisjoint LA (Sigma_locs :|: LAdv) →
+    fseparate LA (Sigma_locs :|: LAdv) →
     AdvantageE (Com_Binding ∘ Adv) (Special_Soundness_f ∘ Adv) A <= 0.
 ```
 
@@ -468,8 +457,8 @@ Lemma eq_upto_inv_perf_ind :
     `{ValidPackage LA E A_export A},
     INV' L₀ L₁ I →
     I (empty_heap, empty_heap) →
-    fdisjoint LA L₀ →
-    fdisjoint LA L₁ →
+    fseparate LA L₀ →
+    fseparate LA L₁ →
     eq_up_to_inv E I p₀ p₁ →
     AdvantageE p₀ p₁ A = 0.
 ```

--- a/theories/Crypt/choice_type.v
+++ b/theories/Crypt/choice_type.v
@@ -109,7 +109,7 @@ Section Cucumber.
      and unpickle respectively.
    *)
 
-  #[program] Fixpoint cucumber' {U : choice_type} : chElement_ordType U → nat :=
+  Fixpoint cucumber' {U : choice_type} : chElement_ordType U → nat :=
     match U with
     | chUnit => pickle
     | chNat => pickle
@@ -129,7 +129,7 @@ Section Cucumber.
       end
     end.
 
-  #[program] Fixpoint cucumber {U : choice_type} : U → nat :=
+  Fixpoint cucumber {U : choice_type} : U → nat :=
     match U with
     | chUnit => pickle
     | chNat => pickle
@@ -159,7 +159,7 @@ Section Cucumber.
   Qed.
 
 
-  #[program] Fixpoint uncucumber'' {U : choice_type}
+  Fixpoint uncucumber'' {U : choice_type}
     : nat → chElement_ordType U :=
     match U with
     | chUnit => λ x, helper tt x
@@ -182,7 +182,7 @@ Section Cucumber.
         if b then inl (uncucumber'' n) else inr (uncucumber'' n)
     end.
 
-  #[program] Fixpoint uncucumber' {U : choice_type} : nat → U :=
+  Fixpoint uncucumber' {U : choice_type} : nat → U :=
     match U with
     | chUnit => λ x, helper tt x
     | chNat => λ x, helper 0 x

--- a/theories/Crypt/examples/AsymScheme.v
+++ b/theories/Crypt/examples/AsymScheme.v
@@ -136,14 +136,13 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
    *)
   Definition L_pk_cpa_L :
     package
-      L_locs
       [interface]
       [interface
         #val #[getpk_id] : 'unit → 'pubkey ;
         #val #[challenge_id] : 'plain × 'plain → 'cipher
       ]
     :=
-    [package
+    [package L_locs ;
       #def  #[getpk_id] (_ : 'unit) : 'pubkey
       {
         pk ← get pk_loc ;;
@@ -162,14 +161,13 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
 
   Definition L_pk_cpa_R :
     package
-      L_locs
       [interface]
       [interface
         #val #[getpk_id] : 'unit → 'pubkey ;
         #val #[challenge_id] : 'plain × 'plain → 'cipher
       ]
     :=
-    [package
+    [package L_locs ;
       #def  #[getpk_id] (_ : 'unit) : 'pubkey
       {
         pk ← get pk_loc ;;
@@ -186,12 +184,11 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
       }
     ].
 
-  Definition cpa_L_vs_R :
-    loc_GamePair [interface
+  Definition cpa_L_vs_R b :
+    game [interface
       #val #[getpk_id] : 'unit → 'pubkey ;
       #val #[challenge_id] : 'plain × 'plain → 'cipher
-    ] :=
-    λ b, if b then {locpackage L_pk_cpa_L} else {locpackage L_pk_cpa_R}.
+    ] := if b then L_pk_cpa_L else L_pk_cpa_R.
 
   (** [The Joy of Cryptography] Definition 15.1
 
@@ -213,14 +210,14 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
   (** HAVE PSEUDORND CIPHERTEXT IN PRESENCE OF CHOSEN PLAINTEXT ATTACKS **)
 
   Definition L_pk_cpa_real :
-    package L_locs
+    package
       [interface]
       [interface
         #val #[getpk_id] : 'unit → 'pubkey ;
         #val #[challenge_id] : 'plain → 'cipher
       ]
     :=
-    [package
+    [package L_locs ;
       #def  #[getpk_id] (_ : 'unit) : 'pubkey
       {
         pk ← get pk_loc ;;
@@ -238,14 +235,14 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
     ].
 
   Definition L_pk_cpa_rand :
-    package L_locs
+    package
       [interface]
       [interface
         #val #[getpk_id] : 'unit → 'pubkey ;
         #val #[challenge_id] : 'plain → 'cipher
       ]
     :=
-    [package
+    [package L_locs ;
       #def  #[getpk_id] (_ : 'unit) : 'pubkey
       {
         pk ← get pk_loc ;;
@@ -262,12 +259,11 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
       }
     ].
 
-  Definition cpa_real_vs_rand :
-    loc_GamePair [interface
+  Definition cpa_real_vs_rand b :
+    game [interface
       #val #[getpk_id] : 'unit → 'pubkey ;
       #val #[challenge_id] : 'plain → 'cipher
-    ] :=
-    λ b, if b then {locpackage L_pk_cpa_real } else {locpackage L_pk_cpa_rand }.
+    ] := if b then L_pk_cpa_real else L_pk_cpa_rand.
 
   (** [The Joy of Cryptography] Definition 15.2
 
@@ -291,14 +287,14 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
   Definition L_locs_counter := [fmap counter_loc ; pk_loc ; sk_loc ].
 
   Definition L_pk_ots_L :
-    package L_locs_counter
+    package
       [interface]
       [interface
         #val #[getpk_id] : 'unit → 'pubkey ;
         #val #[challenge_id] : 'plain × 'plain → 'cipher
       ]
     :=
-    [package
+    [package L_locs_counter ;
       #def #[getpk_id] (_ : 'unit) : 'pubkey
       {
         pk ← get pk_loc ;;
@@ -318,14 +314,14 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
     ].
 
   Definition L_pk_ots_R :
-    package L_locs_counter
+    package
       [interface]
       [interface
         #val #[getpk_id] : 'unit → 'pubkey ;
         #val #[challenge_id] : 'plain × 'plain → 'cipher
       ]
     :=
-    [package
+    [package L_locs_counter ;
       #def #[getpk_id] (_ : 'unit) : 'pubkey
       {
         pk ← get pk_loc ;;
@@ -344,12 +340,11 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
       }
     ].
 
-  Definition ots_L_vs_R :
-    loc_GamePair [interface
+  Definition ots_L_vs_R b :
+    game [interface
       #val #[getpk_id] : 'unit → 'pubkey ;
       #val #[challenge_id] :'plain × 'plain → 'cipher
-    ] :=
-    λ b, if b then {locpackage L_pk_ots_L } else {locpackage L_pk_ots_R }.
+    ] := if b then L_pk_ots_L else L_pk_ots_R.
 
   (** [The Joy of Cryptography] Definition 15.4
 
@@ -370,14 +365,14 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
   (*  *)
 
   Definition L_pk_ots_real :
-    package L_locs_counter
+    package
       [interface]
       [interface
         #val #[getpk_id] : 'unit → 'pubkey ;
         #val #[challenge_id'] : 'plain → 'cipher
       ]
     :=
-    [package
+    [package L_locs_counter ;
       #def  #[getpk_id] (_ : 'unit) : 'pubkey
       {
         pk ← get pk_loc ;;
@@ -398,14 +393,14 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
     ].
 
   Definition L_pk_ots_rnd :
-    package L_locs_counter
+    package
       [interface]
       [interface
         #val #[getpk_id] : 'unit → 'pubkey ;
         #val #[challenge_id'] : 'plain → 'cipher
       ]
     :=
-    [package
+    [package L_locs_counter ;
       #def  #[getpk_id] (_ : 'unit) : 'pubkey
       {
         pk ← get pk_loc ;;
@@ -425,11 +420,10 @@ Module AsymmetricScheme (π : AsymmetricSchemeParams)
       }
     ].
 
-  Definition ots_real_vs_rnd :
-    loc_GamePair [interface
+  Definition ots_real_vs_rnd b :
+    game [interface
       #val #[getpk_id] : 'unit → 'pubkey ;
       #val #[challenge_id'] : 'plain → 'cipher
-    ] :=
-    λ b, if b then {locpackage L_pk_ots_real } else {locpackage L_pk_ots_rnd }.
+    ] := if b then L_pk_ots_real else L_pk_ots_rnd.
 
 End AsymmetricScheme.

--- a/theories/Crypt/examples/DDH.v
+++ b/theories/Crypt/examples/DDH.v
@@ -77,10 +77,11 @@ Module DDH (DDHP : DDHParams) (GP : GroupParam).
   Definition DDH_locs :=
     [fmap secret_loc1 ; secret_loc2 ; secret_loc3].
 
+  Definition DDH_E := [interface #val #[ SAMPLE ] : 'unit → 'group × 'group × 'group ].
+
   Definition DDH_real :
-    package DDH_locs [interface]
-      [interface #val #[ SAMPLE ] : 'unit → 'group × 'group × 'group ] :=
-      [package
+    package [interface] DDH_E :=
+      [package DDH_locs ;
         #def #[ SAMPLE ] (_ : 'unit) : 'group × 'group × 'group
         {
           a ← sample uniform i_space ;;
@@ -91,11 +92,9 @@ Module DDH (DDHP : DDHParams) (GP : GroupParam).
         }
       ].
 
-  Definition DDH_E := [interface #val #[ SAMPLE ] : 'unit → 'group × 'group × 'group ].
-
   Definition DDH_ideal :
-    package DDH_locs [interface] DDH_E :=
-      [package
+    package [interface] DDH_E :=
+      [package DDH_locs ;
         #def #[ SAMPLE ] (_ : 'unit) : 'group × 'group × 'group
         {
           a ← sample uniform i_space ;;
@@ -108,10 +107,7 @@ Module DDH (DDHP : DDHParams) (GP : GroupParam).
         }
       ].
 
-  Definition DDH :
-    loc_GamePair [interface #val #[ SAMPLE ] : 'unit → 'group × 'group × 'group ] :=
-    λ b,
-      if b then {locpackage DDH_real } else {locpackage DDH_ideal }.
+  Definition DDH b : game DDH_E := if b then DDH_real else DDH_ideal.
 
   Definition ϵ_DDH := Advantage DDH.
 

--- a/theories/Crypt/examples/ElGamal.v
+++ b/theories/Crypt/examples/ElGamal.v
@@ -189,9 +189,9 @@ Import MyParam MyAlg ElGamal_Scheme.
 Definition DH_loc := [fmap pk_loc ; sk_loc].
 
 Definition DH_real :
-  package DH_loc [interface]
+  package [interface]
     [interface #val #[query_id] : 'unit → 'pubkey × 'cipher ] :=
-    [package
+    [package DH_loc ;
       #def #[query_id] (_ : 'unit) : 'pubkey × 'cipher
       {
         a ← sample uniform i_sk ;;
@@ -205,9 +205,9 @@ Definition DH_real :
     ].
 
 Definition DH_rnd :
-  package DH_loc [interface]
+  package [interface]
     [interface #val #[query_id] : 'unit → 'pubkey × 'cipher ] :=
-    [package
+    [package DH_loc ;
       #def #[query_id] (_ : 'unit) : 'pubkey × 'cipher
       {
         a ← sample uniform i_sk ;;
@@ -223,14 +223,14 @@ Definition DH_rnd :
     ].
 
 Definition Aux :
-  package ([fmap counter_loc ; pk_loc ])
+  package
     [interface #val #[query_id] : 'unit → 'pubkey × 'cipher]
     [interface
       #val #[getpk_id] : 'unit → 'pubkey ;
       #val #[challenge_id'] : 'plain → 'cipher
     ]
   :=
-  [package
+  [package [fmap counter_loc ; pk_loc ] ;
     #def #[getpk_id] (_ : 'unit) : 'pubkey
     {
       pk ← get pk_loc ;;

--- a/theories/Crypt/examples/Executor.v
+++ b/theories/Crypt/examples/Executor.v
@@ -259,8 +259,8 @@ Section Test.
     ].
 
   Definition test_pack:
-    package locs [interface] E :=
-    [package
+    package [interface] E :=
+    [package locs ;
       #def #[ 0 ] (x : 'nat) : 'nat
       {
         k ← sample uniform 20 ;;

--- a/theories/Crypt/examples/KEMDEM.v
+++ b/theories/Crypt/examples/KEMDEM.v
@@ -552,18 +552,14 @@ Section KEMDEM.
       fseparate (ID IGEN) CD₁ →
       ValidPackage LD₀ IGET ED CD₀ →
       ValidPackage LD₀ IGET ED CD₁ →
-      trimmed ED CD₀ →
-      trimmed ED CD₁ →
       ValidPackage LK₀ ISET EK CK₀ →
       ValidPackage LK₀ IGEN EK CK₁ →
-      trimmed EK CK₀ →
-      trimmed EK CK₁ →
       AdvantageE ((par CK₀ CD₀) ∘ KEY) ((par CK₁ CD₁) ∘ KEY) A <=
       AdvantageE K₀ K₁ (A ∘ (par (ID EK) CD₀)) +
       AdvantageE D₀ D₁ (A ∘ (par CK₁ (ID ED))).
   Proof.
     intros LD₀ LK₀ CK₀ CK₁ CD₀ CD₁ EK ED A K₀ K₁ D₀ D₁.
-    intros pCK₀ pCK₁ pCD₀ pCD₁ hCD₀ hCD₁ tCD₀ tCD₁ hCK₀ hCK₁ tCK₀ tCK₁.
+    intros pCK₀ pCK₁ pCD₀ pCD₁ hCD₀ hCD₁ hCK₀ hCK₁.
     ssprove triangle (par CK₀ CD₀ ∘ KEY) [::
       par CK₁ CD₀ ∘ KEY
     ] (par CK₁ CD₁ ∘ KEY) A
@@ -576,7 +572,6 @@ Section KEMDEM.
       2:{
         erewrite <- interchange.
         all: ssprove_valid.
-        2: apply trimmed_ID.
         rewrite link_id. all: eauto.
         rewrite id_link. all: eauto.
       }
@@ -584,7 +579,6 @@ Section KEMDEM.
       2:{
         erewrite <- interchange.
         all: ssprove_valid.
-        2: apply trimmed_ID.
         rewrite link_id. all: eauto.
         rewrite id_link. all: eauto.
       }
@@ -597,7 +591,6 @@ Section KEMDEM.
       2:{
         erewrite <- interchange.
         all: ssprove_valid.
-        2: apply trimmed_ID.
         rewrite link_id. all: eauto.
         rewrite id_link. all: eauto.
       }
@@ -605,7 +598,6 @@ Section KEMDEM.
       2:{
         erewrite <- interchange.
         all: ssprove_valid.
-        2: apply trimmed_ID.
         rewrite link_id. all: eauto.
         rewrite id_link. all: eauto.
       }
@@ -628,19 +620,15 @@ Section KEMDEM.
       fseparate (ID IGEN) CD₁ →
       ValidPackage LD₀ IGET ED CD₀ →
       ValidPackage LD₀ IGET ED CD₁ →
-      trimmed ED CD₀ →
-      trimmed ED CD₁ →
       ValidPackage LK₀ ISET EK CK₀ →
       ValidPackage LK₀ IGEN EK CK₁ →
-      trimmed EK CK₀ →
-      trimmed EK CK₁ →
       AdvantageE ((par CK₀ CD₀) ∘ KEY) ((par CK₀ CD₁) ∘ KEY) A <=
       AdvantageE K₀ K₁ (A ∘ (par (ID EK) CD₀)) +
       AdvantageE D₀ D₁ (A ∘ (par CK₁ (ID ED))) +
       AdvantageE K₀ K₁ (A ∘ (par (ID EK) CD₁)).
   Proof.
     intros LD₀ LK₀ CK₀ CK₁ CD₀ CD₁ EK ED A K₀ K₁ D₀ D₁.
-    intros pCK₀ pCK₁ pCD₀ pCD₁ hCD₀ hCD₁ tCD₀ tCD₁ hCK₀ hCK₁ tCK₀ tCK₁.
+    intros pCK₀ pCK₁ pCD₀ pCD₁ hCD₀ hCD₁ hCK₀ hCK₁.
     ssprove triangle (par CK₀ CD₀ ∘ KEY) [::
       par CK₁ CD₁ ∘ KEY
     ] (par CK₀ CD₁ ∘ KEY) A
@@ -654,7 +642,6 @@ Section KEMDEM.
       2:{
         erewrite <- interchange.
         all: ssprove_valid.
-        2: apply trimmed_ID.
         rewrite link_id. all: eauto.
         rewrite id_link. all: eauto.
       }
@@ -662,7 +649,6 @@ Section KEMDEM.
       2:{
         erewrite <- interchange.
         all: ssprove_valid.
-        2: apply trimmed_ID.
         rewrite link_id. all: eauto.
         rewrite id_link. all: eauto.
       }
@@ -937,8 +923,6 @@ Section KEMDEM.
       rewrite -Advantage_link.
       eapply single_key_b with (CK₁ := (KEM false).(pack)).
       all: ssprove_valid.
-      1-4: repeat apply trimmed_package_cons.
-      1-4: apply trimmed_empty_package.
     - rewrite !Advantage_E.
       unfold KEM_CCA. unfold KEM_CCA_pkg.
       unfold DEM_CCA. unfold DEM_CCA_pkg.

--- a/theories/Crypt/examples/OTP.v
+++ b/theories/Crypt/examples/OTP.v
@@ -298,10 +298,10 @@ Section OTP_example.
   (* This assumption is stronger than usual crypto definitions. *)
   (* We need control over the key to apply coupling. *)
   Definition IND_CPA_real :
-    package IND_CPA_location
+    package
       [interface]
       [interface #val #[i1] : 'word → 'word ] :=
-    [package
+    [package IND_CPA_location ;
         #def #[i1] (m : 'word) : 'word
         {
           k_val ← sample uniform i_key ;;
@@ -311,10 +311,10 @@ Section OTP_example.
     ].
 
   Definition IND_CPA_ideal :
-    package IND_CPA_location
+    package
       [interface ]
       [interface #val #[i1] : 'word → 'word ] :=
-    [package
+    [package IND_CPA_location ;
       #def #[i1] (m : 'word) : 'word
       {
         m'    ← sample uniform i_words ;;
@@ -324,8 +324,8 @@ Section OTP_example.
       }
     ].
 
-  Definition IND_CPA : loc_GamePair [interface #val #[i1] : 'word → 'word ] :=
-    λ b, if b then {locpackage IND_CPA_real } else {locpackage IND_CPA_ideal }.
+  Definition IND_CPA b : game [interface #val #[i1] : 'word → 'word ] :=
+    if b then IND_CPA_real else IND_CPA_ideal.
 
   #[local] Open Scope ring_scope.
 

--- a/theories/Crypt/examples/PRF.v
+++ b/theories/Crypt/examples/PRF.v
@@ -207,9 +207,9 @@ Section PRF_example.
   Definition EVAL_location_ff := [fmap table_location].
 
   Definition EVAL_pkg_tt :
-    package EVAL_location_tt [interface]
+    package [interface]
       [interface #val #[i0] : 'word → 'key ] :=
-    [package
+    [package EVAL_location_tt ;
       #def #[i0] (r : 'word) : 'key
       {
         k_init ← get key_location ;;
@@ -225,9 +225,9 @@ Section PRF_example.
     ].
 
   Definition EVAL_pkg_ff :
-    package EVAL_location_ff [interface]
+    package [interface]
       [interface #val #[i0] : 'word → 'key ] :=
-    [package
+    [package EVAL_location_ff ;
       #def #[i0] (r : 'word) : 'key
       {
         T ← get table_location ;;
@@ -241,18 +241,13 @@ Section PRF_example.
       }
     ].
 
-  (* TODO Not the most satisfying, it would be nice to think of something else
-    This might come with more automation to deal with the GamePair type.
-  *)
-  Definition EVAL : loc_GamePair [interface #val #[i0] : 'word → 'key ] :=
-    λ b, if b then {locpackage EVAL_pkg_tt } else {locpackage EVAL_pkg_ff }.
-
-  Definition MOD_CPA_location : Locations := emptym.
+  Definition EVAL b : game [interface #val #[i0] : 'word → 'key ] :=
+    if b then EVAL_pkg_tt else EVAL_pkg_ff.
 
   Definition MOD_CPA_tt_pkg :
-    package MOD_CPA_location [interface #val #[i0] : 'word → 'key ]
+    package [interface #val #[i0] : 'word → 'key ]
       [interface #val #[i1] : 'word → 'word × 'word ] :=
-    [package
+    [package emptym ;
       #def #[i1] (m : 'word) : 'word × 'word
       {
         #import {sig #[i0] : 'word → 'key } as eval ;;
@@ -264,9 +259,9 @@ Section PRF_example.
     ].
 
   Definition MOD_CPA_ff_pkg :
-    package MOD_CPA_location [interface #val #[i0] : 'word → 'key]
+    package [interface #val #[i0] : 'word → 'key]
       [interface #val #[i1] : 'word → 'word × 'word ]:=
-    [package
+    [package emptym ;
       #def #[i1] (m : 'word) : 'word × 'word
       {
         #import {sig #[i0] : 'word → 'key } as eval ;;
@@ -281,10 +276,10 @@ Section PRF_example.
   Definition IND_CPA_location : Locations := [fmap key_location].
 
   Definition IND_CPA_pkg_tt :
-    package IND_CPA_location
+    package
       [interface]
       [interface #val #[i1] : 'word → 'word × 'word ] :=
-    [package
+    [package IND_CPA_location ;
       #def #[i1] (m : 'word) : 'word × 'word
       {
         k ← get key_location ;;
@@ -300,10 +295,10 @@ Section PRF_example.
    ].
 
   Definition IND_CPA_pkg_ff :
-    package IND_CPA_location
+    package
       [interface]
       [interface #val #[i1] : 'word → 'word × 'word ] :=
-    [package
+    [package IND_CPA_location ;
       #def #[i1] (m : 'word) : 'word × 'word
       {
         k ← get key_location ;;
@@ -320,10 +315,8 @@ Section PRF_example.
       }
     ].
 
-  Definition IND_CPA :
-    loc_GamePair [interface #val #[i1] : 'word → 'word × 'word ] :=
-    λ b,
-      if b then {locpackage IND_CPA_pkg_tt } else {locpackage IND_CPA_pkg_ff }.
+  Definition IND_CPA b : game [interface #val #[i1] : 'word → 'word × 'word ] :=
+    if b then IND_CPA_pkg_tt else IND_CPA_pkg_ff.
 
   Local Open Scope ring_scope.
 

--- a/theories/Crypt/examples/PRFMAC.v
+++ b/theories/Crypt/examples/PRFMAC.v
@@ -74,10 +74,6 @@ Definition gettag: nat := 5.
 Definition checktag: nat := 6.
 Definition guess: nat := 7.
 
-Definition mkpair {Lt Lf E}
-  (t: package Lt [interface] E) (f: package Lf [interface] E):
-  loc_GamePair E := fun b => if b then {locpackage t} else {locpackage f}.
-
 Context (PRF: Word -> Word -> Word).
 
 Definition EVAL_locs_tt := [fmap k_loc].
@@ -111,10 +107,10 @@ Hint Extern 1 (ValidCode ?L ?I kgen) =>
   : typeclass_instances ssprove_valid_db.
 
 Definition EVAL_pkg_tt:
-  package EVAL_locs_tt
+  package
     [interface]
     [interface #val #[lookup]: 'word → 'word ] :=
-  [package
+  [package EVAL_locs_tt ;
     #def #[lookup] (m: 'word): 'word {
       k ← kgen ;;
       ret (PRF k m)
@@ -122,10 +118,10 @@ Definition EVAL_pkg_tt:
   ].
 
 Definition EVAL_pkg_ff:
-  package EVAL_locs_ff
+  package
     [interface]
     [interface #val #[lookup]: 'word → 'word ] :=
-  [package
+  [package EVAL_locs_ff ;
     #def #[lookup] (m: 'word): 'word {
       T ← get T_loc ;;
       match getm T m with
@@ -138,17 +134,17 @@ Definition EVAL_pkg_ff:
     }
   ].
 
-Definition EVAL := mkpair EVAL_pkg_tt EVAL_pkg_ff.
+Definition EVAL b := if b then EVAL_pkg_tt else EVAL_pkg_ff.
 
 Definition GUESS_locs := [fmap T_loc].
 
 Definition GUESS_pkg_tt:
-  package GUESS_locs
+  package
     [interface]
     [interface
       #val #[lookup]: 'word → 'word ;
       #val #[guess]: 'word × 'word → 'bool ] :=
-  [package
+  [package GUESS_locs ;
     #def #[lookup] (m: 'word): 'word {
       T ← get T_loc ;;
       match getm T m with
@@ -173,12 +169,12 @@ Definition GUESS_pkg_tt:
   ].
 
 Definition GUESS_pkg_ff:
-  package GUESS_locs
+  package
     [interface]
     [interface
       #val #[lookup]: 'word → 'word ;
       #val #[guess]: 'word × 'word → 'bool ] :=
-  [package
+  [package GUESS_locs ;
     #def #[lookup] (m: 'word): 'word {
       T ← get T_loc ;;
       match getm T m with
@@ -195,18 +191,18 @@ Definition GUESS_pkg_ff:
     }
   ].
 
-Definition GUESS := mkpair GUESS_pkg_tt GUESS_pkg_ff.
+Definition GUESS b := if b then GUESS_pkg_tt else GUESS_pkg_ff.
 
 Definition TAG_locs_tt := [fmap k_loc].
 Definition TAG_locs_ff := [fmap k_loc; S_loc].
 
 Definition TAG_pkg_tt:
-  package TAG_locs_tt
+  package
     [interface]
     [interface
       #val #[gettag]: 'word → 'word ;
       #val #[checktag]: 'word × 'word → 'bool ] :=
-  [package
+  [package TAG_locs_tt ;
     #def #[gettag] (m: 'word): 'word {
       k ← kgen ;;
       ret (PRF k m)
@@ -218,12 +214,12 @@ Definition TAG_pkg_tt:
   ].
 
 Definition TAG_pkg_ff:
-  package TAG_locs_ff
+  package
     [interface]
     [interface
       #val #[gettag]: 'word → 'word ;
       #val #[checktag]: 'word × 'word → 'bool ] :=
-  [package
+  [package TAG_locs_ff ;
     #def #[gettag] (m: 'word): 'word {
       S ← get S_loc ;;
       k ← kgen ;;
@@ -237,17 +233,17 @@ Definition TAG_pkg_ff:
     }
   ].
 
-Definition TAG := mkpair TAG_pkg_tt TAG_pkg_ff.
+Definition TAG b := if b then TAG_pkg_tt else TAG_pkg_ff.
 
 Definition TAG_EVAL_locs_ff := [fmap S_loc].
 
 Definition TAG_EVAL_pkg_tt:
-  package emptym
+  package
     [interface #val #[lookup]: 'word → 'word ]
     [interface
       #val #[gettag]: 'word → 'word ;
       #val #[checktag]: 'word × 'word → 'bool ] :=
-  [package
+  [package emptym ;
     #def #[gettag] (m: 'word): 'word {
       #import {sig #[lookup]: 'word → 'word } as lookup ;;
       t ← lookup m ;;
@@ -261,12 +257,12 @@ Definition TAG_EVAL_pkg_tt:
   ].
 
 Definition TAG_EVAL_pkg_ff:
-  package TAG_EVAL_locs_ff
+  package
     [interface #val #[lookup]: 'word → 'word]
     [interface
       #val #[gettag]: 'word → 'word ;
       #val #[checktag]: 'word × 'word → 'bool ] :=
-  [package
+  [package TAG_EVAL_locs_ff ;
     #def #[gettag] (m: 'word): 'word {
       #import {sig #[lookup]: 'word → 'word } as lookup ;;
       S ← get S_loc ;;
@@ -283,14 +279,14 @@ Definition TAG_EVAL_pkg_ff:
 Definition TAG_GUESS_locs := [fmap S_loc ].
 
 Definition TAG_GUESS_pkg:
-  package TAG_GUESS_locs
+  package
     [interface
       #val #[lookup]: 'word → 'word ;
       #val #[guess]: 'word × 'word → 'bool ]
     [interface
       #val #[gettag]: 'word → 'word ;
       #val #[checktag]: 'word × 'word → 'bool ] :=
-  [package
+  [package TAG_GUESS_locs ;
     #def #[gettag] (m: 'word): 'word {
       #import {sig #[lookup]: 'word → 'word } as lookup ;;
       S ← get S_loc ;;

--- a/theories/Crypt/examples/PRFPRG.v
+++ b/theories/Crypt/examples/PRFPRG.v
@@ -74,10 +74,6 @@ Definition count_loc: Location := (2, 'nat).
 Definition query: nat := 3.
 Definition lookup: nat := 4.
 
-Definition mkpair {Lt Lf E}
-  (t: package Lt [interface] E) (f: package Lf [interface] E):
-  loc_GamePair E := fun b => if b then {locpackage t} else {locpackage f}.
-
 Definition EVAL_locs_tt := [fmap k_loc].
 Definition EVAL_locs_ff := [fmap T_loc].
 
@@ -108,10 +104,10 @@ Hint Extern 1 (ValidCode ?L ?I kgen) =>
   : typeclass_instances ssprove_valid_db.
 
 Definition EVAL_pkg_tt:
-  package EVAL_locs_tt
+  package
     [interface]
     [interface #val #[lookup]: 'word → 'word ] :=
-  [package
+  [package EVAL_locs_tt ;
     #def #[lookup] (m: 'word): 'word {
       k ← kgen ;;
       ret (PRF k m)
@@ -119,10 +115,10 @@ Definition EVAL_pkg_tt:
   ].
 
 Definition EVAL_pkg_ff:
-  package EVAL_locs_ff
+  package
     [interface]
     [interface #val #[lookup]: 'word → 'word ] :=
-  [package
+  [package EVAL_locs_ff ;
     #def #[lookup] (m: 'word): 'word {
       T ← get T_loc ;;
       match getm T m with
@@ -135,12 +131,12 @@ Definition EVAL_pkg_ff:
     }
   ].
 
-Definition EVAL := mkpair EVAL_pkg_tt EVAL_pkg_ff.
+Definition EVAL b := if b then EVAL_pkg_tt else EVAL_pkg_ff.
 
 Definition GEN_pkg_tt:
-  package emptym [interface]
+  package [interface]
     [interface #val #[query]: 'unit → 'word × 'word ] :=
-  [package
+  [package emptym ;
     #def #[query] (_: 'unit): 'word × 'word {
       s <$ uniform Word_N ;;
       ret (PRF s zero, PRF s one)
@@ -148,9 +144,9 @@ Definition GEN_pkg_tt:
   ].
 
 Definition GEN_pkg_ff:
-  package emptym [interface]
+  package [interface]
     [interface #val #[query]: 'unit → 'word × 'word ] :=
-  [package
+  [package emptym ;
     #def #[query] (_: 'unit): 'word × 'word {
       x <$ uniform Word_N ;;
       y <$ uniform Word_N ;;
@@ -158,7 +154,7 @@ Definition GEN_pkg_ff:
     }
   ].
 
-Definition GEN := mkpair GEN_pkg_tt GEN_pkg_ff.
+Definition GEN b := if b then GEN_pkg_tt else GEN_pkg_ff.
 
 Definition GEN_HYB_locs := [fmap count_loc ].
 
@@ -171,10 +167,10 @@ Definition GEN_HYB_locs := [fmap count_loc ].
   are valid.
 *)
 Definition GEN_HYB_pkg i:
-  package GEN_HYB_locs
+  package
     [interface]
     [interface #val #[query]: 'unit → 'word × 'word ] :=
-  [package
+  [package GEN_HYB_locs ;
     #def #[query] (_: 'unit): 'word × 'word {
       count ← get count_loc ;;
       #put count_loc := count.+1 ;;
@@ -189,10 +185,10 @@ Definition GEN_HYB_pkg i:
   ].
 
 Definition GEN_HYB_EVAL_pkg i:
-  package GEN_HYB_locs
+  package
     [interface #val #[lookup]: 'word → 'word ]
     [interface #val #[query]: 'unit → 'word × 'word ] :=
-  [package
+  [package GEN_HYB_locs ;
     #def #[query] (_: 'unit): 'word × 'word {
       #import {sig #[lookup]: 'word → 'word } as lookup ;;
       count ← get count_loc ;;

--- a/theories/Crypt/examples/RandomOracle.v
+++ b/theories/Crypt/examples/RandomOracle.v
@@ -57,8 +57,8 @@ Module RO (π : ROParams).
       #val #[ QUERY ] : 'query → 'random
     ].
 
-  Definition RO : package RO_locs [interface] RO_exports :=
-    [package
+  Definition RO : package [interface] RO_exports :=
+    [package RO_locs ;
       #def #[ INIT ] (_ : 'unit) : 'unit
       {
         #put queries_loc := emptym ;;

--- a/theories/Crypt/examples/SecretSharing.v
+++ b/theories/Crypt/examples/SecretSharing.v
@@ -159,9 +159,9 @@ Notation " 'set t " := (chSet t) (at level 2): package_scope.
 Definition shares: nat := 0.
 
 Definition SHARE_pkg_tt:
-  package emptym [interface]
+  package [interface]
     [interface #val #[shares]: ('word × 'word) × 'set 'nat → 'seq 'word ] :=
-  [package
+  [package emptym ;
     #def #[shares] ('(ml, mr, U): ('word × 'word) × 'set 'nat): 'seq 'word {
       if size (domm U) >= 2 then ret emptym
       else
@@ -173,9 +173,9 @@ Definition SHARE_pkg_tt:
   ].
 
 Definition SHARE_pkg_ff:
-  package emptym [interface]
+  package [interface]
     [interface #val #[shares]: ('word × 'word) × 'set 'nat → 'seq 'word ] :=
-  [package
+  [package emptym ;
     #def #[shares] ('(ml, mr, U): ('word × 'word) × 'set 'nat): 'seq 'word {
       if size (domm U) >= 2 then ret emptym
       else
@@ -186,11 +186,7 @@ Definition SHARE_pkg_ff:
     }
   ].
 
-Definition mkpair {Lt Lf E}
-  (t: package Lt [interface] E) (f: package Lf [interface] E):
-  loc_GamePair E := fun b => if b then {locpackage t} else {locpackage f}.
-
-Definition SHARE := mkpair SHARE_pkg_tt SHARE_pkg_ff.
+Definition SHARE b := if b then SHARE_pkg_tt else SHARE_pkg_ff.
 
 Lemma SHARE_equiv:
   SHARE true ≈₀ SHARE false.

--- a/theories/Crypt/examples/ShamirSecretSharing.v
+++ b/theories/Crypt/examples/ShamirSecretSharing.v
@@ -976,18 +976,14 @@ Local Open Scope package_scope.
 
 Definition shares: nat := 0.
 
-Definition mkpair {Lt Lf E}
-  (t: package Lt [interface] E) (f: package Lf [interface] E):
-  loc_GamePair E := fun b => if b then {locpackage t} else {locpackage f}.
-
 (**
   Finally, we can define the packages and prove security of the protocol.
   This part is fairly easy now that we have a bijection.
 *)
 Definition SHARE_pkg_tt:
-  package emptym [interface]
+  package [interface]
     [interface #val #[shares]: ('word × 'word) × 'set 'party → 'seq 'share ] :=
-  [package
+  [package emptym ;
     #def #[shares] ('(ml, mr, U): ('word × 'word) × 'set 'party): 'seq 'share {
       if size (domm U) >= t then ret emptym
       else
@@ -999,9 +995,9 @@ Definition SHARE_pkg_tt:
   ].
 
 Definition SHARE_pkg_ff:
-  package emptym [interface]
+  package [interface]
     [interface #val #[shares]: ('word × 'word) × 'set 'party → 'seq 'share ] :=
-  [package
+  [package emptym ;
     #def #[shares] ('(ml, mr, U): ('word × 'word) × 'set 'party): 'seq 'share {
       if size (domm U) >= t then ret emptym
       else
@@ -1012,7 +1008,7 @@ Definition SHARE_pkg_ff:
     }
   ].
 
-Definition SHARE := mkpair SHARE_pkg_tt SHARE_pkg_ff.
+Definition SHARE b := if b then SHARE_pkg_tt else SHARE_pkg_ff.
 
 Lemma SHARE_equiv:
   SHARE true ≈₀ SHARE false.

--- a/theories/Crypt/examples/SigmaProtocol.v
+++ b/theories/Crypt/examples/SigmaProtocol.v
@@ -156,11 +156,10 @@ Module SigmaProtocol (π : SigmaProtocolParams)
   #[local] Open Scope package_scope.
 
   Definition SHVZK_real:
-    package Sigma_locs
-      [interface]
+    package [interface]
       [interface #val #[ TRANSCRIPT ] : chInput → chTranscript]
     :=
-    [package
+    [package Sigma_locs ;
       #def #[ TRANSCRIPT ] (hwe : chInput) : chTranscript
       {
         let '(h,w,e) := hwe in
@@ -172,11 +171,10 @@ Module SigmaProtocol (π : SigmaProtocolParams)
     ].
 
   Definition SHVZK_ideal:
-    package Simulator_locs
-      [interface]
+    package [interface]
       [interface #val #[ TRANSCRIPT ] : chInput → chTranscript]
     :=
-    [package
+    [package Simulator_locs ;
       #def #[ TRANSCRIPT ] (hwe : chInput) : chTranscript
       {
         let '(h, w, e) := hwe in
@@ -190,11 +188,10 @@ Module SigmaProtocol (π : SigmaProtocolParams)
   Definition ɛ_SHVZK A := AdvantageE SHVZK_real SHVZK_ideal A.
 
   Definition Special_Soundness_f :
-    package emptym
-      [interface]
+    package [interface]
       [interface #val #[ SOUNDNESS ] : chSoundness → 'bool ]
     :=
-    [package
+    [package emptym ;
       #def #[ SOUNDNESS ] (t : chSoundness) : 'bool
       {
         let '(h, (a, ((e, z), (e', z')))) := t in
@@ -210,11 +207,10 @@ Module SigmaProtocol (π : SigmaProtocolParams)
     ].
 
   Definition Special_Soundness_t :
-    package emptym
-      [interface]
+    package [interface]
       [interface #val #[ SOUNDNESS ] : chSoundness → 'bool ]
     :=
-    [package
+    [package emptym ;
       #def #[ SOUNDNESS ] (t : chSoundness) : 'bool
       {
         let '(h, (a, ((e, z), (e', z')))) := t in
@@ -255,14 +251,13 @@ Module SigmaProtocol (π : SigmaProtocolParams)
     Notation " 'chKeys' " := (chProd choiceStatement choiceWitness) (in custom pack_type at level 2).
 
     Definition KEY:
-      package KEY_locs
-        [interface]
+      package [interface]
         [interface
            #val #[ INIT ] : 'unit → 'unit ;
            #val #[ GET ] : 'unit → chStatement
         ]
       :=
-      [package
+      [package KEY_locs ;
          #def #[ INIT ] (_ : 'unit) : 'unit
          {
            b ← get setup_loc ;;
@@ -301,7 +296,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
     Context (compatComSim : fcompat Com_locs Simulator_locs).
 
     Definition Sigma_to_Com :
-      package Sigma_to_Com_locs
+      package
         [interface
           #val #[ INIT ] : 'unit → 'unit ;
           #val #[ GET ] : 'unit → chStatement
@@ -311,7 +306,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
           #val #[ OPEN ] : 'unit → chOpen ;
           #val #[ VER ] : chTranscript → 'bool
         ] :=
-      [package
+      [package Sigma_to_Com_locs ;
         #def #[ COM ] (e : chChallenge) : chMessage
         {
           #import {sig #[ INIT ] : 'unit → 'unit } as key_gen_init ;;
@@ -342,7 +337,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
       ].
 
     Definition Sigma_to_Com_Aux:
-      package (unionm [fmap setup_loc] Sigma_to_Com_locs)
+      package
         [interface
           #val #[ TRANSCRIPT ] : chInput → chTranscript
         ]
@@ -351,7 +346,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
           #val #[ OPEN ] : 'unit → chOpen ;
           #val #[ VER ] : chTranscript → 'bool
         ] :=
-      [package
+      [package unionm [fmap setup_loc] Sigma_to_Com_locs ;
         #def #[ COM ] (e : chChallenge) : chMessage
         {
           #import {sig #[ TRANSCRIPT ] : chInput → chTranscript } as RUN ;;
@@ -390,7 +385,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
 
     (* Commitment to input value*)
     Definition Hiding_real:
-      package emptym
+      package
         [interface
           #val #[ COM ] : chChallenge → chMessage ;
           #val #[ OPEN ] : 'unit → chOpen ;
@@ -398,7 +393,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
         ]
         Hiding_E
       :=
-      [package
+      [package emptym ;
         #def #[ HIDING ] (ms : chHiding) : chMessage
         {
           #import {sig #[ COM ] : chChallenge → chMessage } as com ;;
@@ -415,7 +410,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
 
     (* Commitment to random value *)
     Definition Hiding_ideal :
-      package emptym
+      package
         [interface
           #val #[ COM ] : chChallenge → chMessage ;
           #val #[ OPEN ] : 'unit → chOpen ;
@@ -423,7 +418,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
         ]
         Hiding_E
       :=
-      [package
+      [package emptym ;
         #def #[ HIDING ] (_ : chHiding) : chMessage
         {
           #import {sig #[ COM ] : chChallenge → chMessage } as com ;;
@@ -666,7 +661,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
     Qed.
 
     Definition Com_Binding:
-      package emptym
+      package
         [interface
           #val #[ COM ] : chChallenge → chMessage ;
           #val #[ OPEN ] : 'unit → chOpen ;
@@ -674,7 +669,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
         ]
         [interface #val #[ SOUNDNESS ] : chSoundness → 'bool ]
       :=
-      [package
+      [package emptym ;
         #def #[ SOUNDNESS ] (t : chSoundness) : 'bool
         {
           #import {sig #[ VER ] : chTranscript → 'bool } as Ver ;;
@@ -756,7 +751,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
       : typeclass_instances ssprove_valid_db.
 
     Definition Fiat_Shamir :
-      package Sigma_locs
+      package
         [interface
           #val #[ INIT ] : 'unit → 'unit ;
           #val #[ QUERY ] : 'query → 'random
@@ -766,7 +761,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
           #val #[ RUN ] : chRelation → chTranscript
         ]
       :=
-      [package
+      [package Sigma_locs ;
         #def #[ VERIFY ] (t : chTranscript) : 'bool
         {
           #import {sig #[ QUERY ] : 'query → 'random } as RO_query ;;
@@ -789,7 +784,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
       ].
 
     Definition Fiat_Shamir_SIM :
-      package Sim_locs
+      package
         [interface
           #val #[ QUERY ] : 'query → 'random
         ]
@@ -798,7 +793,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
           #val #[ RUN ] : chRelation → chTranscript
         ]
       :=
-      [package
+      [package Sim_locs ;
         #def #[ VERIFY ] (t : chTranscript) : 'bool
         {
           #import {sig #[ QUERY ] : 'query → 'random } as RO_query ;;
@@ -816,14 +811,14 @@ Module SigmaProtocol (π : SigmaProtocolParams)
       ].
 
     Definition RUN_interactive :
-      package Sigma_locs
+      package
         [interface]
         [interface
           #val #[ VERIFY ] : chTranscript → 'bool ;
           #val #[ RUN ] : chRelation → chTranscript
         ]
       :=
-      [package
+      [package Sigma_locs ;
         #def #[ VERIFY ] (t : chTranscript) : 'bool
         {
           let '(h,a,e,z) := t in
@@ -841,11 +836,11 @@ Module SigmaProtocol (π : SigmaProtocolParams)
       ].
 
     Definition SHVZK_real_aux :
-      package Sigma_locs
+      package
         [interface #val #[ TRANSCRIPT ] : chInput → chTranscript ]
         [interface #val #[ RUN ] : chRelation → chTranscript ]
       :=
-      [package
+      [package Sigma_locs ;
         #def #[ RUN ] (hw : chRelation) : chTranscript
         {
           #import {sig #[ TRANSCRIPT ] : chInput → chTranscript } as SHVZK ;;

--- a/theories/Crypt/examples/SigmaProtocol.v
+++ b/theories/Crypt/examples/SigmaProtocol.v
@@ -855,18 +855,20 @@ Module SigmaProtocol (π : SigmaProtocolParams)
         }
       ].
 
+    Definition IRUN := [interface #val #[ RUN ] : chRelation → chTranscript].
+
     Lemma run_interactive_shvzk :
       ∀ LA A,
         ValidPackage LA [interface
           #val #[ RUN ] : chRelation → chTranscript
         ] A_export A →
         fseparate LA Sigma_locs →
-        AdvantageE RUN_interactive (SHVZK_real_aux ∘ SHVZK_real) A = 0.
+        AdvantageE (ID IRUN ∘ RUN_interactive) (SHVZK_real_aux ∘ SHVZK_real) A = 0.
     Proof.
       intros LA A Va Hdisj.
       eapply eq_rel_perf_ind_eq.
-      2: ssprove_valid.
-      1,3: ssprove_valid.
+      4: apply Va.
+      1,2: ssprove_valid.
       2,3: fmap_solve.
       simplify_eq_rel hw.
       ssprove_code_simpl.
@@ -887,26 +889,27 @@ Module SigmaProtocol (π : SigmaProtocolParams)
       rewrite code_link_scheme
       : ssprove_code_simpl.
 
+    (* Adequacy: fiat_shamir is not proven equivalent on the VERIFY call *)
     Theorem fiat_shamir_correct :
       ∀ LA A ,
-        ValidPackage LA [interface
-          #val #[ RUN ] : chRelation → chTranscript
-        ] A_export A →
+        ValidPackage LA IRUN A_export A →
         fseparate LA Sigma_locs →
         fseparate LA RO_locs →
         fseparate Sigma_locs RO_locs →
-        AdvantageE (Fiat_Shamir ∘ RO) RUN_interactive A = 0.
+        AdvantageE (ID IRUN ∘ Fiat_Shamir ∘ RO) (ID IRUN ∘ RUN_interactive) A = 0.
     Proof.
       intros LA A Va Hd1 Hd2 Hd3.
       eapply eq_rel_perf_ind_ignore.
       5: ssprove_valid.
       1,2: ssprove_valid.
       3,4: fmap_solve.
-      1: apply fsubmapUl_trans, fsubmapUr; fmap_solve.
+      1: rewrite union0m; apply fsubmapUl_trans, fsubmapUr; fmap_solve.
       simplify_eq_rel hw.
-      ssprove_code_simpl.
       destruct hw as [h w].
+      ssprove_code_simpl.
+      ssprove_code_simpl_more.
       ssprove_sync. intros rel.
+      ssprove_code_simpl.
       eapply rsame_head_alt.
       1: exact _.
       1:{

--- a/theories/Crypt/examples/SigmaProtocol.v
+++ b/theories/Crypt/examples/SigmaProtocol.v
@@ -527,7 +527,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
             unfold inv.
             intros l lin h1 s' h2.
             apply h2.
-            eapply notin_temp; [ eassumption | ].
+            eapply notin_has_separate; [ eassumption | ].
             apply (fseparate_trans_r _ _ KEY_locs).
             1,2: fmap_solve.
           }
@@ -574,7 +574,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
             unfold inv.
             intros l lin h1 s' h2.
             apply h2.
-            eapply notin_temp; [ eassumption | ].
+            eapply notin_has_separate; [ eassumption | ].
             apply (fseparate_trans_r _ _ KEY_locs).
             1,2: fmap_solve.
           }
@@ -641,7 +641,7 @@ Module SigmaProtocol (π : SigmaProtocolParams)
           unfold inv.
           intros l lin h1 s' h2.
           apply h2.
-          eapply notin_temp; [ eassumption | ].
+          eapply notin_has_separate; [ eassumption | ].
           apply (fseparate_trans_r _ _ KEY_locs).
           1,2: fmap_solve.
         }

--- a/theories/Crypt/examples/StretchPRG.v
+++ b/theories/Crypt/examples/StretchPRG.v
@@ -49,14 +49,10 @@ Context (PRG: Word -> Word * Word).
 
 Definition query: nat := 0.
 
-Definition mkpair {Lt Lf E}
-  (t: package Lt [interface] E) (f: package Lf [interface] E):
-  loc_GamePair E := fun b => if b then {locpackage t} else {locpackage f}.
-
 Definition GEN_pkg_tt:
-  package emptym [interface]
+  package [interface]
     [interface #val #[query]: 'unit → 'word × 'word ] :=
-  [package
+  [package emptym ;
     #def #[query] (_: 'unit): 'word × 'word {
       s <$ uniform Word_N ;;
       ret (PRG s)
@@ -64,9 +60,9 @@ Definition GEN_pkg_tt:
   ].
 
 Definition GEN_pkg_ff:
-  package emptym [interface]
+  package [interface]
     [interface #val #[query]: 'unit → 'word × 'word ] :=
-  [package
+  [package emptym ;
     #def #[query] (_: 'unit): 'word × 'word {
       x <$ uniform Word_N ;;
       y <$ uniform Word_N ;;
@@ -74,12 +70,12 @@ Definition GEN_pkg_ff:
     }
   ].
 
-Definition GEN := mkpair GEN_pkg_tt GEN_pkg_ff.
+Definition GEN b := if b then GEN_pkg_tt else GEN_pkg_ff.
 
 Definition GEN_STRETCH_pkg_tt:
-  package emptym [interface]
+  package [interface]
     [interface #val #[query]: 'unit → 'word × 'word × 'word ] :=
-  [package
+  [package emptym ;
     #def #[query] (_: 'unit): 'word × 'word × 'word {
       s <$ uniform Word_N ;;
       let (x, y) := PRG s in
@@ -88,9 +84,9 @@ Definition GEN_STRETCH_pkg_tt:
   ].
 
 Definition GEN_STRETCH_pkg_ff:
-  package emptym [interface]
+  package [interface]
     [interface #val #[query]: 'unit → 'word × 'word × 'word ] :=
-  [package
+  [package emptym ;
     #def #[query] (_: 'unit): 'word × 'word × 'word {
       x <$ uniform Word_N ;;
       u <$ uniform Word_N ;;
@@ -99,13 +95,13 @@ Definition GEN_STRETCH_pkg_ff:
     }
   ].
 
-Definition GEN_STRETCH := mkpair GEN_STRETCH_pkg_tt GEN_STRETCH_pkg_ff.
+Definition GEN_STRETCH b := if b then GEN_STRETCH_pkg_tt else GEN_STRETCH_pkg_ff.
 
 Definition GEN_STRETCH_HYB_pkg_1:
-  package emptym
+  package
     [interface #val #[query]: 'unit → 'word × 'word ]
     [interface #val #[query]: 'unit → 'word × 'word × 'word ] :=
-  [package
+  [package emptym ;
     #def #[query] (_: 'unit): 'word × 'word × 'word {
       #import {sig #[query]: 'unit → 'word × 'word } as query ;;
       '(x, y) ← query tt ;;
@@ -114,10 +110,10 @@ Definition GEN_STRETCH_HYB_pkg_1:
   ].
 
 Definition GEN_STRETCH_HYB_pkg_2:
-  package emptym
+  package
     [interface #val #[query]: 'unit → 'word × 'word ]
     [interface #val #[query]: 'unit → 'word × 'word × 'word ] :=
-  [package
+  [package emptym ;
     #def #[query] (_: 'unit): 'word × 'word × 'word {
       #import {sig #[query]: 'unit → 'word × 'word } as query ;;
       x <$ uniform Word_N ;;

--- a/theories/Crypt/examples/SymmRatchet.v
+++ b/theories/Crypt/examples/SymmRatchet.v
@@ -464,10 +464,11 @@ Proof.
   as ineq.
   apply: le_trans.
   1: by apply: ineq.
-  rewrite -> ATTACK_equiv_true, GRing.add0r by fmap_solve.
-  rewrite -> ATTACK_HYB_equiv_1, GRing.addr0 by fmap_solve.
-  rewrite -> ATTACK_HYB_equiv_2, GRing.addr0 by fmap_solve.
-  rewrite -> ATTACK_equiv_false, GRing.addr0 by fmap_solve.
+  rewrite -> ATTACK_equiv_true by fmap_solve.
+  rewrite -> ATTACK_HYB_equiv_1 by fmap_solve.
+  rewrite -> ATTACK_HYB_equiv_2 by fmap_solve.
+  rewrite -> ATTACK_equiv_false by fmap_solve.
+  rewrite GRing.add0r 3!GRing.addr0.
   rewrite /prg_epsilon /cpa_epsilon !Advantage_E -!Advantage_link.
   by rewrite (Advantage_sym (GEN_STRETCH true)) (Advantage_sym (CTXT true)).
 Qed.

--- a/theories/Crypt/examples/SymmRatchet.v
+++ b/theories/Crypt/examples/SymmRatchet.v
@@ -83,10 +83,6 @@ Definition ctxt: nat := 0.
 Definition query: nat := 1.
 Definition attack: nat := 2.
 
-Definition mkpair {Lt Lf E}
-  (t: package Lt [interface] E) (f: package Lf [interface] E):
-  loc_GamePair E := fun b => if b then {locpackage t} else {locpackage f}.
-
 (**
   A [map_loop] is like the [map] function, but it can be used directly as [code]
   in SSProve. This makes it possible to use features from SSProve inside it,
@@ -160,10 +156,10 @@ Hint Extern 50 (_ = code_link (map_loop _ _ _) _) =>
   : ssprove_code_simpl.
 
 Definition CTXT_pkg_tt:
-  package emptym
+  package
     [interface]
     [interface #val #[ctxt]: 'word → 'word ] :=
-  [package
+  [package emptym ;
     #def #[ctxt] (m: 'word): 'word {
       k <$ uniform Word_N ;;
       ret (enc k m)
@@ -171,17 +167,17 @@ Definition CTXT_pkg_tt:
   ].
 
 Definition CTXT_pkg_ff:
-  package emptym
+  package
     [interface]
     [interface #val #[ctxt]: 'word → 'word ] :=
-  [package
+  [package emptym ;
     #def #[ctxt] (m: 'word): 'word {
       c <$ uniform Word_N ;;
       ret c
     }
   ].
 
-Definition CTXT := mkpair CTXT_pkg_tt CTXT_pkg_ff.
+Definition CTXT b := if b then CTXT_pkg_tt else CTXT_pkg_ff.
 
 (**
   We only define security of the stretched PRG. It is not currently possible to
@@ -195,9 +191,9 @@ Definition CTXT := mkpair CTXT_pkg_tt CTXT_pkg_ff.
   leave it as an assumption.
 *)
 Definition GEN_STRETCH_pkg_tt:
-  package emptym [interface]
+  package [interface]
     [interface #val #[query]: 'nat → ('seq 'word) × 'word ] :=
-  [package
+  [package emptym ;
     #def #[query] (k: 'nat): ('seq 'word) × 'word {
       s0 <$ uniform Word_N ;;
       @map_loop _ Word _ (iota 0 k) s0 (fun _ si =>
@@ -207,9 +203,9 @@ Definition GEN_STRETCH_pkg_tt:
   ].
 
 Definition GEN_STRETCH_pkg_ff:
-  package emptym [interface]
+  package [interface]
     [interface #val #[query]: 'nat → ('seq 'word) × 'word ] :=
-  [package
+  [package emptym ;
     #def #[query] (k: 'nat): ('seq 'word) × 'word {
       t ← @map_loop _ Word _ (iota 0 k) tt (fun _ _ =>
         ti <$ uniform Word_N ;;
@@ -220,15 +216,15 @@ Definition GEN_STRETCH_pkg_ff:
     }
   ].
 
-Definition GEN_STRETCH := mkpair GEN_STRETCH_pkg_tt GEN_STRETCH_pkg_ff.
+Definition GEN_STRETCH b := if b then GEN_STRETCH_pkg_tt else GEN_STRETCH_pkg_ff.
 
 (**
   The rest of the games are similar to the ones in the book.
 *)
 Definition ATTACK_pkg_tt:
-  package emptym [interface]
+  package [interface]
     [interface #val #[attack]: 'seq 'word → ('seq 'word) × 'word ] :=
-  [package
+  [package emptym ;
     #def #[attack] (m: 'seq 'word): ('seq 'word) × 'word {
       s0 <$ uniform Word_N ;;
       @map_loop _ Word _ (unzip2 m) s0 (fun mi si =>
@@ -239,9 +235,9 @@ Definition ATTACK_pkg_tt:
   ].
 
 Definition ATTACK_pkg_ff:
-  package emptym [interface]
+  package [interface]
     [interface #val #[attack]: 'seq 'word → ('seq 'word) × 'word ] :=
-  [package
+  [package emptym ;
     #def #[attack] (m: 'seq 'word): ('seq 'word) × 'word {
       c ← @map_loop _ Word _ (unzip2 m) tt (fun _ _ =>
         ci <$ uniform Word_N ;;
@@ -252,13 +248,13 @@ Definition ATTACK_pkg_ff:
     }
   ].
 
-Definition ATTACK := mkpair ATTACK_pkg_tt ATTACK_pkg_ff.
+Definition ATTACK b := if b then ATTACK_pkg_tt else ATTACK_pkg_ff.
 
 Definition ATTACK_GEN_pkg:
-  package emptym
+  package
     [interface #val #[query]: 'nat → ('seq 'word) × 'word ]
     [interface #val #[attack]: 'seq 'word → ('seq 'word) × 'word ] :=
-  [package
+  [package emptym ;
     #def #[attack] (m: 'seq 'word): ('seq 'word) × 'word {
       #import {sig #[query]: 'nat → ('seq 'word) × 'word } as query ;;
       ts ← query (size m) ;;
@@ -271,9 +267,9 @@ Definition ATTACK_GEN_pkg:
   ].
 
 Definition ATTACK_HYB_pkg:
-  package emptym [interface]
+  package [interface]
     [interface #val #[attack]: 'seq 'word → ('seq 'word) × 'word ] :=
-  [package
+  [package emptym ;
     #def #[attack] (m: 'seq 'word): ('seq 'word) × 'word {
       c ← @map_loop _ Word _ (unzip2 m) tt (fun mi _ =>
         ti <$ uniform Word_N ;;
@@ -285,10 +281,10 @@ Definition ATTACK_HYB_pkg:
   ].
 
 Definition ATTACK_CTXT_pkg:
-  package emptym
+  package
   [interface #val #[ctxt]: 'word → 'word ]
     [interface #val #[attack]: 'seq 'word → ('seq 'word) × 'word ] :=
-  [package
+  [package emptym ;
     #def #[attack] (m: 'seq 'word): ('seq 'word) × 'word {
       #import {sig #[ctxt]: 'word → 'word } as ctxt ;;
       c ← @map_loop _ Word _ (unzip2 m) tt (fun mi _ =>

--- a/theories/Crypt/examples/interpreter_test.v
+++ b/theories/Crypt/examples/interpreter_test.v
@@ -63,8 +63,8 @@ Section Test.
     ].
 
   #[local] Definition test_pack:
-    package locs [interface] E :=
-    [package
+    package [interface] E :=
+    [package locs ;
        #def #[ 0 ] (x : 'nat) : 'nat
        {
          k ← sample uniform 20 ;;

--- a/theories/Crypt/examples/package_usage_example.v
+++ b/theories/Crypt/examples/package_usage_example.v
@@ -36,18 +36,18 @@ Definition I2 : Interface :=
     #val #[4] : 'bool × 'bool → 'bool
   ].
 
-Definition pempty : package emptym [interface] [interface] :=
-  [package].
+Definition pempty : package [interface] [interface] :=
+  [package emptym].
 
-Definition p0 : package emptym [interface] I0 :=
-  [package
+Definition p0 : package [interface] I0 :=
+  [package emptym ;
     #def #[3] (x : 'nat) : 'nat {
       ret x
     }
   ].
 
-Definition p1 : package emptym [interface] I1 :=
-  [package
+Definition p1 : package [interface] I1 :=
+  [package emptym ;
     #def #[0] (z : 'bool) : 'bool {
       ret z
     } ;
@@ -65,8 +65,8 @@ Definition foo (x : bool) : code emptym [interface] bool :=
 Definition bar (b : bool) : code emptym [interface] nat :=
   {code if b then ret 0 else ret 1}.
 
-Definition p2 : package emptym [interface] I2 :=
-  [package
+Definition p2 : package [interface] I2 :=
+  [package emptym ;
     #def #[4] (x : 'bool × 'bool) : 'bool {
       let '(u,v) := x in ret v
     }
@@ -74,14 +74,13 @@ Definition p2 : package emptym [interface] I2 :=
 
 Definition test₁ :
   package
-    [fmap (0, 'nat) ]
     [interface #val #[0] : 'nat → 'nat]
     [interface
       #val #[1] : 'nat → 'nat ;
       #val #[2] : 'unit → 'unit
     ]
   :=
-  [package
+  [package [fmap (0, 'nat) ] ;
     #def #[1] (x : 'nat) : 'nat {
       getr (0, 'nat) (λ n : nat,
         opr (0, ('nat, 'nat)) n (λ m,
@@ -98,7 +97,6 @@ Definition sig := {sig #[0] : 'nat → 'nat }.
 
 #[program] Definition test₂ :
   package
-    [fmap (0, 'nat)]
     [interface #val #[0] : 'nat → 'nat ]
     [interface
       #val #[1] : 'nat → 'nat ;
@@ -106,7 +104,7 @@ Definition sig := {sig #[0] : 'nat → 'nat }.
       #val #[3] : {map 'nat → 'nat} → 'option 'nat
     ]
   :=
-  [package
+  [package [fmap (0, 'nat)] ;
     #def #[1] (x : 'nat) : 'nat {
       n ← get (0, 'nat) ;;
       m ← op sig ⋅ n ;;
@@ -127,7 +125,6 @@ Definition sig := {sig #[0] : 'nat → 'nat }.
 (* Testing the #import notation *)
 Definition test₃ :
   package
-    emptym
     [interface
       #val #[0] : 'nat → 'bool ;
       #val #[1] : 'bool → 'unit
@@ -137,7 +134,7 @@ Definition test₃ :
       #val #[3] : 'bool × 'bool → 'bool
     ]
   :=
-  [package
+  [package emptym ;
     #def #[2] (n : 'nat) : 'nat {
       #import {sig #[0] : 'nat → 'bool } as f ;;
       #import {sig #[1] : 'bool → 'unit } as g ;;
@@ -156,8 +153,8 @@ Definition test₃ :
 (** Information is redundant between the export interface and the package
     definition, so it can safely be skipped.
 *)
-Definition test₄ : package emptym [interface] _ :=
-  [package
+Definition test₄ : package [interface] _ :=
+  [package emptym ;
     #def #[ 0 ] (n : 'nat) : 'nat {
       ret (n + n)%N
     } ;

--- a/theories/Crypt/package/fmap_extra.v
+++ b/theories/Crypt/package/fmap_extra.v
@@ -10,6 +10,21 @@ From extructures Require Import ord fset fmap.
 
 #[local] Open Scope fset.
 
+(******************************************************************************)
+(* Extra definitions and lemmas about fmap from extructures.                  *)
+(* This file also provides fmap_solve, which automates proofs of the defs.    *)
+(* below using auto based on the hint database fmap_solve_db. fmap_solve has  *)
+(* some support for symbolic terms, but generally does not deconstruct        *)
+(* assumptions in the context. More hints may be added to extend the solver.  *)
+(* Definitions:                                                               *)
+(*             fhas m kv == the key-value pair kv is present in m             *)
+(*          fsubmap m m' == m is a submap of m' i.e. when m has value v at    *)
+(*                          key k, then m' has value v at key k.              *)
+(*          fcompat m m' == if both maps define a key it has the same value   *)
+(*        fseparate m m' == maps m and m' define a disjoint set of keys.      *)
+(*                          Separation of maps implies compatability.         *)
+(******************************************************************************)
+
 Set Bullet Behavior "Strict Subproofs".
 Set Default Goal Selector "!".
 Set Primitive Projections.
@@ -476,10 +491,7 @@ Hint Extern 4 (fcompat _ _) =>
 Hint Extern 4 (fseparate _ _) =>
   apply fseparateC; done : fmap_solve_db.
 
-(* This hint should not be necessary *)
-(* Hint Resolve fseparateE : fmap_solve_db. *)
-
-Lemma notin_temp {T : ordType} {S : Type} (m m' : {fmap T → S}) (l : T * S)
+Lemma notin_has_separate {T : ordType} {S : Type} (m m' : {fmap T → S}) (l : T * S)
   : fhas m l → fseparate m m' → l.1 \notin domm m'.
 Proof.
   move=> H [H'].
@@ -488,4 +500,4 @@ Proof.
 Qed.
 
 Hint Extern 4 (is_true (_ \notin _)) =>
-  eapply notin_temp; [ eassumption | ] : fmap_solve_db.
+  eapply notin_has_separate; [ eassumption | ] : fmap_solve_db.

--- a/theories/Crypt/package/fmap_extra.v
+++ b/theories/Crypt/package/fmap_extra.v
@@ -136,24 +136,50 @@ Qed.
 Lemma fsubmapxx {T : ordType} {S} (m : {fmap T → S}) : fsubmap m m.
 Proof. rewrite /fsubmap unionmI //. Qed.
 
-Lemma fhas_cons {T : ordType} {S} x' x (xs : seq (T * S)) :
-  fhas (mkfmap (x :: xs)) x' → x = x' ∨ fhas (mkfmap xs) x'.
+Lemma fsubmap_eq {T : ordType} {S} (m m' : {fmap T → S}) :
+  fsubmap m m' → fsubmap m' m → m = m'.
 Proof.
-  move: x x' => [t s] [t' s'] H.
+  unfold fsubmap.
+  intros H H'.
+  rewrite -H -{1}H'.
+  eapply fsubmap_fcompat.
+  1: apply H'.
+  apply fsubmapxx.
+Qed.
+
+Lemma fhas_set_case {T : ordType} {S} x y (m : {fmap T → S}) :
+  fhas (setm m x.1 x.2) y → (x = y) ∨ fhas m y.
+Proof.
+  move: x y => [k v] [k' v'] H.
   rewrite /fhas //= setmE in H.
-  destruct (t' == t) eqn:E.
+  destruct (k' == k) eqn:E.
   - left.
-    move: E => /eqP -> {t'}.
+    move: E => /eqP -> {k'}.
     by noconf H.
   - by right.
 Qed.
+
+Lemma fhas_union {S : ordType} {T} m m' (k : S) (v : T)
+  : fhas (unionm m m') (k, v) → fhas m (k, v) ∨ fhas m' (k, v).
+Proof.
+  rewrite /fhas unionmE.
+  destruct (m k) => //=; auto.
+Qed.
+
+Lemma fhas_union_l {S : ordType} {T} m m' (k : S) (v : T)
+  : fhas m (k, v) → fhas (unionm m m') (k, v).
+Proof.
+  rewrite /fhas unionmE.
+  destruct (m k) => //=; auto.
+Qed.
+
 
 (* Tactics *)
 
 Ltac fmap_invert H :=
   (by apply fhas_empty in H) ||
   ( let x := fresh "x" in
-    apply fhas_cons in H ;
+    apply fhas_set_case in H ;
     destruct H as [x|H]; [ noconf x | fmap_invert H ]
   ).
 

--- a/theories/Crypt/package/pkg_advantage.v
+++ b/theories/Crypt/package/pkg_advantage.v
@@ -284,19 +284,14 @@ Lemma Advantage_par :
     ValidPackage L₀ Game_import E₀ G₀ →
     ValidPackage L₁ Game_import E₁ G₁ →
     ValidPackage L₁' Game_import E₁ G₁' →
-    trimmed E₀ G₀ →
-    trimmed E₁ G₁ →
-    trimmed E₁ G₁' →
     AdvantageE (par G₀ G₁) (par G₀ G₁') A =
     AdvantageE G₁ G₁' (A ∘ par G₀ (ID E₁)).
 Proof.
-  intros G₀ G₁ G₁' A L₀ L₁ L₁' E₀ E₁.
-  intros Va0 Va1 Va1' Te0 Te1 Te1'.
+  intros G₀ G₁ G₁' A L₀ L₁ L₁' E₀ E₁ Va0 Va1 Va1'.
   replace (par G₀ G₁) with ((par G₀ (ID E₁)) ∘ (par (ID Game_import) G₁)).
   2:{
     erewrite <- interchange.
     all: ssprove_valid.
-    2: apply trimmed_ID.
     2: fmap_solve.
     rewrite link_id // id_link //.
   }
@@ -304,12 +299,10 @@ Proof.
   2:{
     erewrite <- interchange.
     all: ssprove_valid.
-    2: apply trimmed_ID.
     2: fmap_solve.
     rewrite link_id // id_link //.
   }
   rewrite -Advantage_link Advantage_par_empty //.
-  Unshelve. all: auto.
 Qed.
 
 Lemma Advantage_sym :

--- a/theories/Crypt/package/pkg_advantage.v
+++ b/theories/Crypt/package/pkg_advantage.v
@@ -37,23 +37,19 @@ Set Primitive Projections.
 
 Definition Game_import : Interface := [interface].
 
-Definition Game_Type (Game_export : Interface) : Type :=
-  loc_package Game_import Game_export.
+Notation game E := (package Game_import E).
 
 Definition RUN := (0%N, ('unit, 'bool)).
 
 Definition A_export : Interface := mkfmap [:: RUN ].
+
+Notation adversary I := (package I A_export).
 
 Lemma RUN_in_A_export : A_export RUN.1 = Some RUN.2.
 Proof.
   rewrite setmE //.
 Qed.
 
-Definition Adversary4Game (Game_export : Interface) : Type :=
-  loc_package Game_export A_export.
-
-Definition Adversary4Game_weak (Game_export : Interface) : Type :=
-  package emptym Game_export A_export.
 
 Definition Game_op_import_S : Type := {_ : ident & void}.
 
@@ -81,14 +77,7 @@ Definition Pr (p : raw_package) :
     (λ '(b, _), SDistr_unit _ b)
     (Pr_op p RUN tt empty_heap).
 
-Definition loc_GamePair (Game_export : Interface) :=
-  bool → Game_Type Game_export.
-
-(* TODO Again, why not an actual pair? *)
-Definition GamePair :=
-  bool → raw_package.
-
-Definition Advantage (G : GamePair) (A : raw_package) : R :=
+Definition Advantage (G : bool → raw_package) (A : raw_package) : R :=
   `| Pr (A ∘ (G false)) true - Pr (A ∘ (G true)) true |.
 
 Definition AdvantageE (G₀ G₁ : raw_package) (A : raw_package) : R :=
@@ -239,21 +228,21 @@ Notation " G0 ≈₀ G1 " :=
   : package_scope.
 
 Lemma Advantage_equiv :
-  ∀ I (G : loc_GamePair I),
+  ∀ I (G : bool → game I),
     (G false) ≈[ Advantage G ] (G true).
 Proof.
   intros I G. intros LA A vA hd₀ hd₁. reflexivity.
 Qed.
 
 Lemma AdvantageE_equiv :
-  ∀ I (G₀ G₁ : Game_Type I),
+  ∀ I (G₀ G₁ : game I),
     G₀ ≈[ AdvantageE G₀ G₁ ] G₁.
 Proof.
   intros I G₀ G₁. intros LA A vA hd₀ hd₁. reflexivity.
 Qed.
 
 Lemma Advantage_E :
-  ∀ (G : GamePair) A,
+  ∀ (G : bool → raw_package) A,
     Advantage G A = AdvantageE (G false) (G true) A.
 Proof.
   intros G A.
@@ -376,7 +365,7 @@ Qed.
 
 Lemma TriangleInequality :
   ∀ {Game_export : Interface}
-    {F G H : Game_Type Game_export}
+    {F G H : game Game_export}
     {ϵ1 ϵ2 ϵ3},
     F ≈[ ϵ1 ] G →
     G ≈[ ϵ2 ] H →
@@ -395,7 +384,7 @@ Proof.
 Qed.
 
 Lemma Reduction :
-  ∀ (M : raw_package) (G : GamePair) A b,
+  ∀ (M : raw_package) (G : bool → raw_package) A b,
     `| Pr (A ∘ (M ∘ (G b))) true | =
     `| Pr ((A ∘ M) ∘ (G b)) true |.
 Proof.
@@ -404,7 +393,7 @@ Proof.
 Qed.
 
 Lemma ReductionLem :
-  ∀ L₀ L₁ E M (G : GamePair)
+  ∀ L₀ L₁ E M (G : bool → raw_package)
     `{ValidPackage L₀ Game_import E (M ∘ G false)}
     `{ValidPackage L₁ Game_import E (M ∘ G true)},
     (M ∘ (G false)) ≈[ λ A, Advantage G (A ∘ M) ] (M ∘ (G true)).

--- a/theories/Crypt/package/pkg_composition.v
+++ b/theories/Crypt/package/pkg_composition.v
@@ -100,24 +100,6 @@ Definition link (p1 p2 : raw_package) : raw_package :=
   @mapm _ typed_raw_function _
     (λ '(So ; To ; f), (So ; To ; λ x, code_link (f x) p2)) p1.
 
-Lemma some_kleisli {S T S' T' : choice_type} (f : S → raw_code T) (g : S' → raw_code T') :
-  Some ((S; T; f) : typed_raw_function) = Some ((S'; T'; g) : typed_raw_function) → S = S' ∧ T = T' ∧ coerce_kleisli f = g.
-Proof.
-  (*
-  move: g.
-  intros H.
-  change g with ((S'; T'; g) : typed_raw_function).π2.π2.
-  rewrite -H.
-  intros H. injection H => {}H ? ?.
-  subst. repeat split.
-  rewrite -H.
-   *)
-  (*apply (EqdepFacts.eq_sigT_snd) in H.*)
-  (*apply EqdepFacts.eq_sigT_eq_dep in H.*)
-Admitted.
-
-
-
 Lemma valid_link :
   ∀ L1 L2 I M E p1 p2,
     ValidPackage L1 M E p1 →
@@ -125,7 +107,7 @@ Lemma valid_link :
     fcompat L1 L2 →
     ValidPackage (unionm L1 L2) I E (link p1 p2).
 Proof.
-  intros L1 l2 I M E p1 p2 [he1 hi1] [he2 hi2] hc.
+  intros L1 l2 I M E p1 p2 [he1 hi1] h2 hc.
   split; [ split |].
   - rewrite he1 => [[f h]].
     exists (fun x => code_link (f x) p2).
@@ -134,41 +116,24 @@ Proof.
     rewrite he1 //=.
     rewrite //= /link mapmE in h.
     elim: (p1 o.1) h => //= [[S [T g]]] h.
-    apply some_kleisli in h as [? [? ?]]; subst.
+    injection h => {}h ? ?; subst; simpl.
     by exists g.
-  - intros o f x h.
+  - intros n F x h.
     simpl in h.
     rewrite //= /link mapmE in h.
-    elim: (p1 o.1) h => //= [[S [T g]]] h.
-    apply some_kleisli in h as [? [? ?]]; subst.
-    rewrite coerce_kleisliE.
+    destruct (p1 n) eqn:e => //=.
+    destruct t as [S [T g]].
+    injection h => {}h; subst; simpl.
     eapply valid_code_link.
-    by exists g.
-    injection h => {}h s t; subst.
+    + eapply valid_injectLocations.
+      * apply fsubmapUl.
+      * apply (hi1 n (S; T; g) x e).
+    + eapply valid_package_inject_locations.
+      * apply fsubmapUr, hc.
+      * apply h2.
 Qed.
-(*
-Proof.
-  intros L1 l2 I M E p1 p2 h1 h2 hc.
-  apply prove_valid_package.
-  eapply from_valid_package in h1.
-  intros [n [So To]] ho. unfold link.
-  rewrite mapmE.
-  specialize (h1 _ ho) as h1'. cbn in h1'.
-  destruct h1' as [f [ef hf]].
-  rewrite ef. cbn.
-  eexists. split. 1: reflexivity.
-  intro x.
-  eapply valid_code_link.
-  - eapply valid_injectLocations.
-    + apply fsubmapUl.
-    + eapply hf.
-  - eapply valid_package_inject_locations.
-    + by apply fsubmapUr.
-    + auto.
-Qed.
- *)
 
-Lemma valid_link_sub :
+Lemma valid_link_weak :
   ∀ L1 L2 I M1 M2 E p1 p2,
     ValidPackage L1 M1 E p1 →
     ValidPackage L2 I M2 p2 →
@@ -203,7 +168,7 @@ Ltac package_evar :=
   : typeclass_instances ssprove_valid_db.
 
 #[export] Hint Extern 1 (ValidPackage ?L ?I ?E (link ?p1 ?p2)) =>
-  package_evar ; [ eapply valid_link_sub | .. ]
+  package_evar ; [ eapply valid_link_weak | .. ]
   : typeclass_instances ssprove_valid_db.
 
 
@@ -247,133 +212,6 @@ Proof.
   - cbn. f_equal. apply functional_extensionality. auto.
 Qed.
 
-Lemma trim_get :
-  ∀ (E : Interface) (p : raw_package) n So To f,
-    fhas p (n, (So; To; f)) →
-    fhas E (n, (So, To)) →
-    trim E p n = Some (So ; To ; f).
-Proof.
-  intros E p n So To f e h.
-  unfold trim. rewrite filtermE. rewrite e. cbn.
-  rewrite h. reflexivity.
-Qed.
-
-Lemma valid_trim :
-  ∀ L I E p,
-    ValidPackage L I E p →
-    ValidPackage L I E (trim E p).
-Admitted.
-(*
-Proof.
-  intros L I E p h.
-  apply prove_valid_package.
-  eapply from_valid_package in h.
-  intros [n [So To]] ho.
-  specialize (h _ ho). cbn in h. destruct h as [f [ef hf]].
-  exists f. intuition auto.
-  apply trim_get. all: auto.
-Qed.
- *)
-
-#[export] Hint Extern 1 (ValidPackage ?L ?I ?E (trim ?E ?p)) =>
-  eapply valid_trim
-  : typeclass_instances ssprove_valid_db.
-
-(* Technical lemma before proving assoc *)
-Lemma link_trim_commut :
-  ∀ E p1 p2,
-    link (trim E p1) p2 =
-    trim E (link p1 p2).
-Proof.
-  intros E p1 p2.
-  apply eq_fmap. intro n.
-  unfold link. unfold trim.
-  repeat rewrite ?filtermE ?mapmE.
-  destruct (p1 n), (E n) => //.
-Qed.
-
-Lemma trim_idemp :
-  ∀ E p,
-    trim E (trim E p) = trim E p.
-Proof.
-  intros E p.
-  apply eq_fmap. intro n.
-  unfold trim. rewrite !filtermE.
-  destruct (p n), (E n) => //.
-Qed.
-
-Lemma resolve_trim :
-  ∀ E o p a,
-    fhas E o →
-    resolve (trim E p) o a = resolve p o a.
-Proof.
-  intros E o p x H.
-  rewrite /resolve filtermE.
-  destruct (p o.1) eqn:e; rewrite e //=.
-  destruct o as [n [S T]].
-  rewrite H //.
-Qed.
-
-Lemma code_link_trim_right :
-  ∀ A L E (v : raw_code A) p,
-    ValidCode L E v →
-    code_link v (trim E p) = code_link v p.
-Proof.
-  intros A L E v p h.
-  induction h in p |- *.
-  - cbn. reflexivity.
-  - cbn. rewrite resolve_trim //.
-    f_equal. by apply functional_extensionality.
-  - cbn. f_equal. apply functional_extensionality. intuition auto.
-  - cbn. f_equal. intuition auto.
-  - cbn. f_equal. apply functional_extensionality. intuition auto.
-Qed.
-
-Lemma trim_get_inv :
-  ∀ E p n So To f,
-    trim E p n = Some (So ; To ; f) →
-    p n = Some (So ; To ; f) ∧ n \in domm E.
-Proof.
-  intros E p n So To f e.
-  unfold trim in e. rewrite filtermE in e. cbn in e.
-  destruct (p n) as [[S1 [T1 f1]]|] eqn:e1.
-  2:{ cbn in e. discriminate. }
-  cbn in e.
-  destruct (E n) eqn:e2.
-  2:{ discriminate. }
-  noconf e.
-  intuition auto.
-  apply /dommP.
-  eexists; apply e2.
-Qed.
-
-Lemma link_trim_right :
-  ∀ L I E p1 p2,
-    ValidPackage L I E p1 →
-    link (trim E p1) (trim I p2) =
-    link (trim E p1) p2.
-Admitted.
-(*
-Proof.
-  intros L I E p1 p2 h.
-  apply eq_fmap. intro n.
-  rewrite /link !mapmE.
-  destruct (trim E p1 n) as [[S1 [T1 f1]]|] eqn:e.
-  2:{ reflexivity. }
-  simpl.
-  do 3 f_equal.
-  extensionality x.
-  apply trim_get_inv in e as [e he].
-  eapply from_valid_package in h.
-  move: he => /dommP [[So To] he].
-  specialize (h (n, (So, To)) he). cbn in h.
-  destruct h as [f [ef h]].
-  rewrite ef in e. noconf e.
-  eapply code_link_trim_right.
-  apply h.
-Qed.
- *)
-
 Lemma link_assoc :
   ∀ p1 p2 p3,
     link p1 (link p2 p3) =
@@ -403,83 +241,78 @@ Notation "p1 ∘ p2" :=
 Definition par (p1 p2 : raw_package) :=
   unionm p1 p2.
 
+Lemma valid_domm {L I E p} :
+  ValidPackage L I E p → domm E = domm p.
+Proof.
+  intros [he hi].
+  apply eq_fset => x.
+  destruct (x \in domm E) eqn:e;
+    destruct (x \in domm p) eqn:e' => //.
+  + move: e e' => /dommP [ST e] /dommPn e'.
+    specialize (he (x, ST)).
+    simpl in he.
+    rewrite he e' in e.
+    by destruct e.
+  + move: e e' => /dommPn e /dommP [[S [T f]] e'].
+    specialize (he (x, (S, T))).
+    simpl in he.
+    assert (∃ f, p x = Some (S; T; f)) by by exists f.
+    rewrite -he e // in H.
+Qed.
+
 Lemma valid_par :
   ∀ L1 L2 I1 I2 E1 E2 p1 p2,
     ValidPackage L1 I1 E1 p1 →
     ValidPackage L2 I2 E2 p2 →
-    fseparate p1 p2 →
+    fseparate E1 E2 →
     fcompat L1 L2 →
     fcompat I1 I2 →
     ValidPackage (unionm L1 L2) (unionm I1 I2) (unionm E1 E2) (par p1 p2).
-Admitted.
-(*
 Proof.
-  intros L1 L2 I1 I2 E1 E2 p1 p2 h1 h2 h cL cI.
-  apply prove_valid_package.
-  eapply from_valid_package in h1.
-  eapply from_valid_package in h2.
-  intros [n [So To]] ho.
-  unfold par. rewrite /fhas 2!unionmE //= in ho |- *.
-  destruct (E1 n) as [[S T]|] eqn:E.
-  - specialize (h1 (n, (S, T)) E) as h'. cbn in h'.
-    destruct h' as [f [e hf]].
-    rewrite e. cbn.
-    simpl in ho.
-    injection ho => ? ?; subst.
-    exists f. intuition auto.
-    eapply valid_injectLocations. 1: apply fsubmapUl.
-    eapply valid_injectMap. 1: apply fsubmapUl.
-    auto.
-  - destruct (E2 n) as [[S T]|] eqn:E' => //.
-    specialize (h2 (n, (S, T)) E') as h'. cbn in h'.
-    destruct h' as [f [e hf]].
-    destruct (p1 n) as [[S1 [T1 f1]]|] eqn:e1.
-    1:{
-      exfalso.
-      move: h => [] /fdisjointP h.
-      specialize (h n).
-      rewrite 2!mem_domm e e1 // in h.
-      specialize (h erefl).
-      move: h => /negP //.
-    }
-    cbn. rewrite e.
-    simpl in ho.
-    injection ho => ? ?; subst.
-    exists f. intuition auto.
-    eapply valid_injectLocations. 1: by apply fsubmapUr.
-    eapply valid_injectMap. 1: by apply fsubmapUr.
-    auto.
+  intros L1 L2 I1 I2 E1 E2 p1 p2 hv1 hv2 [H1] H2 H3.
+  assert (H4 : domm p1 :#: domm p2).
+  1: rewrite -(valid_domm hv1) -(valid_domm hv2) //.
+  move: hv1 hv2 => [he1 hi1] [he2 hi2].
+  split; [ split |].
+  - move: o => [n ST] h.
+    apply fhas_union in h.
+    destruct h.
+    + rewrite he1 in H.
+      destruct H as [f H].
+      exists f.
+      by apply fhas_union_l.
+    + rewrite he2 in H.
+      destruct H as [f H].
+      exists f.
+      rewrite /par unionmC //.
+      by apply fhas_union_l.
+  - move: o => [n ST] h.
+    destruct h as [f H].
+    apply fhas_union in H.
+    destruct H.
+    + apply fhas_union_l.
+      rewrite he1.
+      by exists f.
+    + rewrite /par unionmC //.
+      apply fhas_union_l.
+      rewrite he2.
+      by exists f.
+  - intros n F x h.
+    apply fhas_union in h.
+    destruct h.
+    + eapply hi1 in H.
+      eapply valid_injectLocations. 1: by apply fsubmapUl.
+      eapply valid_injectMap. 1: by apply fsubmapUl.
+      apply H.
+    + eapply hi2 in H.
+      eapply valid_injectLocations. 1: by apply fsubmapUr.
+      eapply valid_injectMap. 1: by apply fsubmapUr.
+      apply H.
 Qed.
- *)
 
 #[export] Hint Extern 1 (ValidPackage ?L ?I ?E (par ?p1 ?p2)) =>
   package_evar ; [ eapply valid_par | .. ]
   : typeclass_instances ssprove_valid_db.
-
-Lemma domm_trim :
-  ∀ E p,
-    domm (trim E p) :<=: domm E.
-Proof.
-  intros E p. unfold trim.
-  apply /fsubsetP => n.
-  rewrite 2!mem_domm filtermE.
-  destruct (E n), (p n) => //=.
-Qed.
-
-Lemma parable_trim :
-  ∀ E1 E2 p1 p2,
-    fdisjoint (domm E1) (domm E2) →
-    fseparate (trim E1 p1) (trim E2 p2).
-Proof.
-  intros E1 E2 p1 p2 h.
-  apply fsep.
-  eapply fdisjoint_trans.
-  { eapply domm_trim. }
-  rewrite fdisjointC.
-  eapply fdisjoint_trans.
-  { eapply domm_trim. }
-  rewrite fdisjointC. auto.
-Qed.
 
 Lemma par_commut :
   ∀ p1 p2,
@@ -515,25 +348,18 @@ Lemma code_link_par_left :
     ValidCode L E v →
     ValidPackage L' I E p1 →
     code_link v (par p1 p2) = code_link v p1.
-Admitted.
-(*
 Proof.
-  intros A I L L' E v p1 p2 hv [hp1].
-  unfold ValidCode in hv.
-  induction hv.
-  - cbn. reflexivity.
-  - cbn. rewrite resolve_par.
-    replace (isSome (p1 o.1)) with true.
-    + f_equal. by extensionality y.
-    + specialize (hp1 _ H).
-      destruct o as [S [T h]].
-      destruct hp1 as [g [H' _]].
-      rewrite H' //.
-  - simpl. f_equal. extensionality x. eauto.
-  - simpl. f_equal. eauto.
-  - simpl. f_equal. extensionality x. eauto.
+  intros A I L L' E x p1 p2 hc [he hi].
+  induction hc => //=.
+  - rewrite resolve_par.
+    rewrite he in H.
+    destruct H as [f H].
+    rewrite H //=.
+    f_equal. by extensionality y.
+  - f_equal. by extensionality y.
+  - by f_equal.
+  - f_equal. by extensionality y.
 Qed.
- *)
 
 Lemma code_link_par_right :
   ∀ A I L L' E (v : raw_code A) p1 p2,
@@ -547,83 +373,44 @@ Proof.
   all: eauto.
 Qed.
 
-(* Predicate stating that a package exports all it implements *)
-Definition trimmed E p :=
-  trim E p = p.
-
-Lemma domm_trimmed :
-  ∀ E p,
-    trimmed E p →
-    fsubset (domm p) (domm E).
-Proof.
-  intros E p h.
-  unfold trimmed in h. rewrite <- h.
-  apply domm_trim.
-Qed.
-
-Lemma trimmed_valid_Some_in :
-  ∀ L I E p n S T f,
-    ValidPackage L I E p →
-    trimmed E p →
-    p n = Some (S ; T ; f) →
-    E n = Some (S, T).
-Admitted.
-(*
-Proof.
-  intros L I E p n S T f hv ht e.
-  unfold trimmed in ht. pose e as e'. rewrite <- ht in e'.
-  unfold trim in e'. rewrite filtermE in e'.
-  rewrite e in e'. simpl in e'.
-  eapply from_valid_package in hv.
-  destruct (E n) as [[S' T']|] eqn:e2 => //.
-  specialize (hv (n, (S', T')) e2).
-  simpl in hv.
-  destruct hv as [f' [hv hv']].
-  rewrite hv in e.
-  injection e => ? ? ?; by subst.
-Qed.
- *)
-
 Lemma interchange :
   ∀ A B C D E F L1 L2 L3 L4 p1 p2 p3 p4,
     ValidPackage L1 B A p1 →
     ValidPackage L2 E D p2 →
     ValidPackage L3 C B p3 →
     ValidPackage L4 F E p4 →
-    trimmed A p1 →
-    trimmed D p2 →
     fseparate p3 p4 →
     par (link p1 p3) (link p2 p4) = link (par p1 p2) (par p3 p4).
-Admitted.
-(*
 Proof.
-  intros A B C D E F L1 L2 L3 L4 p1 p2 p3 p4 h1 h2 h3 h4 t1 t2 p34.
-  apply eq_fmap. intro n.
-  unfold par.
-  rewrite unionmE. unfold link.
-  rewrite !mapmE. rewrite unionmE.
-  destruct (p1 n) as [[S1 [T1 f1]]|] eqn:e1.
-  - rewrite -e1.
-    eapply trimmed_valid_Some_in in e1 as hi. 2,3: eauto.
-    eapply from_valid_package in h1.
-    specialize (h1 (n, (S1, T1)) hi). cbn in h1.
-    destruct h1 as [g [eg hg]].
-    rewrite eg //=.
-    f_equal. f_equal. f_equal. extensionality x.
-    erewrite code_link_par_left. 2: eapply hg.
-    all: eauto.
-  - simpl. destruct (p2 n) as [[S2 [T2 f2]]|] eqn:e2.
-    + rewrite -e2.
-      eapply trimmed_valid_Some_in in e2 as hi. 2,3: eauto.
-      eapply from_valid_package in h2.
-      specialize (h2 (n, (S2, T2)) hi). cbn in h2.
-      destruct h2 as [g [eg hg]].
-      rewrite eg //=.
-      f_equal. f_equal. f_equal. extensionality x.
-      erewrite code_link_par_right. all: eauto.
-    + simpl. reflexivity.
+  intros A B C D E F L1 L2 L3 L4 p1 p2 p3 p4 h1 h2 h3 h4 s34.
+  apply eq_fmap => n.
+  rewrite /par unionmE 3!mapmE unionmE.
+  destruct (A n) as [[S T]|] eqn:e.
+  - destruct h1 as [he1 hi1].
+    specialize (he1 (n, (S, T))).
+    simpl in he1.
+    rewrite he1 in e.
+    destruct e as [f e].
+    rewrite e //=.
+    do 3 f_equal. extensionality x.
+    erewrite code_link_par_left => //.
+    2: apply h3.
+    apply (hi1 n (S; T; f) x), e.
+  - move: e => /dommPn; rewrite valid_domm; move=> /dommPn -> //=.
+    destruct (D n) as [[S T]|] eqn:e'.
+    2: move: e' => /dommPn; rewrite valid_domm; move=> /dommPn -> //=.
+    destruct h2 as [he2 hi2].
+    specialize (he2 (n, (S, T))).
+    simpl in he2.
+    rewrite he2 in e'.
+    destruct e' as [f e'].
+    rewrite e' //=.
+    do 3 f_equal. extensionality x.
+    erewrite code_link_par_right => //.
+    2: apply h4.
+    apply (hi2 n (S; T; f) x), e'.
 Qed.
- *)
+
 
 Local Open Scope type_scope.
 
@@ -743,32 +530,39 @@ Qed.
 Lemma valid_ID :
   ∀ I,
     ValidPackage emptym I I (ID I).
-Admitted.
-(*
 Proof.
   intros I.
-  apply prove_valid_package.
-  intros [id [S T]] ho.
-  rewrite mapimE ho //=.
-  eexists; split; [ reflexivity |].
-  intros x.
-  apply valid_opr => // y.
-  apply valid_ret.
+  split; [ split |].
+  - move: o => [n [S T]] H.
+    exists (λ x, opr (n, (S, T)) x (λ y, ret y)).
+    rewrite /fhas mapimE H //=.
+  - move: o => [n [T S]] [f H].
+    rewrite /fhas mapimE //= in H |- *.
+    destruct (I n) => //.
+    simpl in H.
+    destruct p as [T' S'].
+    f_equal.
+    injection H => {}H ? ?. by subst.
+  - move=> n F x h.
+    pose proof (h).
+    rewrite /fhas mapimE in h.
+    destruct (I n) => //.
+    injection h => {}h.
+    destruct p as [T S].
+    subst.
+    apply valid_opr => //.
+    2: apply valid_ret.
+    rewrite /fhas mapimE in H.
+    simpl.
+    destruct (I n) => //.
+    simpl in H.
+    destruct p as [S' T'].
+    injection H => {}H ? ?. by subst.
 Qed.
- *)
 
 #[export] Hint Extern 2 (ValidPackage ?L ?I ?E (ID ?I')) =>
   eapply valid_ID
   : typeclass_instances ssprove_valid_db.
-
-Lemma trimmed_ID :
-  ∀ I, trimmed I (ID I).
-Proof.
-  intros I.
-  unfold trimmed. apply eq_fmap. intro n.
-  unfold trim. rewrite filtermE mapimE.
-  destruct (I n) => //.
-Qed.
 
 Lemma code_link_id :
   ∀ A (v : raw_code A) L I,
@@ -789,52 +583,39 @@ Qed.
 Lemma link_id :
   ∀ L I E p,
     ValidPackage L I E p →
-    trimmed E p →
     link p (ID I) = p.
-Admitted.
-(*
 Proof.
-  intros L I E p hp tp.
-  apply eq_fmap. intro n. unfold link.
-  rewrite mapmE. destruct (p n) as [[S [T f]]|] eqn:e.
-  - rewrite -e.
-    eapply trimmed_valid_Some_in in e as hi. 2,3: eauto.
-    eapply from_valid_package in hp.
-    specialize (hp (n, (S, T)) hi) as h'. cbn in h'.
-    destruct h' as [g [eg hg]].
-    rewrite eg //=.
-    f_equal. f_equal. f_equal. extensionality x.
-    rewrite e in eg. noconf eg. cbn in hg.
-    eapply code_link_id. all: eauto.
-  - reflexivity.
+  intros L I E p [_ hi].
+  apply eq_fmap => n.
+  rewrite /link mapmE.
+  destruct (p n) eqn:e => //.
+  destruct t as [S [T f]].
+  simpl. do 3 f_equal. extensionality x.
+  specialize (hi n (S; T; f)).
+  eapply code_link_id.
+  apply hi, e.
 Qed.
- *)
 
 Lemma id_link :
   ∀ L I E p,
     ValidPackage L I E p →
-    trimmed E p →
     link (ID E) p = p.
-Admitted.
-(*
 Proof.
-  intros L I E p hp tp.
-  apply eq_fmap. intro n. unfold link.
-  rewrite mapmE mapimE.
-  rewrite -{2}tp.
-  rewrite /trim filtermE.
-  destruct (E n) as [[S T]|] eqn:E' => //=.
-  2: destruct (p n) => //.
-  apply from_valid_package in hp.
-  specialize (hp (n, (S, T)) E').
-  destruct hp as [f [H H']].
-  rewrite H.
-  rewrite /resolve H //=.
-  do 3 f_equal.
-  extensionality x.
-  rewrite bind_ret coerce_kleisliE //=.
+  intros L I E p v.
+  apply eq_fmap => n.
+  rewrite /link mapmE mapimE.
+  destruct (E n) eqn:e => //=.
+  - destruct v as [he _].
+    specialize (he (n, p0)).
+    simpl in he.
+    rewrite he in e.
+    destruct e as [f e].
+    destruct p0 as [S T].
+    rewrite e //=.
+    do 3 f_equal. extensionality x.
+    rewrite /resolve e coerce_kleisliE bind_ret //.
+  - move: e => /dommPn; rewrite valid_domm; move=> /dommPn -> //=.
 Qed.
- *)
 
 Lemma code_link_if :
   ∀ A (c₀ c₁ : raw_code A) (p : raw_package) b,

--- a/theories/Crypt/package/pkg_core_definition.v
+++ b/theories/Crypt/package/pkg_core_definition.v
@@ -606,42 +606,19 @@ Class ValidPackage (L : Locations) (I E : Interface) p :=
   is_valid_package : valid_package L I E p.
 
 (* Packages *)
-Record package L I E := mkpackage {
-  pack : raw_package ;
-  pack_valid : ValidPackage L I E pack
-}.
-
-Arguments mkpackage [_ _ _] _ _.
-Arguments pack [_ _ _] _.
-Arguments pack_valid [_ _ _] _.
-
-(* Packages coming with their set of locations *)
-Record loc_package I E := mkloc_package {
+Record package I E := mkpackage {
   locs : Locations ;
-  locs_pack : package locs I E
+  pack : raw_package ;
+  pack_valid : ValidPackage locs I E pack
 }.
 
-Arguments mkloc_package [_ _] _ _.
+Arguments mkpackage [_ _] _ _ _.
 Arguments locs [_ _] _.
-Arguments locs_pack [_ _] _.
-
-Coercion locs_pack : loc_package >-> package.
-
-Lemma loc_package_ext :
-  ∀ {I E} (p1 p2 : loc_package I E),
-    p1.(locs) = p2.(locs) →
-    p1.(locs_pack).(pack) =1 p2.(locs_pack).(pack) →
-    p1 = p2.
-Proof.
-  intros I E p1 p2 e1 e2.
-  destruct p1 as [l1 [p1 h1]], p2 as [l2 [p2 h2]].
-  apply eq_fmap in e2.
-  cbn in *. subst.
-  f_equal. f_equal. apply proof_irrelevance.
-Qed.
+Arguments pack [_ _] _.
+Arguments pack_valid [_ _] _.
 
 Notation "{ 'package' p }" :=
-  (mkpackage p _)
+  (mkpackage _ p _)
   (format "{ package  p  }") : package_scope.
 
 Notation "{ 'package' p '#with' h }" :=
@@ -653,14 +630,6 @@ Coercion pack : package >-> raw_package.
 #[export] Hint Extern 1 (ValidPackage ?L ?I ?E (?p.(pack))) =>
   eapply p.(pack_valid)
   : typeclass_instances ssprove_valid_db.
-
-Notation "{ 'locpackage' p }" :=
-  (mkloc_package _ (mkpackage p _))
-  (format "{ locpackage  p  }") : package_scope.
-
-Notation "{ 'locpackage' p '#with' h }" :=
-  (mkloc_package _ (mkpackage p h))
-  (only parsing) : package_scope.
 
 (* Some validity lemmata *)
 
@@ -721,13 +690,14 @@ Proof.
 Qed.
 
 Lemma package_ext :
-  ∀ {L I E} (p1 p2 : package L I E),
+  ∀ {I E} (p1 p2 : package I E),
+    p1.(locs) =1 p2.(locs) →
     p1.(pack) =1 p2.(pack) →
     p1 = p2.
 Proof.
-  intros L I E p1 p2 e.
+  intros I E p1 p2 e e'.
   destruct p1 as [p1 h1], p2 as [p2 h2].
-  apply eq_fmap in e.
+  apply eq_fmap in e, e'.
   cbn in *. subst.
   f_equal. apply proof_irrelevance.
 Qed.
@@ -736,7 +706,7 @@ Qed.
 
 Lemma mkpackage_rewrite :
   ∀ {L I E T} {x y} (p : T → _) h (e : x = y),
-    @mkpackage L I E (p x) h = mkpackage (p y) (sig_rewrite_aux p h e).
+    @mkpackage I E L (p x) h = mkpackage L (p y) (sig_rewrite_aux p h e).
 Proof.
   intros L I E T x y p h e. subst. reflexivity.
 Qed.

--- a/theories/Crypt/package/pkg_notation.v
+++ b/theories/Crypt/package/pkg_notation.v
@@ -186,23 +186,23 @@ Module PackageNotation.
     f constr, A custom pack_type, B custom pack_type,
     format "#val  #[ f ]  :  A  →  B").
 
-  Notation "[ 'package' ]" :=
-    (mkpackage (mkfmap [::]) _)
+  Notation "[ 'package' L ]" :=
+    (mkpackage L (mkfmap [::]) _)
     (at level 0, only parsing)
     : package_scope.
 
-  Notation "[ 'package' x1 ]" :=
-    (mkpackage (mkfmap (x1 :: [::])) _)
-    (at level 0, x1 custom package at level 2, format "[ package  x1  ]")
+  Notation "[ 'package' L ; x1 ]" :=
+    (mkpackage L (mkfmap (x1 :: [::])) _)
+    (at level 0, x1 custom package at level 2, format "[ package  L  ;  x1  ]")
     : package_scope.
 
-  Notation "[ 'package' x1 ; x2 ; .. ; xn ]" :=
-    (mkpackage (mkfmap (x1 :: x2 :: .. [:: xn] ..)) _)
+  Notation "[ 'package' L ; x1 ; x2 ; .. ; xn ]" :=
+    (mkpackage L (mkfmap (x1 :: x2 :: .. [:: xn] ..)) _)
     (at level 0,
     x1 custom package at level 2,
     x2 custom package at level 2,
     xn custom package at level 2,
-    format "[ package  '[' x1  ;  '/' x2  ;  '/' ..  ;  '/' xn  ']' ]")
+    format "[ package  '[' L  ;  '/' x1  ;  '/' x2  ;  '/' ..  ;  '/' xn  ']' ]")
     : package_scope.
 
   Notation " '#def' #[ f ] ( x : A ) : B { e }" :=

--- a/theories/Crypt/package/pkg_rhl.v
+++ b/theories/Crypt/package/pkg_rhl.v
@@ -355,14 +355,16 @@ Proof.
     apply Hp. intuition auto.
   - cbn - [semantic_judgement].
     apply inversion_valid_opr in vA as hA. destruct hA as [hi vk].
-    destruct o as [id [S T]].
-    eapply from_valid_package in vp₀.
-    specialize (vp₀ _ hi). simpl in vp₀.
-    destruct vp₀ as [f₀ [e₀ h₀]].
-    eapply from_valid_package in vp₁.
-    specialize (vp₁ _ hi). simpl in vp₁.
-    destruct vp₁ as [f₁ [e₁ h₁]].
-    specialize (hp id S T x hi).
+
+    destruct vp₀ as [vp0e vp0i].
+    specialize (vp0e o) as [vp0e _].
+    specialize (vp0e hi) as [f₀ e₀].
+    destruct vp₁ as [vp1e vp1i].
+    specialize (vp1e o) as [vp1e _].
+    specialize (vp1e hi) as [f₁ e₁].
+    destruct o as [id [T S]].
+
+    specialize (hp _ _ _ x hi).
     rewrite /resolve e₀ e₁ 2!coerce_kleisliE in hp |- *.
     rewrite 2!repr_bind.
     eapply bind_rule_pp. 1:{ eapply to_sem_jdg in hp. exact hp. }

--- a/theories/Crypt/package/pkg_tactics.v
+++ b/theories/Crypt/package/pkg_tactics.v
@@ -109,43 +109,18 @@ Qed.
 Lemma valid_empty_package :
   ∀ L I,
     ValidPackage L I [interface] emptym.
-Admitted.
-(*
 Proof.
   intros L I.
-  apply prove_valid_package.
-  intros [id [S T]] ho. rewrite /fhas emptymE // in ho.
+  split; [ split |].
+  - intros H. exfalso. apply (fhas_empty _ H).
+  - intros [f H]. exfalso. apply (fhas_empty _ H).
+  - intros n F x H. exfalso. apply (fhas_empty _ H).
 Qed.
- *)
 
 #[export] Hint Extern 1 (ValidPackage ?L ?I ?E (mkfmap [::])) =>
   try (replace E with [interface] by eapply fset0E) ;
   eapply valid_empty_package
   : typeclass_instances ssprove_valid_db.
-
-Lemma valid_package1 :
-  ∀ L I i A B f,
-    (∀ x, ValidCode L I (f x)) →
-    ValidPackage L I (mkfmap [:: (i, (A, B))]) (mkfmap [:: (i, mkdef A B f)]).
-Admitted.
-(*
-Proof.
-  intros L I i A B f hf.
-  apply prove_valid_package.
-  intros [i' [S T]] ho. rewrite /fhas setmE emptymE //= in ho.
-  destruct (i' == i) eqn:e => //.
-  injection ho => ? ?; subst.
-  exists f.
-  move: e => /eqP -> //.
-  rewrite setmE eq_refl //.
-Qed.
- *)
-
-(* Would be a shortcut, but when backtracking, this has an unnecessary cost *)
-(* #[export] Hint Extern 1 (ValidPackage ?L ?I ?E (mkfmap [:: (?i, mkdef ?A ?B ?f)])) =>
-  eapply valid_package1 ;
-  intro ; eapply valid_code_from_class
-  : typeclass_instances. *)
 
 Lemma valid_package_cons :
   ∀ L I i A B f E p,
@@ -153,24 +128,37 @@ Lemma valid_package_cons :
     (∀ x, ValidCode L I (f x)) →
     ValidPackage L I (mkfmap ((i, (A, B)) :: E))
       (mkfmap ((i, mkdef A B f) :: p)).
-Admitted.
-(*
 Proof.
-  intros L I i A B f E p hp hf.
-  apply prove_valid_package.
-  intros [i' [S T]] ho. rewrite //= setmE in ho.
-  destruct (i' == i) eqn:e.
-  - move: e => /eqP e.
-    injection ho => ? ?; subst.
-    simpl. exists f.
-    rewrite setmE eq_refl //.
-  - eapply from_valid_package in hp.
-    specialize (hp (i', (S, T)) ho).
-    destruct hp as [g [eg hg]].
-    exists g.
-    rewrite //= setmE e //.
+  intros L I n A B f E p h c.
+  split; [ split |].
+  - move: o => [m [S T]].
+    rewrite //= 2!setmE.
+    destruct (m == n) eqn:e.
+    + move: e => /eqP e o.
+      noconf e. noconf o. by exists f.
+    + destruct h as [he _].
+      specialize (he (m, (S, T))).
+      simpl in he.
+      by rewrite he.
+  - move: o => [m [S T]].
+    rewrite //= 2!setmE.
+    destruct (m == n) eqn:e.
+    + intros [g H].
+      by noconf H.
+    + intros [g H].
+      destruct h as [he _].
+      specialize (he (m, (S, T))).
+      simpl in he.
+      rewrite he.
+      by exists g.
+  - intros m F x.
+    rewrite //= setmE.
+    destruct (m == n) eqn:e.
+    + move: e => /eqP e o.
+      noconf e. noconf o. apply c.
+    + destruct h as [_ hi].
+      apply hi.
 Qed.
- *)
 
 Lemma valid_package_cons_upto :
   ∀ L I i A B A' B' f E p,
@@ -194,37 +182,6 @@ Qed.
   | intro
   ]
   : typeclass_instances ssprove_valid_db.
-
-Lemma trimmed_empty_package :
-  trimmed [interface] (mkfmap nil).
-Proof.
-  unfold trimmed. simpl. unfold trim.
-  apply eq_fmap. intro n.
-  rewrite filtermE. rewrite emptymE. reflexivity.
-Qed.
-
-Lemma trimmed_package_cons :
-  ∀ i A B f p E,
-    trimmed (mkfmap E) (mkfmap p) →
-    trimmed (mkfmap ((i, (A, B)) :: E)) (mkfmap ((i, mkdef A B f) :: p)).
-Proof.
-  intros i A B f p E h.
-  unfold trimmed. unfold trim.
-  apply eq_fmap. intro n.
-  rewrite filtermE //= 2!setmE.
-  destruct (n == i) eqn:e => //.
-  unfold trimmed, trim in h.
-  apply eq_fmap in h. specialize (h n).
-  rewrite filtermE // in h.
-Qed.
-
-#[export] Hint Extern 1 (trimmed ?E (mkfmap [::])) =>
-  eapply trimmed_empty_package
-: typeclass_instances ssprove_valid_db.
-
-#[export] Hint Extern 2 (trimmed ?E (mkfmap ((?i, mkdef ?A ?B ?f) :: ?p))) =>
-  eapply trimmed_package_cons
-: typeclass_instances ssprove_valid_db.
 
 Lemma valid_scheme :
   ∀ A L I c,

--- a/theories/Crypt/package/pkg_tactics.v
+++ b/theories/Crypt/package/pkg_tactics.v
@@ -109,11 +109,14 @@ Qed.
 Lemma valid_empty_package :
   ∀ L I,
     ValidPackage L I [interface] emptym.
+Admitted.
+(*
 Proof.
   intros L I.
   apply prove_valid_package.
   intros [id [S T]] ho. rewrite /fhas emptymE // in ho.
 Qed.
+ *)
 
 #[export] Hint Extern 1 (ValidPackage ?L ?I ?E (mkfmap [::])) =>
   try (replace E with [interface] by eapply fset0E) ;
@@ -124,6 +127,8 @@ Lemma valid_package1 :
   ∀ L I i A B f,
     (∀ x, ValidCode L I (f x)) →
     ValidPackage L I (mkfmap [:: (i, (A, B))]) (mkfmap [:: (i, mkdef A B f)]).
+Admitted.
+(*
 Proof.
   intros L I i A B f hf.
   apply prove_valid_package.
@@ -134,6 +139,7 @@ Proof.
   move: e => /eqP -> //.
   rewrite setmE eq_refl //.
 Qed.
+ *)
 
 (* Would be a shortcut, but when backtracking, this has an unnecessary cost *)
 (* #[export] Hint Extern 1 (ValidPackage ?L ?I ?E (mkfmap [:: (?i, mkdef ?A ?B ?f)])) =>
@@ -147,6 +153,8 @@ Lemma valid_package_cons :
     (∀ x, ValidCode L I (f x)) →
     ValidPackage L I (mkfmap ((i, (A, B)) :: E))
       (mkfmap ((i, mkdef A B f) :: p)).
+Admitted.
+(*
 Proof.
   intros L I i A B f E p hp hf.
   apply prove_valid_package.
@@ -162,6 +170,7 @@ Proof.
     exists g.
     rewrite //= setmE e //.
 Qed.
+ *)
 
 Lemma valid_package_cons_upto :
   ∀ L I i A B A' B' f E p,

--- a/theories/Crypt/package/pkg_user_util.v
+++ b/theories/Crypt/package/pkg_user_util.v
@@ -101,7 +101,7 @@ Set Primitive Projections.
 Open Scope pack.
 
 Ltac simplify_linking := simpl; repeat
-  (rewrite (resolve_set, resolve_link, coerce_kleisliE); simpl).
+  (rewrite (resolve_set, resolve_link, resolve_ID_set, coerce_kleisliE); simpl).
 
 Ltac simplify_eq_rel m :=
   let id := fresh "id" in


### PR DESCRIPTION
(This builds upon #69, so until it is merged the diff also includes those changes - A representative diff can be seen here for now https://github.com/MarkusKL/ssprove/pull/5).
This is the final PR with breaking changes to the main codebase, so afterwards the focus is to merge #70.
In parallel, I will add the nominal operators as an optional import.

This PR makes the following improvements:
- ValidPackage is strengthened to subsume the concept of trimmed i.e.
  ValidPackage (old) + trimmed (old) <-> ValidPackage (new)
  This has minimal impact on the examples except for the fact that it may have revealed an adequacy bug in Fiat-Shamir construction (see comment and changes in code). Changes to e.g. KEMDEM are strict simplifications of the code.
- The locations parameter has been internalized, so that `package` is parameterized only by imports and exports. To reduce the amount of definitions about packages (avoiding the `package` vs. `loc_package` dichotomy). Games for interface I are now captured by the notation `game I := package [interface] I` and adversaries for I are captured by the notation `adversary I := package I A_export`. This makes if easy to define a game pair for `I` as `bool -> game I` even if the two game use different locations.

Breaking changes:
- `trim` is removed. Trim a package using link by changing `trim E p` to `ID E o p`.
- `trimmed` is removed. Every ValidPackage is trimmed, so `trimmed` side conditions are gone from lemmas.
- `package` takes only two parameters `I` and `E` making it more like the old `loc_package`.
- `[package ... ]` notation takes the locations of the defined package as first parameter.
- User proofs about package validity need to be updated, but most can probably be remove due to automation from #65 .