### PR TITLE
add chTuple to choice_type and otf_injective

### DIFF
--- a/theories/Crypt/choice_type.v
+++ b/theories/Crypt/choice_type.v
@@ -48,7 +48,9 @@ Inductive choice_type :=
 | chFin (n : nat)
 | chWord (nbits : wsize)
 | chList (A : choice_type)
-| chSum (A B : choice_type).
+| chSum (A B : choice_type)
+| chTuple (A: choice_type) (n : nat).
+
 
 Derive NoConfusion NoConfusionHom for choice_type.
 
@@ -97,6 +99,9 @@ HB.instance Definition _ nbits
 HB.instance Definition _ (A : choice_type) (T : Crypt.type A)
   := hasInterp.Build (chList A) (list T).
 
+HB.instance Definition _ (A : choice_type) (n : nat) (T : Crypt.type A)
+  := hasInterp.Build (chTuple A n) (n.-tuple T).
+
 HB.instance Definition _ (A B : choice_type)
   (T : Crypt.type A) (S : Crypt.type B)
   := hasInterp.Build (chSum A B) (T + S)%type.
@@ -114,6 +119,7 @@ Fixpoint chInterp (U : choice_type) : Crypt.type U :=
   | chWord nbits => word nbits
   | chList u => list (chInterp u)
   | chSum u v => (chInterp u + chInterp v)%type
+  | chTuple u n => n.-tuple (chInterp u)
   end.
 
 (* When a Crypt.type is found for an arbitrary type, the

--- a/theories/Crypt/examples/Executor.v
+++ b/theories/Crypt/examples/Executor.v
@@ -186,6 +186,11 @@ End Executor.
       | Some (seed', x) => Some (seed', [:: x])
       | _ => None
       end
+  | chTuple A n =>
+      match sampler A seed with
+      | Some (seed', x) => Some (seed', [tuple (x) | i < n])
+      | _ => None
+      end
   | chSum A B =>
       let '(seed', b) := ((seed + 1)%nat, Nat.even seed) in
       if b

--- a/theories/Crypt/package/pkg_distr.v
+++ b/theories/Crypt/package/pkg_distr.v
@@ -74,6 +74,12 @@ Proof.
   apply enum_rankK.
 Qed.
 
+Lemma otf_injective :
+  ∀ {F}, injective (@otf F).
+Proof.
+  rewrite /injective /otf => x1 x2 H_eq. apply enum_val_inj. 
+Qed.
+
 Lemma card_prod_iprod :
   ∀ i j,
     #|(prod (ordinal i:finType) (ordinal j:finType)) :finType| = (i * j)%N.

--- a/theories/Crypt/package/pkg_interpreter.v
+++ b/theories/Crypt/package/pkg_interpreter.v
@@ -168,6 +168,11 @@ Section Interpreter.
         | Some (seed', x) => Some (seed', [:: x])
         | _ => None
         end
+    | chTuple A n =>
+        match sampler A seed with
+        | Some (seed', x) => Some (seed', [tuple x | i < n])
+        | _ => None
+        end
     | chSum A B =>
         let '(seed', b) := ((seed + 1)%nat, Nat.even seed) in
         if b

--- a/theories/Crypt/package/pkg_notation.v
+++ b/theories/Crypt/package/pkg_notation.v
@@ -129,6 +129,7 @@ Module PackageNotation.
   Notation " 'word n " := (chWord n) (in custom pack_type at level 2).
   Notation " 'option x " := (chOption x) (in custom pack_type at level 2).
   Notation " 'list x " := (chList x) (in custom pack_type at level 2).
+  Notation " 'tuple x n" := (chTuple x n) (in custom pack_type at level 2).
 
 
   Notation " 'fin n " :=
@@ -152,6 +153,7 @@ Module PackageNotation.
   Notation " 'word n " := (chWord n) (at level 2) : package_scope.
   Notation " 'option x " := (chOption x) (at level 2) : package_scope.
   Notation " 'list x " := (chList x) (at level 2) : package_scope.
+  Notation " 'tuple x n " := (chTuple x n) (at level 2) : package_scope.
 
   Notation " 'fin x " :=
     (chFin x)


### PR DESCRIPTION
I added the new `chTuple` to `choiceType`. I have also added a lemma for the injectivity of `otf`. Those are the changes I made in the submodule of `SSProve` I am using currently using. In order to so, I needed to add a new case for `sampler`. I have tried to follow the philosophy of the one for list, but I am not sure of the purpose of the function so let me know if I have done something wrong.